### PR TITLE
disable jenkins version release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 pipeline {
   agent any
   stages {
+    /*
     stage('Version') {
       when {
         branch 'master'
@@ -11,6 +12,7 @@ pipeline {
         versionRelease('meteor')
       }
     }
+    */
     stage('Build') {
       steps {
         sofieSlackSendBuildStarted()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Disable to automatically push a new release for commits to master.


* **What is the current behavior?** (You can also link to an open issue here)
Automatically push a new release for commits to master.


* **What is the new behavior (if this is a feature change)?**
Should be triggered manually instead.


* **Other information**:
