### PR TITLE
Feature: streamdeck

### DIFF
--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -1,0 +1,31 @@
+@media screen and (width: 360px) and (height: 216px) {
+	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		overflow: hidden;
+		
+		.dashboard-panel {
+			padding: 0;
+			margin: 0;
+			
+			.dashboard-panel__header {
+				display: none;
+			}
+
+			.dashboard-panel__panel {
+				margin: 0 -2px 0 0;
+				max-height: 100%;
+				overflow: hidden;
+
+				.dashboard-panel__panel__button {
+					width: 71px;
+					height: 70px;
+					margin: 1px 1px 1px 0px;
+					font-size: 13px;
+				}
+			}
+		}
+	}
+}

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -4,6 +4,11 @@
 	   screen and (width: 768px) and (height: 384px),
 	   /** Stream Deck Mini, button size 80px */
 	   screen and (width: 240px) and (height: 160px) {
+
+	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport {
+		background: #000;
+	}
+
 	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
 		top: 0;
 		left: 0;
@@ -14,6 +19,7 @@
 		.dashboard-panel {
 			padding: 0;
 			margin: 0;
+			background: #252627;
 			
 			.dashboard-panel__header {
 				display: none;

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -5,6 +5,36 @@
 	   /** Stream Deck Mini, button size 80px */
 	   screen and (width: 240px) and (height: 160px) {
 
+	#render-target > .container-fluid > .rundown-view {
+		background: #000;
+
+		> .rundown-view__label {
+			> p {
+				display: none;
+			}
+		}
+
+		&.rundown-view--unpublished {
+			> .rundown-view__label {
+				&::before {
+					display: block;
+					position: absolute;
+					content: '...';
+					color: #fff;
+					top: 50%;
+					left: 50%;
+					transform: translate(-50%, -50%);
+				}
+			}
+		}
+
+		&.rundown-view--loading {
+			> .mod.mhl.mvl.alc {
+				transform: translate(-160%, -135%);
+			}
+		}
+	}
+
 	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport {
 		background: #000;
 	}

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -1,4 +1,9 @@
-@media screen and (width: 360px) and (height: 216px) {
+	   /** Stream Deck Original, button size 72px */
+@media screen and (width: 360px) and (height: 216px),
+	   /** Stream Deck XL, button size 96px */
+	   screen and (width: 768px) and (height: 384px),
+	   /** Stream Deck Mini, button size 80px */
+	   screen and (width: 240px) and (height: 160px) {
 	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
 		top: 0;
 		left: 0;
@@ -18,14 +23,58 @@
 				margin: 0 -2px 0 0;
 				max-height: 100%;
 				overflow: hidden;
-
-				.dashboard-panel__panel__button {
-					width: 71px;
-					height: 70px;
-					margin: 1px 1px 1px 0px;
-					font-size: 13px;
-				}
 			}
+		}
+	}
+}
+
+/** Stream Deck Original */
+@media screen and (width: 360px) and (height: 216px) {
+	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
+		--dashboard-button-grid-width: 1.5em;
+		--dashboard-button-grid-height: 1.5em;
+		--dashboard-panel-margin-width: 0em;
+		--dashboard-panel-margin-height: 0em;
+	
+		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
+			width: 71px;
+			height: 71px;
+			margin: 0px 1px 1px 0px;
+			font-size: 13px;
+		}
+	}
+}
+
+/** Stream Deck XL */
+@media screen and (width: 768px) and (height: 384px) {
+	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
+		--dashboard-button-grid-width: 2.007em;
+		--dashboard-button-grid-height: 2.007em;
+		--dashboard-panel-margin-width: 0em;
+		--dashboard-panel-margin-height: 0em;
+
+		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
+			width: 95px;
+			height: 95px;
+			margin: 0px 1px 1px 0px;
+			font-size: 15px;
+		}
+	}
+}
+
+/** Stream Deck Mini */
+@media screen and (width: 240px) and (height: 160px) {
+	#render-target > .container-fluid > .rundown-view__shelf.dark.full-viewport > .dashboard {
+		--dashboard-button-grid-width: 1.669em;
+		--dashboard-button-grid-height: 1.669em;
+		--dashboard-panel-margin-width: 0em;
+		--dashboard-panel-margin-height: 0em;
+
+		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
+			width: 79px;
+			height: 79px;
+			margin: 0px 1px 1px 0px;
+			font-size: 13px;
 		}
 	}
 }

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -19,6 +19,10 @@
 				display: none;
 			}
 
+			.adlib-panel__list-view__toolbar {
+				display: none;
+			}
+
 			.dashboard-panel__panel {
 				margin: 0 -2px 0 0;
 				max-height: 100%;

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -33,6 +33,12 @@
 				margin: 0 -2px 0 0;
 				max-height: 100%;
 				overflow: hidden;
+
+				> .dashboard-panel__panel__button {
+					> .dashboard-panel__panel__button__label {
+						top: 4px;
+					}
+				}
 			}
 		}
 	}

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -8,6 +8,11 @@
 	bottom: 2px;
 	right: 2px;
 	overflow: auto;
+
+	--dashboard-button-grid-width: 1.875em;
+	--dashboard-button-grid-height: 1.625em;
+	--dashboard-panel-margin-width: 0.938em;
+	--dashboard-panel-margin-height: 2.750em;
 }
 
 .dashboard-panel {

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -15,12 +15,12 @@
 	background: rgba(0, 0, 0, 0.2);
 	border: 1px solid rgba(0,0,0,0.1);
 	border-radius: 5px;
-	padding: 10px;
-	margin: 10px;
+	padding: 0.625rem;
+	margin: 0.625rem;
 	user-select: none;
 
 	.dashboard-panel__header {
-		margin: 0 0 10px;
+		margin: 0 0 0.625rem;
 		padding: 0;
 		white-space: nowrap;
 		overflow: hidden;
@@ -37,11 +37,11 @@
 		}
 
 		display: flex;
-		padding: 10px 5px;
+		padding: 0.625rem 0.313rem;
 
 		> .adlib-panel__list-view__toolbar__filter {
 			flex: 2 2;
-			max-width: 25em;
+			max-width: 25rem;
 			position: relative;
 
 			> .adlib-panel__list-view__toolbar__filter__input {
@@ -101,14 +101,15 @@
   		align-items: flex-end;
 		position: relative;
 		background: #000;
+		border: none;
 		border-radius: 3px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: normal;
 		line-break: loose;
 		word-break: break-all;
-		width: 82px;
-		height: 72px;
+		width: 6.40625em;
+		height: 5.625em;
 		border: none;
 		margin: 4px;
 		vertical-align: top;
@@ -146,6 +147,11 @@
 				z-index: 10;
 				// animation: 2s button-flash normal infinite;
 			}
+		}
+
+		&:focus {
+			outline: none;
+			box-shadow: none;
 		}
 
 		&:active {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -46,8 +46,10 @@ interface IState {
 	searchFilter: string | undefined
 }
 
-const BUTTON_GRID_WIDTH = 1
-const BUTTON_GRID_HEIGHT = 0.61803
+const BUTTON_GRID_WIDTH = 1.875
+const BUTTON_GRID_HEIGHT = 1.625
+const PANEL_MARGIN_WIDTH = 0.938
+const PANEL_MARGIN_HEIGHT = 2.750
 
 interface IDashboardPanelProps {
 	searchFilter?: string | undefined
@@ -345,30 +347,30 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 					<div className='dashboard-panel'
 						style={{
 							width: filter.width >= 0 ?
-								(filter.width * BUTTON_GRID_WIDTH) + 'vw' :
+								((filter.width * BUTTON_GRID_WIDTH) + PANEL_MARGIN_WIDTH) + 'em' :
 								undefined,
 							height: filter.height >= 0 ?
-								(filter.height * BUTTON_GRID_HEIGHT) + 'vw' :
+								((filter.height * BUTTON_GRID_HEIGHT) + PANEL_MARGIN_HEIGHT) + 'em' :
 								undefined,
 							left: filter.x >= 0 ?
-								(filter.x * BUTTON_GRID_WIDTH) + 'vw' :
+								(filter.x * BUTTON_GRID_WIDTH) + 'em' :
 								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'vw' :
+									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'em' :
 									undefined,
 							top: filter.y >= 0 ?
-								(filter.y * BUTTON_GRID_HEIGHT) + 'vw' :
+								(filter.y * BUTTON_GRID_HEIGHT) + 'em' :
 								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
+									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'em' :
 									undefined,
 							right: filter.x < 0 ?
-								((-1 * filter.x - 1) * BUTTON_GRID_WIDTH) + 'vw' :
+								((-1 * filter.x - 1) * BUTTON_GRID_WIDTH) + 'em' :
 								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'vw' :
+									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'em' :
 									undefined,
 							bottom: filter.y < 0 ?
-								((-1 * filter.y - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
+								((-1 * filter.y - 1) * BUTTON_GRID_HEIGHT) + 'em' :
 								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
+									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'em' :
 									undefined
 						}}
 					>

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -46,11 +46,6 @@ interface IState {
 	searchFilter: string | undefined
 }
 
-const BUTTON_GRID_WIDTH = 1.875
-const BUTTON_GRID_HEIGHT = 1.625
-const PANEL_MARGIN_WIDTH = 0.938
-const PANEL_MARGIN_HEIGHT = 2.750
-
 interface IDashboardPanelProps {
 	searchFilter?: string | undefined
 	mediaPreviewUrl?: string
@@ -347,30 +342,30 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 					<div className='dashboard-panel'
 						style={{
 							width: filter.width >= 0 ?
-								((filter.width * BUTTON_GRID_WIDTH) + PANEL_MARGIN_WIDTH) + 'em' :
+								`calc((${filter.width} * var(--dashboard-button-grid-width)) + var(--dashboard-panel-margin-width))` :
 								undefined,
 							height: filter.height >= 0 ?
-								((filter.height * BUTTON_GRID_HEIGHT) + PANEL_MARGIN_HEIGHT) + 'em' :
+								`calc((${filter.height} * var(--dashboard-button-grid-height)) + var(--dashboard-panel-margin-height))` :
 								undefined,
 							left: filter.x >= 0 ?
-								(filter.x * BUTTON_GRID_WIDTH) + 'em' :
+								`calc(${filter.x} * var(--dashboard-button-grid-width))` :
 								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'em' :
+									`calc(${-1 * filter.width - 1} * var(--dashboard-button-grid-width))` :
 									undefined,
 							top: filter.y >= 0 ?
-								(filter.y * BUTTON_GRID_HEIGHT) + 'em' :
+								`calc(${filter.y} * var(--dashboard-button-grid-height))` :
 								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'em' :
+									`calc(${-1 * filter.height - 1} * var(--dashboard-button-grid-height))` :
 									undefined,
 							right: filter.x < 0 ?
-								((-1 * filter.x - 1) * BUTTON_GRID_WIDTH) + 'em' :
+								`calc(${-1 * filter.x - 1} * var(--dashboard-button-grid-width))` :
 								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'em' :
+									`calc(${-1 * filter.width - 1} * var(--dashboard-button-grid-width))` :
 									undefined,
 							bottom: filter.y < 0 ?
-								((-1 * filter.y - 1) * BUTTON_GRID_HEIGHT) + 'em' :
+								`calc(${-1 * filter.y - 1} * var(--dashboard-button-grid-height))` :
 								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'em' :
+									`calc(${-1 * filter.height - 1} * var(--dashboard-button-grid-height))` :
 									undefined
 						}}
 					>

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -35,8 +35,8 @@ interface IDashboardButtonProps {
 	widthScale?: number
 	heightScale?: number
 }
-const DEFAULT_BUTTON_WIDTH = 82
-const DEFAULT_BUTTON_HEIGHT = 72
+const DEFAULT_BUTTON_WIDTH = 6.40625
+const DEFAULT_BUTTON_HEIGHT = 5.625
 
 interface IDashboardButtonTrackedProps {
 	status: RundownAPI.PieceStatusCode | undefined
@@ -121,8 +121,12 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 				'live': this.props.isOnAir
 			}, RundownUtils.getSourceLayerClassName(this.props.layer.type))}
 				style={{
-					width: (this.props.widthScale || 1) * DEFAULT_BUTTON_WIDTH,
-					height: (this.props.heightScale || 1) * DEFAULT_BUTTON_HEIGHT
+					width: this.props.widthScale ?
+						(this.props.widthScale * DEFAULT_BUTTON_WIDTH) + 'em' :
+						undefined,
+					height: this.props.heightScale ?
+						(this.props.heightScale * DEFAULT_BUTTON_HEIGHT) + 'em' :
+						undefined
 				}}
 				onClick={(e) => this.props.onToggleAdLib(this.props.item, e.shiftKey, e)}
 				data-obj-id={this.props.item._id}


### PR DESCRIPTION
This PR introduces support for displaying the dashboard on an Elgato Stream Deck device using a web browser renderer. I'm using this Electron-based tool: [jstarpl/stream-deck-browser](https://github.com/jstarpl/stream-deck-browser) to display the dashboard layout on the Stream Deck.

The proper formatting for the device (alignment of virtual buttons to hardware buttons) is achieved using CSS Media Queries.