### PR TITLE
Fix: segment viewport manipulation using scroll wheel

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -264,6 +264,10 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 	setSegmentRef = (el: HTMLDivElement) => {
 		this.segmentBlock = el
 		if (typeof this.props.segmentRef === 'function') this.props.segmentRef(this as any, this.props.segment._id)
+
+		if (this.segmentBlock) {
+			this.segmentBlock.addEventListener('wheel', this.onTimelineWheel, { passive: false, capture: true })
+		}
 	}
 
 	setTimelineRef = (el: HTMLDivElement) => {
@@ -565,9 +569,11 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 				<TimelineGrid {...this.props}
 					onResize={this.onTimelineResize} />
 				<div className='segment-timeline__timeline-container'
-					onTouchStartCapture={this.onTimelineTouchStart}
-					onWheelCapture={this.onTimelineWheel}>
-					<div className='segment-timeline__timeline' key={this.props.segment._id + '-timeline'} ref={this.setTimelineRef} style={this.timelineStyle()}>
+					onTouchStartCapture={this.onTimelineTouchStart}>
+					<div className='segment-timeline__timeline'
+						key={this.props.segment._id + '-timeline'}
+						ref={this.setTimelineRef}
+						style={this.timelineStyle()}>
 						<ErrorBoundary>
 							{this.renderTimeline()}
 							{this.renderEndOfSegment()}


### PR DESCRIPTION
**What is happening?**
Segment Timeline (Viewport) manipulation doesn't work since Chrome 73, when scroll events became passive.

**What should happen?**
It should be possible to manipulate the segment timeline using the mouse wheel and modifiers (alt & ctrl) or if the mouse supports horizontal wheel: using the horizontal wheel without any modifiers.

**What this PR changes?**
This has happened, because React attaches event listeners on the document root and therefore mouse wheel events on the Segment Timeline are treated as if they are scroll events. This PR removes the native react event handler and attaches the mouse wheel event handler directly to the Timeline element.