### PR TITLE
wip: descriptive version numbers in the ui

### DIFF
--- a/meteor/.meteorignore
+++ b/meteor/.meteorignore
@@ -1,4 +1,5 @@
 coverage
+scripts
 **/.coverage/
 **/__mocks__/
 **/__tests__/

--- a/meteor/client/ui/Dashboard.tsx
+++ b/meteor/client/ui/Dashboard.tsx
@@ -46,7 +46,7 @@ export default translate()(class Dashboard extends React.Component<Translated<IP
 					<h1>{t('Welcome to the Sofie Automation system')}</h1>
 				</div>
 				<div className='mtl gutter version-info'>
-					<p>{t('Sofie Automation version')}: {PackageInfo.version || 'UNSTABLE'}, {t('Sofie status')}: {statusCodeToString(t, this.state.systemStatus || 0)}</p>
+					<p>{t('Sofie Automation version')}: {PackageInfo.versionExtended || PackageInfo.version || 'UNSTABLE'}, {t('Sofie status')}: {statusCodeToString(t, this.state.systemStatus || 0)}</p>
 				</div>
 			</div>
 		)

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -452,7 +452,7 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 			</div>
 			<div className='mtl gutter version-info'>
 				<p>
-					{t('Sofie Automation')} {t('version')}: {PackageInfo.version || 'UNSTABLE'}
+					{t('Sofie Automation')} {t('version')}: {PackageInfo.versionExtended || PackageInfo.version || 'UNSTABLE'}
 				</p>
 				<div>
 					{

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-core",
-  "version": "0.0.0-develop",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12256,6 +12256,32 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-git": {
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
+      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "sinon": {
       "version": "7.3.2",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-core",
-  "version": "0.0.0-develop",
+  "version": "0.0.0",
   "private": true,
   "engines": {
     "node": "8.x"
@@ -123,6 +123,7 @@
     "meteor-promise": "0.8.7",
     "node-license-validator": "^1.3.0",
     "open-cli": "^5.0.0",
+    "simple-git": "^1.126.0",
     "sinon": "^7.3.2",
     "standard-version": "^6.0.1",
     "ts-jest": "^24.0.2",

--- a/meteor/scripts/generate-version-file.js
+++ b/meteor/scripts/generate-version-file.js
@@ -1,0 +1,29 @@
+const moment = require('moment')
+const fs = require('fs')
+const path = require('path')
+const simpleGit = require('simple-git/promise')('..')
+
+const isRelease = !!process.argv.find(a => a.match(/--release/i))
+// console.log('release:', isRelease)
+
+const pkgPath = path.join(__dirname, '../package.json')
+const pkg = JSON.parse(fs.readFileSync(pkgPath))
+
+;(async () => {
+	const commitTime = await simpleGit.raw(['log', '-1', '--pretty=format:%ct', 'HEAD'])
+	const dateStr = moment(parseInt(commitTime, 10) * 1000).format('YYYYMMDD-HHmm')
+
+	if (isRelease) {
+		const commitHash = await simpleGit.revparse(['--short', 'HEAD'])
+		pkg.versionExtended = `${pkg.version}+g${commitHash}-${dateStr}`
+	} else {
+		const versionStr = await simpleGit.raw(['describe', '--always'])
+		const branch = await simpleGit.raw(['rev-parse', '--abbrev-ref', 'HEAD'])
+		pkg.versionExtended = `${pkg.version}+${branch.trim()}-${versionStr.trim()}-${dateStr}`
+	}
+
+	console.log('Version:', pkg.versionExtended)
+
+	fs.writeFileSync(pkgPath, JSON.stringify(pkg, undefined, 2))
+
+})()

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -262,7 +262,7 @@ function updateRundownFromIngestData (
 				showStyleBase: showStyle.base._rundownVersionHash,
 				showStyleVariant: showStyle.variant._rundownVersionHash,
 				blueprint: showStyleBlueprintDb.blueprintVersion,
-				core: PackageInfo.version,
+				core: PackageInfo.versionExtended || PackageInfo.version,
 			},
 
 			// omit the below fields

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1201,7 +1201,7 @@ export namespace ServerPlayoutAPI {
 
 			const versionsContent = (markerObject.metadata || {}).versions || {}
 
-			if (versionsContent.core !== PackageInfo.version) return 'coreVersion'
+			if (versionsContent.core !== (PackageInfo.versionExtended || PackageInfo.version)) return 'coreVersion'
 
 			if (versionsContent.studio !== (studio._rundownVersionHash || 0)) return 'studio'
 

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -293,7 +293,7 @@ function getTimelineRundown (studio: Studio, activeRundownData: RundownData | nu
 						layer: id,
 						metadata: {
 							versions: {
-								core: PackageInfo.version,
+								core: PackageInfo.versionExtended || PackageInfo.version,
 								blueprintId: studio.blueprintId,
 								blueprintVersion: blueprint.blueprintVersion,
 								studio: studio._rundownVersionHash,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -314,7 +314,7 @@ export namespace ClientRundownAPI {
 		if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
 		if (!rundown.importVersions) return 'unknown'
 
-		if (rundown.importVersions.core !== PackageInfo.version) return 'coreVersion'
+		if (rundown.importVersions.core !== (PackageInfo.versionExtended || PackageInfo.version)) return 'coreVersion'
 
 		const showStyleVariant = ShowStyleVariants.findOne(rundown.showStyleVariantId)
 		if (!showStyleVariant) return 'missing showStyleVariant'

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -382,7 +382,7 @@ export function getRelevantSystemVersions (): { [name: string]: string } {
 		_.each(names, (name) => {
 			versions[name] = sanitizeVersion(dependencies[name])
 		})
-		versions['core'] = PackageInfo.version // package version
+		versions['core'] = PackageInfo.versionExtended || PackageInfo.version // package version
 
 	} else logger.error(`Core package dependencies missing`)
 	return versions
@@ -395,7 +395,7 @@ function startupMessage () {
 	logger.info(`Core starting up`)
 	logger.info(`Core system version: "${CURRENT_SYSTEM_VERSION}"`)
 
-	logger.info(`Core package version: "${PackageInfo.version}"`)
+	logger.info(`Core package version: "${PackageInfo.versionExtended || PackageInfo.version}"`)
 
 	const versions = getRelevantSystemVersions()
 	_.each(versions, (version, name) => {


### PR DESCRIPTION
Produces the format:
Release: `1.0.0+gd841ca55-20191022-1658`
Dev: `0.0.0+develop-r13rc5-70-gd841ca55-20191022-1658`
The release one should be pretty self explanatory.
The dev one, is the broken down as follows:
`0.0.0` - version from package.json
`develop` the branch name
`r13rc5-70-gd841ca55` most recent tag, number of commits since, and the hash
`20191022-1658` date and time of commit

This will help developers and testers quickly and easily identify what a build is without needing to check the deployment history in slack.

For now this is replacing any existing version numbers, some of it may have been done too aggressively.
It needs a bit more testing, but shall hold off on that until its get approval to be merged.