### PR TITLE
fix: more performant subscription based on studioId and rundownId

### DIFF
--- a/meteor/client/lib/reactiveData/reactiveData.ts
+++ b/meteor/client/lib/reactiveData/reactiveData.ts
@@ -119,7 +119,7 @@ export namespace reactiveData {
 		return rVar
 	}
 
-	export function getUnsentExternalMessageCount (studioId: string): ReactiveVar<number> {
+	export function getUnsentExternalMessageCount (studioId: string, rundownId: string): ReactiveVar<number> {
 		const rVar = new ReactiveVar<number>(0)
 
 		Tracker.autorun(() => {
@@ -127,6 +127,7 @@ export namespace reactiveData {
 			const unsentMessages = ExternalMessageQueue.find({
 				expires: { $gt: now },
 				studioId: { $eq: studioId },
+				rundownId: { $eq: rundownId },
 				sent: { $not: { $gt: 0 } },
 				tryCount: { $not: { $lt: 1 } }
 			}, {

--- a/meteor/client/ui/RundownView/RundownNotifier.ts
+++ b/meteor/client/ui/RundownView/RundownNotifier.ts
@@ -88,7 +88,7 @@ class RundownViewNotifier extends WithManagedTracker {
 						this.reactiveMediaStatus(rRundownId, showStyleBase, studio)
 						this.reactivePartNotes(rRundownId)
 						this.reactivePeripheralDeviceStatus(studio._id)
-						this.reactiveQueueStatus(studio._id)
+						this.reactiveQueueStatus(studio._id, rRundownId)
 					} else {
 						this.cleanUpMediaStatus()
 					}
@@ -383,13 +383,14 @@ class RundownViewNotifier extends WithManagedTracker {
 		})
 	}
 
-	private reactiveQueueStatus (studioId: string) {
+	private reactiveQueueStatus (studioId: string, rundownId: string) {
+		const t = i18nTranslator
 		let reactiveUnsentMessageCount: ReactiveVar<number>
-		meteorSubscribe(PubSub.externalMessageQueue, { studioId: studioId })
-		reactiveUnsentMessageCount = reactiveData.getUnsentExternalMessageCount(studioId)
+		meteorSubscribe(PubSub.externalMessageQueue, { studioId: studioId, rundownId: rundownId })
+		reactiveUnsentMessageCount = reactiveData.getUnsentExternalMessageCount(studioId, rundownId)
 		this.autorun(() => {
 			if (reactiveUnsentMessageCount.get() > 0 && this._unsentExternalMessagesStatus === undefined) {
-				this._unsentExternalMessagesStatus = new Notification(`unsent_${studioId}`, NoticeLevel.WARNING, 'External message queue has unsent messages.', 'ExternalMessageQueue', getCurrentTime(), true, undefined, -1)
+				this._unsentExternalMessagesStatus = new Notification(`unsent_${studioId}`, NoticeLevel.WARNING, t('External message queue has unsent messages.'), 'ExternalMessageQueue', getCurrentTime(), true, undefined, -1)
 				this._unsentExternalMessageStatusDep.changed()
 			}
 			if (reactiveUnsentMessageCount.get() === 0 && this._unsentExternalMessagesStatus !== undefined) {

--- a/meteor/lib/collections/ExternalMessageQueue.ts
+++ b/meteor/lib/collections/ExternalMessageQueue.ts
@@ -56,5 +56,9 @@ Meteor.startup(() => {
 			sent: 1,
 			lastTry: 1
 		})
+		ExternalMessageQueue._ensureIndex({
+			studioId: 1,
+			rundownId: 1
+		})
 	}
 })


### PR DESCRIPTION
Addressed @nytamin concerns about text translation and reduced the subscription scope to studioId and rundownId.