### PR TITLE
Feature: runtime arguments arguments

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -106,7 +106,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 										translateY: [0, 100],
 										opacity: [1, 0]
 									}, easing: 'spring', duration: 250 }} runOnMount={true}>
-										<div className='border-box overlay-m'>
+										<dialog open={true} className='border-box overlay-m'>
 											<div className='flex-row info vertical-align-stretch tight-s'>
 												<div className='flex-col c12'>
 													<h2>
@@ -135,7 +135,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 													'right': this.props.secondaryText !== undefined
 												})} onClick={this.handleAccept}>{this.props.acceptText}</button>
 											</div>
-										</div>
+										</dialog>
 									</VelocityReact.VelocityTransitionGroup>
 								</div>
 							</div>

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -106,7 +106,9 @@ export namespace mousetrapHelper {
 		}
 		// capitalize first letter of each combo key
 		hotkey = hotkey.replace(/(\w)\w*/ig, (substring: string) => {
-			return substring.substr(0, 1).toUpperCase() + substring.substr(1)
+			return substring.substr(0, 1).toUpperCase() + substring.substr(1).toLowerCase()
+		}).replace(/(\s*,\s*)/g, (separator: string) => {
+			return ', '
 		})
 
 		return hotkey

--- a/meteor/client/styles/contextMenu.scss
+++ b/meteor/client/styles/contextMenu.scss
@@ -4,7 +4,7 @@ nav.react-contextmenu {
 	font-weight: 400;
 	line-height: 1.5;
 	letter-spacing: 0.5px;
-	z-index: 1000;
+	z-index: 900;
 	user-select: none;
 
 	border-radius: 4px;

--- a/meteor/client/styles/modalDialog.scss
+++ b/meteor/client/styles/modalDialog.scss
@@ -1,5 +1,12 @@
 .glass-pane {
 	.border-box {
+		display: block;
+		padding: 0;
+		border: none;
 		pointer-events: auto;
 	}
+}
+
+.dark .border-box {
+	color: #fff;
 }

--- a/meteor/client/ui/RunningOrderView.tsx
+++ b/meteor/client/ui/RunningOrderView.tsx
@@ -1167,15 +1167,15 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		this.usedArgumentKeys.length = 0
 
 		if (this.props.studioInstallation) {
-			this.props.studioInstallation.roArguments.forEach((i) => {
+			_.each(this.props.studioInstallation.roArguments, (i) => {
 				const combos = i.hotkeys.split(',')
-				combos.forEach((combo) => {
+				_.each(combos, (combo) => {
 					const handler = (e: KeyboardEvent) => {
 						if (disableInInputFields(e)) return
 
-						if (this.props.runningOrder && this.props.runningOrder.active && this.props.runningOrder.currentSegmentLineId) {
+						if (this.props.runningOrder && this.props.runningOrder.active && this.props.runningOrder.nextSegmentLineId) {
 							Meteor.call(ClientAPI.methods.execMethod, eventContextForLog(e), PlayoutAPI.methods.roToggleSegmentLineArgument,
-								this.props.runningOrder._id, this.props.runningOrder.currentSegmentLineId, i.property, i.value,
+								this.props.runningOrder._id, this.props.runningOrder.nextSegmentLineId, i.property, i.value,
 							(err) => {
 								if (err) {
 									// TODO: notify user
@@ -1202,6 +1202,7 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		this._cleanUp()
 		$(document.body).removeClass(['dark', 'vertical-overflow-only'])
 		$(window).off('scroll', this.onWindowScroll)
+		$(window).off('beforeunload', this.onBeforeUnload)
 
 		_.each(this.bindKeys, (k) => {
 			if (k.up) {
@@ -1213,12 +1214,22 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 			}
 		})
 
+		_.each(this.usedArgumentKeys, (k) => {
+			if (k.up) {
+				mousetrapHelper.unbind(k.key, 'ROArguments', 'keyup')
+				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+			}
+			if (k.down) {
+				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+			}
+		})
+
 		window.removeEventListener(RunningOrderViewEvents.goToLiveSegment, this.onGoToLiveSegment)
 	}
 
 	onBeforeUnload = (e: any) => {
 		const {t} = this.props
-		
+
 		e.preventDefault()
 		e.returnValue = t('This running order is now active. Are you sure you want to exit this screen?')
 
@@ -1401,7 +1412,7 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 							<RunningOrderFullscreenControls isFollowingOnAir={this.state.followLiveSegments} onFollowOnAir={this.onGoToLiveSegment} onRewindSegments={this.onRewindSegments} />
 						</ErrorBoundary>
 						<ErrorBoundary>
-							{ this.state.studioMode && 
+							{ this.state.studioMode &&
 								<Prompt when={this.props.runningOrder.active} message={t('This running order is now active. Are you sure you want to exit this screen?')} />
 							}
 						</ErrorBoundary>

--- a/meteor/client/ui/RunningOrderView.tsx
+++ b/meteor/client/ui/RunningOrderView.tsx
@@ -1139,7 +1139,7 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		}
 
 		if (typeof this.props.studioInstallation !== typeof prevProps.studioInstallation ||
-			this.props.studioInstallation && this.props.studioInstallation.roArguments) {
+			this.props.studioInstallation && this.props.studioInstallation.runtimeArguments) {
 			this.refreshHotkeys()
 		}
 	}
@@ -1157,17 +1157,17 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 
 		this.usedArgumentKeys.forEach((k) => {
 			if (k.up) {
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keyup')
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keyup')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
 			}
 			if (k.down) {
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
 			}
 		})
 		this.usedArgumentKeys.length = 0
 
 		if (this.props.studioInstallation) {
-			_.each(this.props.studioInstallation.roArguments, (i) => {
+			_.each(this.props.studioInstallation.runtimeArguments, (i) => {
 				const combos = i.hotkeys.split(',')
 				_.each(combos, (combo) => {
 					const handler = (e: KeyboardEvent) => {
@@ -1191,8 +1191,8 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 						key: combo,
 						label: i.label || ''
 					})
-					mousetrapHelper.bind(combo, handler, 'keyup', 'ROArguments')
-					mousetrapHelper.bind(combo, noOp, 'keydown', 'ROArguments')
+					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
+					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
 				})
 			})
 		}
@@ -1216,11 +1216,11 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 
 		_.each(this.usedArgumentKeys, (k) => {
 			if (k.up) {
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keyup')
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keyup')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
 			}
 			if (k.down) {
-				mousetrapHelper.unbind(k.key, 'ROArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
 			}
 		})
 

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -362,7 +362,7 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 				onScroll={this.onScroll}
 				followingSegmentLine={this.props.followingSegmentLine}
 				isLastSegment={this.props.isLastSegment} />
-		)
+		) || null
 	}
 }
 )

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -21,7 +21,7 @@ import { IOutputLayer,
 	MappingPanasonicPtz,
 	MappingHyperdeckType,
 	HotkeyDefinition,
-	IStudioROArgumentsItem
+	IStudioRuntimeArgumentsItem
 } from '../../../lib/collections/StudioInstallations'
 import { ShowStyles } from '../../../lib/collections/ShowStyles'
 import { EditAttribute, EditAttributeBase } from '../../lib/EditAttribute'
@@ -40,6 +40,7 @@ import { PeripheralDevice, PeripheralDevices, PlayoutDeviceType } from '../../..
 import { Link } from 'react-router-dom'
 import { MomentFromNow } from '../../lib/Moment'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { mousetrapHelper } from '../../lib/mousetrapHelper'
 
 interface IProps {
 	studioInstallation: StudioInstallation
@@ -58,7 +59,7 @@ interface IChildStudioInterfaceProps {
 	onRemoveMapping?: (layerId: string) => void
 	onDeleteConfigItem?: (item: IStudioConfigItem) => void
 	onDeleteHotkeyLegend?: (item: HotkeyDefinition) => void
-	onDeleteROArgument?: (item: IStudioROArgumentsItem) => void
+	onDeleteROArgument?: (item: IStudioRuntimeArgumentsItem) => void
 	onAddSource?: () => void
 	onAddOutput?: () => void
 	onAddDevice?: (item: PeripheralDevice) => void
@@ -416,16 +417,16 @@ class StudioKeyValueSettings extends React.Component<Translated<IStudioKeyValueS
 	}
 }
 
-interface IStudioROArgumentsSettingsProps extends IProps, IChildStudioInterfaceProps {
+interface IStudioRuntimeArgumentsSettingsProps extends IProps, IChildStudioInterfaceProps {
 }
-interface IStudioROArgumentsSettingsState {
+interface IStudioRuntimeArgumentsSettingsState {
 	showDeleteConfirm: boolean
-	deleteConfirmItem: IStudioROArgumentsItem | undefined
+	deleteConfirmItem: IStudioRuntimeArgumentsItem | undefined
 	editedItems: Array<Number>
 }
 
-class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgumentsSettingsProps>, IStudioROArgumentsSettingsState> {
-	constructor (props: Translated<IStudioROArgumentsSettingsProps>) {
+class StudioRuntimeArgumentsSettings extends React.Component<Translated<IStudioRuntimeArgumentsSettingsProps>, IStudioRuntimeArgumentsSettingsState> {
+	constructor (props: Translated<IStudioRuntimeArgumentsSettingsProps>) {
 		super(props)
 
 		this.state = {
@@ -458,7 +459,7 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 		}
 	}
 
-	confirmDelete = (item: IStudioROArgumentsItem) => {
+	confirmDelete = (item: IStudioRuntimeArgumentsItem) => {
 		this.setState({
 			showDeleteConfirm: true,
 			deleteConfirmItem: item
@@ -486,13 +487,13 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 	renderItems () {
 		const { t } = this.props
 		return (
-			(this.props.studioInstallation.roArguments || []).map((item, index) => {
+			(this.props.studioInstallation.runtimeArguments || []).map((item, index) => {
 				return <React.Fragment key={index + '_' + item.property}>
 					<tr className={ClassNames({
 						'hl': this.isItemEdited(index)
 					})}>
 						<th className='settings-studio-custom-config-table__name c2'>
-							{item.hotkeys}
+							{mousetrapHelper.shortcutLabel(item.hotkeys)}
 						</th>
 						<td className='settings-studio-custom-config-table__value c3'>
 							{item.property}
@@ -518,7 +519,7 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 											{t('Hotkeys')}
 											<EditAttribute
 												modifiedClassName='bghl'
-												attribute={'roArguments.' + index + '.hotkeys'}
+												attribute={'runtimeArguments.' + index + '.hotkeys'}
 												obj={this.props.studioInstallation}
 												type='text'
 												collection={StudioInstallations}
@@ -530,7 +531,7 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 											{t('Property')}
 											<EditAttribute
 												modifiedClassName='bghl'
-												attribute={'roArguments.' + index + '.property'}
+												attribute={'runtimeArguments.' + index + '.property'}
 												obj={this.props.studioInstallation}
 												type='text'
 												collection={StudioInstallations}
@@ -542,7 +543,7 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 											{t('Value')}
 											<EditAttribute
 												modifiedClassName='bghl'
-												attribute={'roArguments.' + index + '.value'}
+												attribute={'runtimeArguments.' + index + '.value'}
 												obj={this.props.studioInstallation}
 												type='text'
 												collection={StudioInstallations}
@@ -568,10 +569,10 @@ class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgu
 		return (
 			<div>
 				<ModalDialog title={t('Delete this item?')} acceptText={t('Delete')} secondaryText={t('Cancel')} show={this.state.showDeleteConfirm} onAccept={(e) => this.handleConfirmDeleteAccept(e)} onSecondary={(e) => this.handleConfirmDeleteCancel(e)}>
-					<p>{t('Are you sure you want to delete this running order argument "{{property}}: {{value}}"?', { property: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.property), value: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.value) })}</p>
+					<p>{t('Are you sure you want to delete this runtime argument "{{property}}: {{value}}"?', { property: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.property), value: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.value) })}</p>
 					<p>{t('Please note: This action is irreversible!')}</p>
 				</ModalDialog>
-				<h3>{t('Running Order Arguments')}</h3>
+				<h3>{t('Runtime Arguments for Blueprints')}</h3>
 				<table className='expando settings-studio-custom-config-table'>
 					<tbody>
 						{this.renderItems()}
@@ -1610,7 +1611,7 @@ class HotkeyLegendSettings extends React.Component<Translated<IStudioKeyValueSet
 						'hl': this.isItemEdited(item)
 					})}>
 						<th className='settings-studio-custom-config-table__name c2'>
-							{item.key}
+							{mousetrapHelper.shortcutLabel(item.key)}
 						</th>
 						<td className='settings-studio-custom-config-table__value c3'>
 							{item.label}
@@ -1791,11 +1792,11 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 		}
 	}
 
-	onDeleteROArgument = (item: IStudioROArgumentsItem) => {
+	onDeleteROArgument = (item: IStudioRuntimeArgumentsItem) => {
 		if (this.props.studioInstallation) {
 			StudioInstallations.update(this.props.studioInstallation._id, {
 				$pull: {
-					roArguments: item
+					runtimeArguments: item
 				}
 			})
 		}
@@ -1857,7 +1858,7 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 	onAddROArgument = () => {
 		const { t } = this.props
 
-		const newItem = literal<IStudioROArgumentsItem>({
+		const newItem = literal<IStudioRuntimeArgumentsItem>({
 			property: 'new-property',
 			value: '1',
 			hotkeys: 'mod+shift+z'
@@ -1865,11 +1866,9 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 
 		StudioInstallations.update(this.props.studioInstallation._id, {
 			$push: {
-				roArguments: newItem
+				runtimeArguments: newItem
 			}
 		})
-
-		debugger
 	}
 
 	onAddHotkeyLegend = () => {
@@ -1946,7 +1945,7 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 					</div>
 					<div className='row'>
 						<div className='col c12 r1-c12'>
-							<StudioROArgumentsSettings {...this.props} onAddROArgument={this.onAddROArgument} onDeleteROArgument={this.onDeleteROArgument} />
+							<StudioRuntimeArgumentsSettings {...this.props} onAddROArgument={this.onAddROArgument} onDeleteROArgument={this.onDeleteROArgument} />
 						</div>
 					</div>
 					<div className='row'>

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -20,7 +20,8 @@ import { IOutputLayer,
 	MappingPanasonicPtzType,
 	MappingPanasonicPtz,
 	MappingHyperdeckType,
-	HotkeyDefinition
+	HotkeyDefinition,
+	IStudioROArgumentsItem
 } from '../../../lib/collections/StudioInstallations'
 import { ShowStyles } from '../../../lib/collections/ShowStyles'
 import { EditAttribute, EditAttributeBase } from '../../lib/EditAttribute'
@@ -57,12 +58,14 @@ interface IChildStudioInterfaceProps {
 	onRemoveMapping?: (layerId: string) => void
 	onDeleteConfigItem?: (item: IStudioConfigItem) => void
 	onDeleteHotkeyLegend?: (item: HotkeyDefinition) => void
+	onDeleteROArgument?: (item: IStudioROArgumentsItem) => void
 	onAddSource?: () => void
 	onAddOutput?: () => void
 	onAddDevice?: (item: PeripheralDevice) => void
 	onAddMapping?: () => void
 	onAddHotkeyLegend?: () => void
 	onAddConfigItem?: () => void
+	onAddROArgument?: () => void
 }
 
 interface IStudioOutputSettingsProps extends IProps, IChildStudioInterfaceProps {
@@ -405,6 +408,177 @@ class StudioKeyValueSettings extends React.Component<Translated<IStudioKeyValueS
 				</table>
 				<div className='mod mhs'>
 					<button className='btn btn-primary' onClick={this.props.onAddConfigItem}>
+						<FontAwesomeIcon icon={faPlus} />
+					</button>
+				</div>
+			</div>
+		)
+	}
+}
+
+interface IStudioROArgumentsSettingsProps extends IProps, IChildStudioInterfaceProps {
+}
+interface IStudioROArgumentsSettingsState {
+	showDeleteConfirm: boolean
+	deleteConfirmItem: IStudioROArgumentsItem | undefined
+	editedItems: Array<Number>
+}
+
+class StudioROArgumentsSettings extends React.Component<Translated<IStudioROArgumentsSettingsProps>, IStudioROArgumentsSettingsState> {
+	constructor (props: Translated<IStudioROArgumentsSettingsProps>) {
+		super(props)
+
+		this.state = {
+			showDeleteConfirm: false,
+			deleteConfirmItem: undefined,
+			editedItems: []
+		}
+	}
+
+	isItemEdited = (index: Number) => {
+		return this.state.editedItems.indexOf(index) >= 0
+	}
+
+	finishEditItem = (index: Number) => {
+		let i = this.state.editedItems.indexOf(index)
+		if (i >= 0) {
+			this.state.editedItems.splice(i, 1)
+			this.setState({
+				editedItems: this.state.editedItems
+			})
+		}
+	}
+
+	editItem = (index: Number) => {
+		if (this.state.editedItems.indexOf(index) < 0) {
+			this.state.editedItems.push(index)
+			this.setState({
+				editedItems: this.state.editedItems
+			})
+		}
+	}
+
+	confirmDelete = (item: IStudioROArgumentsItem) => {
+		this.setState({
+			showDeleteConfirm: true,
+			deleteConfirmItem: item
+		})
+	}
+
+	handleConfirmDeleteCancel = (e) => {
+		this.setState({
+			deleteConfirmItem: undefined,
+			showDeleteConfirm: false
+		})
+	}
+
+	handleConfirmDeleteAccept = (e) => {
+		if (this.props.onDeleteROArgument && typeof this.props.onDeleteROArgument === 'function' && this.state.deleteConfirmItem) {
+			this.props.onDeleteROArgument(this.state.deleteConfirmItem)
+		}
+
+		this.setState({
+			deleteConfirmItem: undefined,
+			showDeleteConfirm: false
+		})
+	}
+
+	renderItems () {
+		const { t } = this.props
+		return (
+			(this.props.studioInstallation.roArguments || []).map((item, index) => {
+				return <React.Fragment key={index + '_' + item.property}>
+					<tr className={ClassNames({
+						'hl': this.isItemEdited(index)
+					})}>
+						<th className='settings-studio-custom-config-table__name c2'>
+							{item.hotkeys}
+						</th>
+						<td className='settings-studio-custom-config-table__value c3'>
+							{item.property}
+						</td>
+						<td className='settings-studio-custom-config-table__value c3'>
+							{item.value}
+						</td>
+						<td className='settings-studio-custom-config-table__actions table-item-actions c3'>
+							<button className='action-btn' onClick={(e) => this.editItem(index)}>
+								<FontAwesomeIcon icon={faPencilAlt} />
+							</button>
+							<button className='action-btn' onClick={(e) => this.confirmDelete(item)}>
+								<FontAwesomeIcon icon={faTrash} />
+							</button>
+						</td>
+					</tr>
+					{this.isItemEdited(index) &&
+						<tr className='expando-details hl'>
+							<td colSpan={4}>
+								<div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Hotkeys')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'roArguments.' + index + '.hotkeys'}
+												obj={this.props.studioInstallation}
+												type='text'
+												collection={StudioInstallations}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Property')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'roArguments.' + index + '.property'}
+												obj={this.props.studioInstallation}
+												type='text'
+												collection={StudioInstallations}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Value')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'roArguments.' + index + '.value'}
+												obj={this.props.studioInstallation}
+												type='text'
+												collection={StudioInstallations}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+								</div>
+								<div className='mod alright'>
+									<button className={ClassNames('btn btn-primary')} onClick={(e) => this.finishEditItem(index)}>
+										<FontAwesomeIcon icon={faCheck} />
+									</button>
+								</div>
+							</td>
+						</tr>
+					}
+				</React.Fragment>
+			})
+		)
+	}
+
+	render () {
+		const { t } = this.props
+		return (
+			<div>
+				<ModalDialog title={t('Delete this item?')} acceptText={t('Delete')} secondaryText={t('Cancel')} show={this.state.showDeleteConfirm} onAccept={(e) => this.handleConfirmDeleteAccept(e)} onSecondary={(e) => this.handleConfirmDeleteCancel(e)}>
+					<p>{t('Are you sure you want to delete this running order argument "{{property}}: {{value}}"?', { property: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.property), value: (this.state.deleteConfirmItem && this.state.deleteConfirmItem.value) })}</p>
+					<p>{t('Please note: This action is irreversible!')}</p>
+				</ModalDialog>
+				<h3>{t('Running Order Arguments')}</h3>
+				<table className='expando settings-studio-custom-config-table'>
+					<tbody>
+						{this.renderItems()}
+					</tbody>
+				</table>
+				<div className='mod mhs'>
+					<button className='btn btn-primary' onClick={this.props.onAddROArgument}>
 						<FontAwesomeIcon icon={faPlus} />
 					</button>
 				</div>
@@ -1617,6 +1791,16 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 		}
 	}
 
+	onDeleteROArgument = (item: IStudioROArgumentsItem) => {
+		if (this.props.studioInstallation) {
+			StudioInstallations.update(this.props.studioInstallation._id, {
+				$pull: {
+					roArguments: item
+				}
+			})
+		}
+	}
+
 	onAddSource = () => {
 		const maxRank = StudioSettings.findHighestRank(this.props.studioInstallation.sourceLayers)
 		const { t } = this.props
@@ -1668,6 +1852,24 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 				config: newItem
 			}
 		})
+	}
+
+	onAddROArgument = () => {
+		const { t } = this.props
+
+		const newItem = literal<IStudioROArgumentsItem>({
+			property: 'new-property',
+			value: '1',
+			hotkeys: 'mod+shift+z'
+		})
+
+		StudioInstallations.update(this.props.studioInstallation._id, {
+			$push: {
+				roArguments: newItem
+			}
+		})
+
+		debugger
 	}
 
 	onAddHotkeyLegend = () => {
@@ -1740,6 +1942,11 @@ export default translateWithTracker((props: IStudioSettingsProps, state) => {
 						</div>
 						<div className='col c12 rl-c6'>
 							<StudioOutputSettings {...this.props} onDeleteOutput={this.onDeleteOutput} onAddOutput={this.onAddOutput} />
+						</div>
+					</div>
+					<div className='row'>
+						<div className='col c12 r1-c12'>
+							<StudioROArgumentsSettings {...this.props} onAddROArgument={this.onAddROArgument} onDeleteROArgument={this.onDeleteROArgument} />
 						</div>
 					</div>
 					<div className='row'>

--- a/meteor/lib/api/playout.ts
+++ b/meteor/lib/api/playout.ts
@@ -32,6 +32,7 @@ export namespace PlayoutAPI {
 		'roActivateHold' = 'playout.roActivateHold',
 		'roStoriesMoved' = 'playout.roStoriesMoved',
 		'roDisableNextSegmentLineItem' = 'playout.roDisableNextSegmentLineItem',
+		'roToggleSegmentLineArgument' = 'playout.roToggleSegmentLineArgument',
 		'segmentLinePlaybackStartedCallback' = 'playout.segmentLinePlaybackStartedCallback',
 		'segmentLineItemPlaybackStartedCallback' = 'playout.segmentLineItemPlaybackStartedCallback',
 		'segmentLineItemTakeNow' = 'playout.segmentLineItemTakeNow',

--- a/meteor/lib/collections/SegmentLines.ts
+++ b/meteor/lib/collections/SegmentLines.ts
@@ -73,6 +73,11 @@ export interface DBSegmentLine {
 	afterSegmentLine?: string
 	/** if the segmentLine was dunamically inserted (adlib) */
 	dynamicallyInserted?: boolean
+
+	/** Runtime blueprint arguments allows Sofie-side data to be injected into the blueprint for an SL */
+	runtimeArguments?: TemplateRuntimeArguments
+	/** An SL should be marked as `dirty` if the SL blueprint has been injected with runtimeArguments */
+	dirty?: boolean
 }
 export interface SegmentLineTimings {
 	/** Point in time the SegmentLine was taken, (ie the time of the user action) */
@@ -135,6 +140,7 @@ export class SegmentLine implements DBSegmentLine {
 	public holdMode?: SegmentLineHoldMode
 	public notes?: Array<SegmentLineNote>
 	public afterSegmentLine?: string
+	public dirty?: boolean
 
 	public runtimeArguments?: TemplateRuntimeArguments
 

--- a/meteor/lib/collections/SegmentLines.ts
+++ b/meteor/lib/collections/SegmentLines.ts
@@ -14,6 +14,8 @@ import { RundownAPI } from '../api/rundown'
 import { checkSLIContentStatus } from '../mediaObjects'
 import { Meteor } from 'meteor/meteor'
 
+import { TemplateRuntimeArguments } from '../../server/api/templates/templates'
+
 /** A "Line" in NRK Lingo. */
 export interface DBSegmentLine {
 	_id: string
@@ -133,6 +135,8 @@ export class SegmentLine implements DBSegmentLine {
 	public holdMode?: SegmentLineHoldMode
 	public notes?: Array<SegmentLineNote>
 	public afterSegmentLine?: string
+
+	public runtimeArguments?: TemplateRuntimeArguments
 
 	constructor (document: DBSegmentLine) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/lib/collections/StudioInstallations.ts
+++ b/meteor/lib/collections/StudioInstallations.ts
@@ -91,7 +91,7 @@ export interface DBStudioInstallation {
 
 	hotkeyLegend?: Array<HotkeyDefinition>
 
-	roArguments?: Array<IStudioROArgumentsItem>
+	runtimeArguments?: Array<IStudioRuntimeArgumentsItem>
 }
 
 export interface ISourceLayerBase {
@@ -124,7 +124,7 @@ export interface ISourceLayerBase {
 	onPresenterScreen?: boolean
 }
 
-export interface IStudioROArgumentsItem {
+export interface IStudioRuntimeArgumentsItem {
 	label?: string
 	hotkeys: string
 	property: string
@@ -184,7 +184,7 @@ export class StudioInstallation implements DBStudioInstallation {
 	public defaultShowStyle: string
 	public config: Array<IStudioConfigItem>
 	public hotkeyLegend?: Array<HotkeyDefinition>
-	public roArguments: Array<IStudioROArgumentsItem>
+	public runtimeArguments: Array<IStudioRuntimeArgumentsItem>
 
 	constructor (document: DBStudioInstallation) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/lib/collections/StudioInstallations.ts
+++ b/meteor/lib/collections/StudioInstallations.ts
@@ -125,6 +125,7 @@ export interface ISourceLayerBase {
 }
 
 export interface IStudioROArgumentsItem {
+	label?: string
 	hotkeys: string
 	property: string
 	value: string

--- a/meteor/lib/collections/StudioInstallations.ts
+++ b/meteor/lib/collections/StudioInstallations.ts
@@ -90,6 +90,8 @@ export interface DBStudioInstallation {
 	config: Array<IStudioConfigItem>
 
 	hotkeyLegend?: Array<HotkeyDefinition>
+
+	roArguments?: Array<IStudioROArgumentsItem>
 }
 
 export interface ISourceLayerBase {
@@ -120,6 +122,12 @@ export interface ISourceLayerBase {
 	allowDisable?: boolean
 	/** If set to true, items in this layer will be used for presenters screen display */
 	onPresenterScreen?: boolean
+}
+
+export interface IStudioROArgumentsItem {
+	hotkeys: string
+	property: string
+	value: string
 }
 
 export interface IStudioConfigItem {
@@ -175,6 +183,7 @@ export class StudioInstallation implements DBStudioInstallation {
 	public defaultShowStyle: string
 	public config: Array<IStudioConfigItem>
 	public hotkeyLegend?: Array<HotkeyDefinition>
+	public roArguments: Array<IStudioROArgumentsItem>
 
 	constructor (document: DBStudioInstallation) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -1311,7 +1311,7 @@ function updateWithinSegment (ro: RunningOrder, segmentId: string): boolean {
 
 	return changed
 }
-function runPostProcessTemplate (ro: RunningOrder, segment: Segment) {
+export function runPostProcessTemplate (ro: RunningOrder, segment: Segment) {
 	let showStyle = ShowStyles.findOne(ro.showStyleId)
 	if (!showStyle) throw new Meteor.Error(404, 'ShowStyle "' + ro.showStyleId + '" not found!')
 
@@ -1328,7 +1328,8 @@ function runPostProcessTemplate (ro: RunningOrder, segment: Segment) {
 		runningOrder: ro,
 		studioId: ro.studioInstallationId,
 		segmentLine: firstSegmentLine,
-		templateId: showStyle.postProcessBlueprint
+		templateId: showStyle.postProcessBlueprint,
+		runtimeArguments: {}
 	}
 	let tr: TemplateResultAfterPost | undefined
 	try {
@@ -1420,7 +1421,7 @@ function runPostProcessTemplate (ro: RunningOrder, segment: Segment) {
 	return (changedSli.added > 0 || changedSli.removed > 0 || changedSli.updated > 0)
 }
 
-function updateStory (ro: RunningOrder, segmentLine: SegmentLine, story: IMOSROFullStory): boolean {
+export function updateStory (ro: RunningOrder, segmentLine: SegmentLine, story: IMOSROFullStory): boolean {
 	let showStyle = ShowStyles.findOne(ro.showStyleId)
 	if (!showStyle) throw new Meteor.Error(404, 'ShowStyle "' + ro.showStyleId + '" not found!')
 
@@ -1431,7 +1432,8 @@ function updateStory (ro: RunningOrder, segmentLine: SegmentLine, story: IMOSROF
 		studioId: ro.studioInstallationId,
 		// segment: Segment,
 		segmentLine: segmentLine,
-		templateId: 'N/A'
+		templateId: 'N/A',
+		runtimeArguments: segmentLine.runtimeArguments || {}
 	}
 	let tr: RunTemplateResult | undefined
 	try {

--- a/meteor/server/api/playout.ts
+++ b/meteor/server/api/playout.ts
@@ -1635,6 +1635,9 @@ methods[PlayoutAPI.methods.roTake] = (roId: string) => {
 methods[PlayoutAPI.methods.userRoTake] = (roId: string) => {
 	return ServerPlayoutAPI.userRoTake(roId)
 }
+methods[PlayoutAPI.methods.roToggleSegmentLineArgument] = (roId: string, slId: string, property: string, value: string) => {
+	return ServerPlayoutAPI.roToggleSegmentLineArgument(roId, slId, property, value)
+}
 methods[PlayoutAPI.methods.roSetNext] = (roId: string, slId: string) => {
 	return ServerPlayoutAPI.roSetNext(roId, slId, true)
 }

--- a/meteor/server/api/playout.ts
+++ b/meteor/server/api/playout.ts
@@ -182,7 +182,8 @@ export namespace ServerPlayoutAPI {
 			$unset: {
 				duration: 1,
 				startedPlayback: 1,
-				timings: 1
+				timings: 1,
+				runtimeArguments: 1
 			}
 		}, {multi: true})
 
@@ -502,6 +503,7 @@ export namespace ServerPlayoutAPI {
 			$unset: {
 				duration: 1,
 				startedPlayback: 1,
+				runtimeArguments: 1
 			}
 		}))
 		ps.push(asyncCollectionUpdate(SegmentLineItems, {
@@ -1514,7 +1516,7 @@ export namespace ServerPlayoutAPI {
 		const runningOrder = RunningOrders.findOne(roId)
 		if (!runningOrder) throw new Meteor.Error(404, `Running order "${roId}" not found!`)
 
-		const segmentLine = SegmentLines.findOne(slId)
+		let segmentLine = SegmentLines.findOne(slId)
 		if (!segmentLine) throw new Meteor.Error(404, `Segment Line "${slId}" not found!`)
 
 		const rArguments = segmentLine.runtimeArguments || {}
@@ -1530,6 +1532,10 @@ export namespace ServerPlayoutAPI {
 			mSet['runtimeArguments.' + property] = value
 			SegmentLines.update(segmentLine._id, {$set: mSet})
 		}
+
+		segmentLine = SegmentLines.findOne(slId)
+
+		if (!segmentLine) throw new Meteor.Error(404, `Segment Line "${slId}" not found!`)
 
 		const story = runningOrder.fetchCache(CachePrefix.FULLSTORY + segmentLine._id) as IMOSROFullStory
 		const changed = updateStory(runningOrder, segmentLine, story)

--- a/meteor/server/api/runtimeFunctions.ts
+++ b/meteor/server/api/runtimeFunctions.ts
@@ -67,7 +67,8 @@ export function runtimeFunctionTestCode (runtimeFunction: RuntimeFunction, showS
 			studioId: 'myStudio',
 			// segment: Segment
 			segmentLine: new SegmentLine(tmpSegmentLine),
-			templateId: runtimeFunction._id
+			templateId: runtimeFunction._id,
+			runtimeArguments: {}
 		}
 
 		let innerContext = getContext(tmpContext)

--- a/meteor/server/api/templates/templates.ts
+++ b/meteor/server/api/templates/templates.ts
@@ -70,6 +70,9 @@ export type SegmentLineItemOptional = Fix<SegmentLineItem>
 export type SegmentLineItemOptional = Optional<SegmentLineItem>
 export type SegmentLineAdLibItemOptional = Optional<SegmentLineAdLibItem>
 export type RunningOrderBaselineItemOptional = Optional<RunningOrderBaselineItem>
+export type TemplateRuntimeArguments = {
+	[key: string]: string
+}
 
 export interface TemplateSet {
 	getId: (context: TemplateContextInner, story: IMOSROFullStory) => string
@@ -85,6 +88,7 @@ export interface TemplateContext {
 	// segment: Segment
 	segmentLine: SegmentLine
 	templateId: string
+	runtimeArguments: TemplateRuntimeArguments
 }
 
 export enum LayerType {


### PR DESCRIPTION
This feature allows to set runtime arguments (as key: value items) on a segment line. Setting them is triggered using a shortcut key and changing the runtime arguments causes a re-run of the SL blueprint using the cached MOS data.

If a runtime argument is used, a given segment line is marked as `dirty` and the blueprint will be run again on any SL reset (RO reset, set as next, etc.) and the `dirty` flag will be cleared.