### PR TITLE
fix: lookahead transitions respect prev_full class

### DIFF
--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -356,6 +356,18 @@ const StudioMappings = translate()(class StudioMappings extends React.Component<
 							className='input text-input input-l'></EditAttribute>
 					</label>
 				</div>
+				<div className='mod mvs mhs'>
+					<label className='field'>
+						{t('Priority')}
+						<EditAttribute
+							modifiedClassName='bghl'
+							attribute={'mappings.' + layerId + '.priority'}
+							obj={this.props.studio}
+							type='int'
+							collection={Studios}
+							className='input text-input input-l'></EditAttribute>
+					</label>
+				</div>
 			</React.Fragment>
 		)
 	}

--- a/meteor/client/ui/Settings/components/PlayoutDeviceSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/PlayoutDeviceSettingsComponent.tsx
@@ -280,8 +280,8 @@ export const PlayoutDeviceSettingsComponent = translate()(class PlayoutDeviceSet
 			</div>
 			<div className='mod mvs mhs'>
 				<label className='field'>
-					{t('Ramp Function Path')}
-					<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.options.rampMotorFunctionPath'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+					{t('Priority')}
+					<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.options.priority'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
 				</label>
 			</div>
 		</React.Fragment>

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -312,9 +312,11 @@ function findObjectsForPart (rundownData: RundownData, layer: string, timeOrdere
 			const orderedItems = getOrderedPiece(startingPartOnLayer.part)
 
 			let allowTransition = false
+			let classesFromPreviousPart: string[] = []
 			if (startingPartOnLayerIndex >= 1 && activeRundown.currentPartId) {
 				const prevPieceGroup = timeOrderedPartsWithPieces[startingPartOnLayerIndex - 1]
 				allowTransition = !prevPieceGroup.part.disableOutTransition
+				classesFromPreviousPart = prevPieceGroup.part.classesForNext || []
 			}
 
 			const transObj = orderedItems.find(i => !!i.isTransition)
@@ -354,6 +356,10 @@ function findObjectsForPart (rundownData: RundownData, layer: string, timeOrdere
 					let transitionKF: TimelineTypes.TimelineKeyframe | undefined = undefined
 					if (allowTransition) {
 						transitionKF = _.find(obj.keyframes || [], kf => kf.enable.while === '.is_transition')
+
+						if (!transitionKF && _.find(classesFromPreviousPart || [], c => c === 'prev_clip_full')) {
+							transitionKF = _.find(obj.keyframes || [], kf => kf.enable.while === '.is_transition & .prev_clip_full')
+						}
 					}
 					const newContent = Object.assign({}, obj.content, transitionKF ? transitionKF.content : {})
 

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -357,8 +357,11 @@ function findObjectsForPart (rundownData: RundownData, layer: string, timeOrdere
 					if (allowTransition) {
 						transitionKF = _.find(obj.keyframes || [], kf => kf.enable.while === '.is_transition')
 
-						if (!transitionKF && _.find(classesFromPreviousPart || [], c => c === 'prev_clip_full')) {
-							transitionKF = _.find(obj.keyframes || [], kf => kf.enable.while === '.is_transition & .prev_clip_full')
+						// TODO - this keyframe matching is a hack, and is very fragile
+
+						if (!transitionKF && classesFromPreviousPart && classesFromPreviousPart.length > 0) {
+							// Check if the keyframe also uses a class to match. This handles a specific edge case
+							transitionKF = _.find(obj.keyframes || [], kf => _.any(classesFromPreviousPart, cl => kf.enable.while === `.is_transition & .${cl}`))
 						}
 					}
 					const newContent = Object.assign({}, obj.content, transitionKF ? transitionKF.content : {})


### PR DESCRIPTION
This fix makes lookahead respect a class from the Previous Part such that a transition can be enabled.

I've noticed that when Parts are played out of order the lookahead will "forget" what part was before the current part and it will remove the transition right before actually playing and then add it back when sending the play command. I haven't quite looked into what happens there, but I think in the current implementation of lookahead that's reasonable limitation and won't happen when parts are nicely played in order.