### PR TITLE
System migrations

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -57,7 +57,7 @@ export function setupMockPeripheralDevice (
 	category: PeripheralDeviceAPI.DeviceCategory,
 	type: PeripheralDeviceAPI.DeviceType,
 	subType: PeripheralDeviceAPI.DeviceSubType,
-	studio: Studio,
+	studio?: Studio,
 	doc?: Partial<PeripheralDevice>
 ) {
 	doc = doc || {}
@@ -65,7 +65,7 @@ export function setupMockPeripheralDevice (
 	const defaultDevice: PeripheralDevice = {
 		_id: 'mockDevice' + (dbI++),
 		name: 'mockDevice',
-		studioId: studio._id,
+		studioId: studio ? studio._id : undefined,
 
 		category: category,
 		type: type,
@@ -396,6 +396,14 @@ export function setupDefaultStudioEnvironment (): DefaultEnvironment {
 		studio,
 		core,
 		ingestDevice
+	}
+}
+export function setupEmptyEnvironment () {
+
+	const core = setupMockCore({})
+
+	return {
+		core
 	}
 }
 export function setupDefaultRundown (env: DefaultEnvironment, rundownId0?: string): string {

--- a/meteor/server/api/blueprints/__tests__/lib.ts
+++ b/meteor/server/api/blueprints/__tests__/lib.ts
@@ -1,0 +1,32 @@
+import { BlueprintManifestType, SomeBlueprintManifest } from 'tv-automation-sofie-blueprints-integration'
+import { literal } from '../../../../lib/lib'
+import { Blueprint } from '../../../../lib/collections/Blueprints'
+
+export function generateFakeBlueprint (
+	id: string,
+	type?: BlueprintManifestType,
+	codeFcn?: () => SomeBlueprintManifest
+) {
+	return literal<Blueprint>({
+		_id: id,
+		name: 'Fake blueprint',
+		code: `{default: (${(codeFcn && codeFcn.toString()) || '() => 5'})()}`,
+		created: 0,
+		modified: 0,
+
+		blueprintType: type,
+
+		studioConfigManifest: [],
+		showStyleConfigManifest: [],
+
+		databaseVersion: {
+			showStyle: {},
+			studio: {},
+		},
+
+		blueprintVersion: '',
+		integrationVersion: '',
+		TSRVersion: '',
+		minimumCoreVersion: '',
+	})
+}

--- a/meteor/server/migration/0_1_0.ts
+++ b/meteor/server/migration/0_1_0.ts
@@ -68,33 +68,5 @@ addMigrationSteps('0.1.0', [
 			inputType: null,
 			attribute: null
 		}]
-	},
-	{
-		id: 'Mos-gateway exists',
-		canBeRunAutomatically: false,
-		dependOnResultFrom: 'studio exists',
-		validate: () => {
-			let studios = Studios.find().fetch()
-			let missing: string | boolean = false
-			_.each(studios, (studio: Studio) => {
-				const dev = PeripheralDevices.findOne({
-					type: PeripheralDeviceAPI.DeviceType.MOS,
-					studioId: studio._id
-				})
-				if (!dev) {
-					missing = `Mos-device is missing on ${studio._id}`
-				}
-			})
-
-			return missing
-		},
-		// Note: No migrate() function, user must fix this him/herself
-		input: [{
-			label: 'Mos-device not set up for all studios',
-			description: 'Start up the Mos-gateway and make sure it\'s connected to Sofie',
-			inputType: null,
-			attribute: null
-		}]
 	}
-
 ])

--- a/meteor/server/migration/0_1_0.ts
+++ b/meteor/server/migration/0_1_0.ts
@@ -61,7 +61,7 @@ addMigrationSteps('0.1.0', [
 
 				let missing: string | boolean = false
 				PeripheralDevices.find().forEach((device) => {
-					if (!device.studioId) PeripheralDevices.update(device._id, { $set: { studioId: studio._id }})
+					if (!device.studioId) PeripheralDevices.update(device._id, { $set: { studioId: studio._id } })
 				})
 			} else {
 				throw new Error(`Unable to automatically assign Peripheral-devices to a studio, since there are ${studios.length} studios. Please assign them manually`)

--- a/meteor/server/migration/0_25_0.ts
+++ b/meteor/server/migration/0_25_0.ts
@@ -1,4 +1,4 @@
-import { addMigrationSteps, CURRENT_SYSTEM_VERSION } from './databaseMigration'
+import { addMigrationSteps } from './databaseMigration'
 import * as _ from 'underscore'
 import { renamePropertiesInCollection, setExpectedVersion } from './lib'
 import * as semver from 'semver'

--- a/meteor/server/migration/__tests__/migrations.test.ts
+++ b/meteor/server/migration/__tests__/migrations.test.ts
@@ -1,0 +1,120 @@
+import { Meteor } from 'meteor/meteor'
+import * as _ from 'underscore'
+import { setupEmptyEnvironment, setupMockPeripheralDevice } from '../../../__mocks__/helpers/database'
+import { PeripheralDevice } from '../../../lib/collections/PeripheralDevices'
+import { testInFiber } from '../../../__mocks__/helpers/jest'
+import { getCoreSystem, ICoreSystem, GENESIS_SYSTEM_VERSION } from '../../../lib/collections/CoreSystem'
+import { CURRENT_SYSTEM_VERSION } from '../databaseMigration'
+import { MigrationMethods, RunMigrationResult, GetMigrationStatusResult } from '../../../lib/api/migration'
+import { literal } from '../../../lib/lib'
+import { MigrationStepInputResult } from 'tv-automation-sofie-blueprints-integration'
+import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
+import { Studios } from '../../../lib/collections/Studios'
+
+require('../api.ts') // include in order to create the Meteor methods needed
+
+// Include all migration scripts:
+const normalizedPath = require('path').join(__dirname, '../')
+require('fs').readdirSync(normalizedPath).forEach((fileName) => {
+	if (fileName.match(/\d+_\d+_\d+\.ts/)) { // x_y_z.ts
+		require('../' + fileName)
+	}
+})
+
+describe('Test ingest actions for rundowns and segments', () => {
+
+	beforeAll(() => {
+		setupEmptyEnvironment()
+	})
+	function getSystem () {
+		return getCoreSystem() as ICoreSystem
+	}
+	function userInput (migrationStatus: GetMigrationStatusResult, userInput?: {[key: string]: any}): MigrationStepInputResult[] {
+		return _.compact(_.map(migrationStatus.migration.manualInputs, (manualInput) => {
+			if (
+				manualInput.stepId &&
+				manualInput.attribute
+			) {
+				return literal<MigrationStepInputResult>({
+					stepId: manualInput.stepId,
+					attribute: manualInput.attribute,
+					value: userInput && userInput[manualInput.stepId]
+				})
+			}
+		}))
+	}
+
+	testInFiber('System migrations, initial setup', () => {
+
+		expect(getSystem().version).toEqual(GENESIS_SYSTEM_VERSION)
+
+		const migrationStatus0: GetMigrationStatusResult = Meteor.call(MigrationMethods.getMigrationStatus)
+
+		expect(migrationStatus0).toMatchObject({
+			migrationNeeded: true,
+
+			migration: {
+				canDoAutomaticMigration: true,
+				// manualInputs: [],
+				hash: expect.stringContaining(''),
+				automaticStepCount: expect.any(Number),
+				manualStepCount: 0,
+				ignoredStepCount: expect.any(Number),
+				partialMigration: true
+				// chunks: expect.any(Array)
+			}
+		})
+		expect(migrationStatus0.migration.automaticStepCount).toBeGreaterThanOrEqual(1)
+
+		const migrationResult0: RunMigrationResult = Meteor.call(MigrationMethods.runMigration,
+			migrationStatus0.migration.chunks,
+			migrationStatus0.migration.hash,
+			userInput(migrationStatus0)
+		)
+
+		expect(migrationResult0).toMatchObject({
+			migrationCompleted: false,
+			partialMigration: true,
+			warnings: expect.any(Array),
+			snapshot: expect.any(String)
+		})
+
+		const studios = Studios.find().fetch() // Created in the migration step before
+		expect(studios).toHaveLength(1)
+		const studio = studios[0]
+
+		// Connect a Playout-gateway to the system:
+		setupMockPeripheralDevice(
+			PeripheralDeviceAPI.DeviceCategory.PLAYOUT,
+			PeripheralDeviceAPI.DeviceType.PLAYOUT,
+			PeripheralDeviceAPI.SUBTYPE_PROCESS,
+			studio
+		)
+
+		// Continue with migration:
+		const migrationStatus1: GetMigrationStatusResult = Meteor.call(MigrationMethods.getMigrationStatus)
+		expect(migrationStatus1.migrationNeeded).toEqual(true)
+		expect(migrationStatus1.migration.automaticStepCount).toBeGreaterThanOrEqual(1)
+
+		const migrationResult1: RunMigrationResult = Meteor.call(MigrationMethods.runMigration,
+			migrationStatus1.migration.chunks,
+			migrationStatus1.migration.hash,
+			userInput(migrationStatus1, {
+				'CoreSystem.storePath': 'mock',
+				'Studios.settings.mediaPreviewsUrl': 'mock',
+				'Studios.settings.sofieUrl': 'http://localhost',
+				'Studios.settings.slackEvaluationUrls': 'mock',
+				'Studios.settings.supportedMediaFormats': '1920x1080i5000, 1280x720, i5000, i5000tff'
+			})
+		)
+		expect(migrationResult1).toMatchObject({
+			migrationCompleted: true,
+			// partialMigration: true,
+			warnings: expect.any(Array),
+			snapshot: expect.any(String)
+		})
+
+		expect(getSystem().version).toEqual(CURRENT_SYSTEM_VERSION)
+
+	})
+})

--- a/meteor/server/migration/__tests__/migrations.test.ts
+++ b/meteor/server/migration/__tests__/migrations.test.ts
@@ -79,16 +79,11 @@ describe('Test ingest actions for rundowns and segments', () => {
 			snapshot: expect.any(String)
 		})
 
-		const studios = Studios.find().fetch() // Created in the migration step before
-		expect(studios).toHaveLength(1)
-		const studio = studios[0]
-
 		// Connect a Playout-gateway to the system:
 		setupMockPeripheralDevice(
 			PeripheralDeviceAPI.DeviceCategory.PLAYOUT,
 			PeripheralDeviceAPI.DeviceType.PLAYOUT,
-			PeripheralDeviceAPI.SUBTYPE_PROCESS,
-			studio
+			PeripheralDeviceAPI.SUBTYPE_PROCESS
 		)
 
 		// Continue with migration:

--- a/meteor/server/migration/api.ts
+++ b/meteor/server/migration/api.ts
@@ -1,0 +1,39 @@
+import { check, Match } from 'meteor/check'
+import { setMeteorMethods, Methods } from '../methods'
+import { MigrationMethods, MigrationChunk } from '../../lib/api/migration'
+import { getMigrationStatus, runMigration, forceMigration, resetDatabaseVersions } from './databaseMigration'
+import { MigrationStepInputResult } from 'tv-automation-sofie-blueprints-integration'
+
+const methods: Methods = {}
+methods[MigrationMethods.getMigrationStatus] = () => {
+	return getMigrationStatus()
+}
+methods[MigrationMethods.runMigration] = (
+	chunks: Array<MigrationChunk>,
+	hash: string,
+	inputResults: Array<MigrationStepInputResult>,
+	isFirstOfPartialMigrations?: boolean
+) => {
+
+	check(chunks, Array)
+	check(hash, String)
+	check(inputResults, Array)
+	check(isFirstOfPartialMigrations, Match.Optional(Boolean))
+
+	return runMigration(
+		chunks,
+		hash,
+		inputResults,
+		isFirstOfPartialMigrations
+	)
+}
+methods[MigrationMethods.forceMigration] = (chunks: Array<MigrationChunk>) => {
+	check(chunks, Array)
+
+	return forceMigration(chunks)
+}
+methods[MigrationMethods.resetDatabaseVersions] = () => {
+	return resetDatabaseVersions()
+}
+
+setMeteorMethods(methods)


### PR DESCRIPTION
This PR adds the feature to run system migrations before blueprint-blueprints.

It also deals with several issues that came up during implementation:
* Added tests for initial migrations
* Remove requirement of MOS-gateway. Since there are other ingest gateways that could be used, it doesn't make sense to require this one during installation.

TODO:
- [x] Add to tests: mocked blueprints (system, studio, showStyle) which exposes migrations
- [x] Make Core/system migrations run before blueprints
- [x] Define in which order blueprints migrations are run
- [x] Tests