### PR TITLE
fix: default duration for KAM in timing group

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -268,7 +268,7 @@ export const RundownTimingProvider = withTracker<IRundownTimingProviderProps, IR
 					(parts[itIndex + 1] && parts[itIndex + 1].displayDurationGroup === part.displayDurationGroup)
 				)) {
 					this.displayDurationGroups[part.displayDurationGroup] = (this.displayDurationGroups[part.displayDurationGroup] || 0) + (part.expectedDuration || 0)
-					displayDuration = Math.min(part.displayDuration || part.expectedDuration || 0, part.expectedDuration || 0) || this.displayDurationGroups[part.displayDurationGroup]
+					displayDuration = Math.min(part.displayDuration || part.expectedDuration || 0, part.expectedDuration || 0) || this.displayDurationGroups[part.displayDurationGroup] || this.props.defaultDuration || 3000
 					memberOfDisplayDurationGroup = true
 				}
 				if (part.startedPlayback && lastStartedPlayback && !part.duration) {
@@ -362,10 +362,7 @@ export interface WithTimingOptions {
 	isHighResolution?: boolean
 	filter?: string | any[]
 }
-
-export type WithTiming<T> = T & RundownTiming.InjectedROTimingProps & {
-	children?: React.ReactNode
-}
+export type WithTiming<T> = T & RundownTiming.InjectedROTimingProps
 type IWrappedComponent<IProps, IState> = new (props: WithTiming<IProps>, state: IState) => React.Component<WithTiming<IProps>, IState>
 
 /**

--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -362,7 +362,7 @@ export interface WithTimingOptions {
 	isHighResolution?: boolean
 	filter?: string | any[]
 }
-export type WithTiming<T> = T & RundownTiming.InjectedROTimingProps
+export type WithTiming<T> = T & RundownTiming.InjectedROTimingProps & { children?: React.ReactNode }
 type IWrappedComponent<IProps, IState> = new (props: WithTiming<IProps>, state: IState) => React.Component<WithTiming<IProps>, IState>
 
 /**


### PR DESCRIPTION
Issue was that if KAM part has display duration (based on script take point) of 0, expected duration set to 0 and that it is always first in a group, the overall expected duration of the entire group has not been accumulated yet. This pull request sets the segLineDisplayDuration (via local variable displayDuration) to the default when no other values are available.