### PR TITLE
Hotfix: AMQP reconnection failing

### DIFF
--- a/meteor/server/api/integration/rabbitMQ.ts
+++ b/meteor/server/api/integration/rabbitMQ.ts
@@ -68,7 +68,7 @@ class ConnectionManager extends Manager<AMQP.Connection> {
 		await super.init()
 
 		if (this.connection) {
-			await this.connection.close()
+			await this.connection.close().catch(() => null) // already closed connections will error
 		}
 
 		this.initializing = this.initConnection()

--- a/meteor/server/api/integration/rabbitMQ.ts
+++ b/meteor/server/api/integration/rabbitMQ.ts
@@ -73,7 +73,13 @@ class ConnectionManager extends Manager<AMQP.Connection> {
 
 		this.initializing = this.initConnection()
 
-		this.connection = await this.initializing
+		try {
+			this.connection = await this.initializing
+		} catch (e) {
+			// make sure this doesn't hang around
+			delete this.initializing
+			throw new Error(e)
+		}
 		delete this.initializing
 
 		this.channelManager = new ChannelManager(this.connection)


### PR DESCRIPTION
This PR contains two fixes solving one problem:
 * Calling close on a closed AMQP connection throws an error
 * Handling failure of intialization such that future initalizations do not get blocked