### PR TITLE
Add a copy of live line countdown to the top header

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -107,6 +107,52 @@ $segment-layer-separator-color: transparentize(#000, 0.5);
 	padding-right: $statusbar-width;
 	transition: 0s padding-right 0s;
 
+	.rundown-view__part__icon {
+		display: inline-block;
+		margin-left: 0.2em;
+
+		&.rundown-view__part__icon--next {
+			position: relative;
+			width: 0;
+			height: 0;
+			top: -2px;
+			border-width: 5px 0 5px 9px;
+			border-style: solid;
+			border-color: transparent transparent transparent $general-next-color;
+
+			&::after {
+				content: ' ';
+				position: absolute;
+				top: -5px;
+				right: -1px;
+				height: 10px;
+				width: 0;
+				border-left: 2px solid $general-next-color;
+			}
+		}
+
+		&.rundown-view__part__icon--auto-next {
+			position: relative;
+			width: 0;
+			height: 0;
+			top: -2px;
+			left: 4px;
+			border-width: 5px 0 5px 9px;
+			border-style: solid;
+			border-color: transparent transparent transparent $general-next-color;
+
+			&::after {
+				content: ' ';
+				position: absolute;
+				top: -5px;
+				left: -13px;
+				height: 10px;
+				width: 0;
+				border-left: 2px solid $general-next-color;
+			}
+		}
+	}
+
 	.header.rundown .notification-pop-ups {
 		top: 65px;
 	}
@@ -229,6 +275,19 @@ body.no-overflow {
 				text-align: center;
 			}
 
+			&.current-remaining {
+				position: absolute;
+				left: calc(50% + 3.5em);
+				text-align: left;
+				color: $liveline-timecode-color;
+				font-weight: 500;
+
+				.overtime {
+					color: $general-fast-color;
+					text-shadow: 0px 0px 6px transparentize($general-fast-color, 0.2);
+				}
+			}
+
 			.timing-clock-label {
 				position: absolute;
 				top: -1em;
@@ -286,11 +345,11 @@ body.no-overflow {
 			text-transform: uppercase;
 			background: #fff;
 			border-radius: 1rem;
+			line-height: 1em;
 			font-weight: 700;
 			color: #000;
-			top: 13px;
-			right: -5px;
-			transform: translateX(100%);
+			top: 2.4em;
+			left: 0;
 			padding: 2px 5px 1px;
 
 			&.rundown__header-status--hold {
@@ -923,54 +982,8 @@ body.no-overflow {
 
 			transition: $output-layer-group-collapse-animation-duration opacity ease-in-out $output-layer-group-collapse-animation-duration;
 
-			&.overtime {
+			> .overtime {
 				color: $general-late-color;
-			}
-		}
-
-		.segment-timeline__liveline__icon {
-			display: inline-block;
-			margin-left: 0.2em;
-
-			&.segment-timeline__liveline__icon--next {
-				position: relative;
-				width: 0;
-				height: 0;
-				top: -2px;
-				border-width: 5px 0 5px 9px;
-				border-style: solid;
-				border-color: transparent transparent transparent $general-next-color;
-
-				&::after {
-					content: ' ';
-					position: absolute;
-					top: -5px;
-					right: -1px;
-					height: 10px;
-					width: 0;
-					border-left: 2px solid $general-next-color;
-				}
-			}
-
-			&.segment-timeline__liveline__icon--auto-next {
-				position: relative;
-				width: 0;
-				height: 0;
-				top: 1px;
-				left: 4px;
-				border-width: 5px 0 5px 9px;
-				border-style: solid;
-				border-color: transparent transparent transparent $general-next-color;
-
-				&::after {
-					content: ' ';
-					position: absolute;
-					top: -5px;
-					left: -13px;
-					height: 10px;
-					width: 0;
-					border-left: 2px solid $general-next-color;
-				}
 			}
 		}
 
@@ -980,7 +993,7 @@ body.no-overflow {
 			text-transform: uppercase;
 			font-size: 0.7rem;
 			padding: 2px 5px 1px;
-			line-height: 1.2em;
+			line-height: 1.0em;
 			margin-top: 2px;
 			font-weight: 700;
 			color: #000;

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -22,7 +22,7 @@ import { Part, Parts } from '../../lib/collections/Parts'
 
 import { ContextMenu, MenuItem, ContextMenuTrigger } from 'react-contextmenu'
 
-import { RundownTimingProvider, withTiming, WithTiming } from './RundownView/RundownTiming'
+import { RundownTimingProvider, withTiming, WithTiming, CurrentPartRemaining, AutoNextStatus } from './RundownView/RundownTiming'
 import { SegmentTimelineContainer, PieceUi } from './SegmentTimeline/SegmentTimelineContainer'
 import { SegmentContextMenu } from './SegmentTimeline/SegmentContextMenu'
 import { Shelf, ShelfBase, ShelfTabs } from './Shelf/Shelf'
@@ -266,11 +266,15 @@ class extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 				}
 				<span className='timing-clock time-now'>
 					<Moment interval={0} format='HH:mm:ss' date={getCurrentTime()} />
+				</span>
+				{ this.props.rundown.currentPartId && <span className='timing-clock current-remaining'>
+					<CurrentPartRemaining heavyClassName='overtime' />
+					<AutoNextStatus />
 					{this.props.rundown.holdState && this.props.rundown.holdState !== RundownHoldState.COMPLETE ?
 						<div className='rundown__header-status rundown__header-status--hold'>{t('Hold')}</div>
 						: null
 					}
-				</span>
+				</span> }
 				{ this.props.rundown.expectedDuration ?
 					(<React.Fragment>
 						{this.props.rundown.expectedStart && this.props.rundown.expectedDuration &&

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -268,7 +268,7 @@ class extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 					<Moment interval={0} format='HH:mm:ss' date={getCurrentTime()} />
 				</span>
 				{ this.props.rundown.currentPartId && <span className='timing-clock current-remaining'>
-					<CurrentPartRemaining heavyClassName='overtime' />
+					<CurrentPartRemaining currentPartId={this.props.rundown.currentPartId} heavyClassName='overtime' />
 					<AutoNextStatus />
 					{this.props.rundown.holdState && this.props.rundown.holdState !== RundownHoldState.COMPLETE ?
 						<div className='rundown__header-status rundown__header-status--hold'>{t('Hold')}</div>

--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -624,11 +624,15 @@ class AutoNextStatus extends React.Component<WithTiming<{}>> {
 const SPEAK_ADVANCE = 500
 
 interface IPartRemainingProps {
+	currentPartId: string | null
 	hideOnZero?: boolean
 	className?: string
 	heavyClassName?: string
 	speaking?: boolean
 }
+
+// global variable for remembering last uttered displayTime
+let prevDisplayTime: number | undefined = undefined
 
 /**
  * A presentational component that will render a countdown to the end of the current part
@@ -638,6 +642,7 @@ interface IPartRemainingProps {
 export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 	isHighResolution: true
 })(class CurrentPartRemaining extends React.Component<WithTiming<IPartRemainingProps>> {
+
 	render () {
 		const displayTimecode = this.props.timingDurations.remainingTimeOnCurrentPart
 		return (<span className={ClassNames(this.props.className, 
@@ -645,7 +650,7 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 			)}>{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '', false, true)}</span>)
 	}
 
-	speak (prevDisplayTime: number) {
+	speak () {
 		// Note that the displayTime is negative when counting down to 0.
 		let displayTime = this.props.timingDurations.remainingTimeOnCurrentPart || 0
 
@@ -671,18 +676,25 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 				case -9: text = 'Nine'; break
 				case -10: text = 'Ten'; break
 			}
-			if (displayTime === 0 && prevDisplayTime === -1) {
-				text = 'Zero'
-			}
+			// if (displayTime === 0 && prevDisplayTime !== undefined) {
+			// 	text = 'Zero'
+			// }
 			
 			if (text) {
 				SpeechSynthesiser.speak(text, 'countdown')
 			}
+
+			prevDisplayTime = displayTime
 		}
 	}
 
 	componentDidUpdate (prevProps: WithTiming<IPartRemainingProps>) {
-		if (this.props.speaking) this.speak(prevProps.timingDurations.remainingTimeOnCurrentPart || -1)
+		if (this.props.speaking) {
+			if (this.props.currentPartId !== prevProps.currentPartId) {
+				prevDisplayTime = undefined
+			}
+			this.speak()
+		}
 	}
 })
 

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -15,7 +15,8 @@ import { SegmentTimelineZoomControls } from './SegmentTimelineZoomControls'
 import {
 	SegmentDuration,
 	PartCountdown,
-	RundownTiming
+	RundownTiming,
+	CurrentPartRemaining
 } from '../RundownView/RundownTiming'
 
 import { RundownUtils } from '../../lib/rundown'
@@ -37,6 +38,7 @@ import * as Zoom_Out_MouseOut from './Zoom_Out_MouseOut.json'
 import * as Zoom_Out_MouseOver from './Zoom_Out_MouseOver.json'
 import { LottieButton } from '../../lib/LottieButton'
 import { PartNote, NoteType } from '../../../lib/api/notes'
+import { getAllowSpeaking } from '../../lib/localStorage';
 
 interface IProps {
 	id: string
@@ -63,7 +65,6 @@ interface IProps {
 	followLiveLine: boolean,
 	liveLineHistorySize: number,
 	livePosition: number,
-	displayTimecode: number,
 	autoNextPart: boolean,
 	onScroll: (scrollLeft: number, event: any) => void
 	onZoomChange: (newScale: number, event: any) => void
@@ -403,12 +404,12 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 						onClick={(e) => this.props.onFollowLiveLine && this.props.onFollowLiveLine(true, e)}>
 						{t('On Air')}
 					</div>
-					<div className={ClassNames('segment-timeline__liveline__timecode', {
-						'overtime': !!(Math.floor(this.props.displayTimecode / 1000) > 0)
-					})}>
-						<span>{RundownUtils.formatDiffToTimecode(this.props.displayTimecode || 0, true, false, true, false, true, '', false, true)}</span>
-						{!this.props.autoNextPart && <div className='segment-timeline__liveline__icon segment-timeline__liveline__icon--next'></div>}
-						{this.props.autoNextPart && <div className='segment-timeline__liveline__icon segment-timeline__liveline__icon--auto-next'></div>}
+					<div className='segment-timeline__liveline__timecode'>
+						<CurrentPartRemaining speaking={getAllowSpeaking()} heavyClassName='overtime' />
+						{this.props.autoNextPart ?
+							<div className='rundown-view__part__icon rundown-view__part__icon--auto-next'></div> :
+							<div className='rundown-view__part__icon rundown-view__part__icon--next'></div>
+						}
 						{this.props.rundown.holdState && this.props.rundown.holdState !== RundownHoldState.COMPLETE ?
 							<div className='segment-timeline__liveline__status segment-timeline__liveline__status--hold'>{t('Hold')}</div>
 							: null

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -405,7 +405,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 						{t('On Air')}
 					</div>
 					<div className='segment-timeline__liveline__timecode'>
-						<CurrentPartRemaining speaking={getAllowSpeaking()} heavyClassName='overtime' />
+						<CurrentPartRemaining currentPartId={this.props.rundown.currentPartId} speaking={getAllowSpeaking()} heavyClassName='overtime' />
 						{this.props.autoNextPart ?
 							<div className='rundown-view__part__icon rundown-view__part__icon--auto-next'></div> :
 							<div className='rundown-view__part__icon rundown-view__part__icon--next'></div>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -24,8 +24,6 @@ import { getElementWidth } from '../../utils/dimensions'
 import { isMaintainingFocus, scrollToSegment } from '../../lib/viewPort'
 import { PubSub } from '../../../lib/api/pubsub'
 
-const SPEAK_ADVANCE = 500
-
 export interface SegmentUi extends Segment {
 	/** Output layers available in the installation used by this segment */
 	outputLayers?: {
@@ -76,8 +74,7 @@ interface IState {
 	},
 	collapsed: boolean,
 	followLiveLine: boolean,
-	livePosition: number,
-	displayTimecode: number
+	livePosition: number
 }
 interface ITrackedProps {
 	segmentui: SegmentUi | undefined,
@@ -196,8 +193,6 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 	intersectionObserver: IntersectionObserver | undefined
 	mountedTime: number
 
-	private _prevDisplayTime: number
-
 	constructor (props: IProps & ITrackedProps) {
 		super(props)
 
@@ -206,8 +201,7 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 			collapsed: UIStateStorage.getItemBoolean(`rundownView.${this.props.rundown._id}`, `segment.${props.segmentId}`, false),
 			scrollLeft: 0,
 			followLiveLine: false,
-			livePosition: 0,
-			displayTimecode: 0
+			livePosition: 0
 		}
 
 		this.isLiveSegment = props.isLiveSegment || false
@@ -258,16 +252,13 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 			})
 		} else if (this.props.rundown && !this.props.rundown.active && prevProps.rundown && prevProps.rundown.active) {
 			this.setState({
-				livePosition: 0,
-				displayTimecode: 0
+				livePosition: 0
 			})
 		}
 
 		if (this.props.followLiveSegments && !prevProps.followLiveSegments) {
 			this.onFollowLiveLine(true, {})
 		}
-
-		this.updateSpeech()
 	}
 
 	componentWillUnmount () {
@@ -321,16 +312,8 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 				(e.detail.currentTime - lastStartedPlayback + partOffset) :
 				(partOffset + lastPlayOffset)
 
-			let onAirPartDuration = (this.props.currentLivePart.duration || this.props.currentLivePart.expectedDuration || 0)
-			if (this.props.currentLivePart.displayDurationGroup && !this.props.currentLivePart.displayDuration) {
-				onAirPartDuration = this.props.currentLivePart.renderedDuration || onAirPartDuration
-			}
-
 			this.setState(_.extend({
-				livePosition: newLivePosition,
-				displayTimecode: this.props.currentLivePart.startedPlayback && lastStartedPlayback ?
-					(e.detail.currentTime - (lastStartedPlayback + onAirPartDuration)) :
-					(onAirPartDuration * -1)
+				livePosition: newLivePosition
 			}, this.state.followLiveLine ? {
 				scrollLeft: Math.max(newLivePosition - (this.props.liveLineHistorySize / this.props.timeScale), 0)
 			} : null))
@@ -402,45 +385,6 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 		}
 		if (typeof this.props.onSegmentScroll === 'function') this.props.onSegmentScroll()
 	}
-	updateSpeech () {
-
-		// Note that the displayTime is negative when counting down to 0.
-		let displayTime = this.state.displayTimecode
-
-		if (displayTime === 0) {
-			// do nothing
-		} else {
-			displayTime += SPEAK_ADVANCE
-			displayTime = Math.floor(displayTime / 1000)
-		}
-
-		if (this._prevDisplayTime !== displayTime) {
-
-			let text = '' // Say nothing
-
-			if (getAllowSpeaking()) {
-				switch (displayTime) {
-					case -1: text = 'One'; break
-					case -2: text = 'Two'; break
-					case -3: text = 'Three'; break
-					case -4: text = 'Four'; break
-					case -5: text = 'Five'; break
-					case -6: text = 'Six'; break
-					case -7: text = 'Seven'; break
-					case -8: text = 'Eight'; break
-					case -9: text = 'Nine'; break
-					case -10: text = 'Ten'; break
-				}
-				if (displayTime === 0 && this._prevDisplayTime === -1) {
-					text = 'Zero'
-				}
-			}
-			this._prevDisplayTime = displayTime
-			if (text) {
-				SpeechSynthesiser.speak(text, 'countdown')
-			}
-		}
-	}
 
 	render () {
 		return this.props.segmentui && (
@@ -471,7 +415,6 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 				followLiveLine={this.state.followLiveLine}
 				liveLineHistorySize={this.props.liveLineHistorySize}
 				livePosition={this.state.livePosition}
-				displayTimecode={this.state.displayTimecode}
 				onContextMenu={this.props.onContextMenu}
 				onFollowLiveLine={this.onFollowLiveLine}
 				onShowEntireSegment={this.onShowEntireSegment}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds a copy of the live line part countdown to the top header.

* **What is the current behavior?** (You can also link to an open issue here)

There is no countdown in the header. Also, time remaining calculations are done in the SegmentTimeline component.

* **What is the new behavior (if this is a feature change)?**

Adds a copy of the countdown to the top header in the RundownView. It also moves certain time remaining calculations into the RundownTiming component as well as adds a utility check for "will this part autonext". Also adds two React components to display time remaining and "will autonext" flags.

* **Other information**:
