### PR TITLE
Make warning text readable.

### DIFF
--- a/meteor/client/styles/_colorScheme.scss
+++ b/meteor/client/styles/_colorScheme.scss
@@ -1,5 +1,6 @@
 $color-status-good: green;
 $color-status-minor-warning: lime;
+$color-status-minor-warning-text: black;
 $color-status-warning: gold;
 $color-status-bad: #FF5E00;
 $color-status-fatal: #E62421;

--- a/meteor/client/styles/notifications.scss
+++ b/meteor/client/styles/notifications.scss
@@ -39,7 +39,7 @@
             flex: 0;
             min-width: 40px;
             background: $color-status-minor-warning;
-            color: $color-status-warning;
+            color: $color-status-minor-warning-text;
 
             text-align: center;
             padding-top: 10px;

--- a/meteor/client/styles/rundownSystemStatus.scss
+++ b/meteor/client/styles/rundownSystemStatus.scss
@@ -49,6 +49,7 @@
 			&.minor {
 				background: $color-status-minor-warning;
 				box-shadow: 0 0 15px 1px $color-status-minor-warning;
+				color: $color-status-minor-warning-text;
 			}
 
 			&.major {

--- a/meteor/client/styles/systemStatus.scss
+++ b/meteor/client/styles/systemStatus.scss
@@ -88,6 +88,7 @@
 			.pill {
 				background: $color-status-minor-warning;
 				border: $color-status-minor-warning;
+				color: $color-status-minor-warning-text;
 			}
 		}
 


### PR DESCRIPTION
Modify css such that this warning pill:

![Screenshot from 2019-07-08 10-08-30](https://user-images.githubusercontent.com/5892030/60798141-7a2dbf80-a168-11e9-9528-012f1007f939.png)

Becomes more readable:

![Screenshot from 2019-07-08 10-08-49](https://user-images.githubusercontent.com/5892030/60798147-7dc14680-a168-11e9-97c5-7bb60f064374.png)
