### PR TITLE
fix: don't reset invalid part actual duration, only displayDuration

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -348,7 +348,6 @@ withTracker<IRundownTimingProviderProps, IRundownTimingProviderState, IRundownTi
 				// Handle invalid parts by overriding the values to preset values for Invalid parts
 				if (part.invalid) {
 					currentRemaining = 0
-					partDuration = 0
 					partDisplayDuration = this.props.defaultDuration || DEFAULT_DURATION
 					this.partPlayed[part._id] = 0
 				}

--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -347,7 +347,6 @@ withTracker<IRundownTimingProviderProps, IRundownTimingProviderState, IRundownTi
 
 				// Handle invalid parts by overriding the values to preset values for Invalid parts
 				if (part.invalid) {
-					currentRemaining = 0
 					partDisplayDuration = this.props.defaultDuration || DEFAULT_DURATION
 					this.partPlayed[part._id] = 0
 				}


### PR DESCRIPTION
This PR makes sure that an invalid part doesn't have it's duration reset to 0. The displayDuration is still reset to 0 so that invalid parts behave as they do now.