### PR TITLE
fix(lookahead): RETAIN mode now follows the WHEN_CLEAR behaviour instead of PRELOAD

### DIFF
--- a/meteor/server/api/playout.ts
+++ b/meteor/server/api/playout.ts
@@ -2350,7 +2350,7 @@ export function addLookeaheadObjectsToTimeline (roData: RoData, studioInstallati
 			r.isBackground = true
 			delete r.inGroup // force it to be cleared
 
-			if (m.lookahead !== LookaheadMode.WHEN_CLEAR) {
+			if (m.lookahead === LookaheadMode.PRELOAD) {
 				r.originalLLayer = r.LLayer
 				r.LLayer += '_lookahead'
 			}


### PR DESCRIPTION
Partner of https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/60