### PR TITLE
fix: warnings on segments should now have segment-sourced labels

### DIFF
--- a/meteor/server/api/blueprints/__tests__/context.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context.test.ts
@@ -301,7 +301,7 @@ describe('Test blueprint api context', () => {
 			const rundown = Rundowns.findOne(rundownId) as Rundown
 			expect(rundown).toBeTruthy()
 
-			const context = new SegmentContext(rundown, undefined, {})
+			const context = new SegmentContext(rundown, undefined, {}, '')
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.getRuntimeArguments('')).toBeUndefined()
@@ -319,7 +319,7 @@ describe('Test blueprint api context', () => {
 					c: 'd'
 				},
 				part5: {}
-			})
+			}, '')
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.getRuntimeArguments('')).toBeUndefined()
@@ -351,7 +351,7 @@ describe('Test blueprint api context', () => {
 					externalId: 'part5',
 					runtimeArguments: {}
 				}) as DBPart
-			])
+			], '')
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.getRuntimeArguments('')).toBeUndefined()
@@ -373,7 +373,7 @@ describe('Test blueprint api context', () => {
 			const context = new PartContext(rundown, undefined, {
 				a: 'b',
 				c: 'd'
-			})
+			}, '')
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.getRuntimeArguments()).toEqual({
@@ -387,7 +387,7 @@ describe('Test blueprint api context', () => {
 			const rundown = Rundowns.findOne(rundownId) as Rundown
 			expect(rundown).toBeTruthy()
 
-			const context = new PartContext(rundown, undefined, {})
+			const context = new PartContext(rundown, undefined, {}, '')
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.getRuntimeArguments()).toEqual({})

--- a/meteor/server/api/blueprints/context.ts
+++ b/meteor/server/api/blueprints/context.ts
@@ -34,6 +34,7 @@ import { AsRunLogEvent, AsRunLog } from '../../../lib/collections/AsRunLog'
 import { Pieces } from '../../../lib/collections/Pieces'
 import { PartNote, NoteType } from '../../../lib/api/notes'
 import { loadCachedRundownData, loadIngestDataCachePart } from '../ingest/ingestCache'
+import { Segment } from '../../../lib/collections/Segments';
 
 /** Common */
 
@@ -257,9 +258,10 @@ export class RundownContext extends ShowStyleContext implements IRundownContext 
 export type BlueprintRuntimeArgumentsSet = { [key: string]: BlueprintRuntimeArguments | undefined }
 export class SegmentContext extends RundownContext implements ISegmentContext {
 	private readonly runtimeArguments: Readonly<BlueprintRuntimeArgumentsSet>
+	private readonly segment: Readonly<Segment>
 
-	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArgumentsSet | DBPart[]) {
-		super(rundown, studio)
+	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArgumentsSet | DBPart[], contextName?: string) {
+		super(rundown, studio, contextName)
 
 		if (_.isArray(runtimeArguments)) {
 			const existingRuntimeArguments: BlueprintRuntimeArgumentsSet = {}
@@ -282,8 +284,8 @@ export class SegmentContext extends RundownContext implements ISegmentContext {
 export class PartContext extends RundownContext implements IPartContext {
 	private readonly runtimeArguments: Readonly<BlueprintRuntimeArguments>
 
-	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArguments) {
-		super(rundown, studio)
+	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArguments, contextName?: string) {
+		super(rundown, studio, contextName)
 
 		this.runtimeArguments = runtimeArguments
 	}

--- a/meteor/server/api/blueprints/context.ts
+++ b/meteor/server/api/blueprints/context.ts
@@ -260,7 +260,7 @@ export class SegmentContext extends RundownContext implements ISegmentContext {
 	private readonly runtimeArguments: Readonly<BlueprintRuntimeArgumentsSet>
 	private readonly segment: Readonly<Segment>
 
-	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArgumentsSet | DBPart[], contextName?: string) {
+	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArgumentsSet | DBPart[], contextName: string) {
 		super(rundown, studio, contextName)
 
 		if (_.isArray(runtimeArguments)) {
@@ -284,7 +284,7 @@ export class SegmentContext extends RundownContext implements ISegmentContext {
 export class PartContext extends RundownContext implements IPartContext {
 	private readonly runtimeArguments: Readonly<BlueprintRuntimeArguments>
 
-	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArguments, contextName?: string) {
+	constructor (rundown: Rundown, studio: Studio | undefined, runtimeArguments: BlueprintRuntimeArguments, contextName: string) {
 		super(rundown, studio, contextName)
 
 		this.runtimeArguments = runtimeArguments

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -340,7 +340,7 @@ function updateRundownFromIngestData (
 
 		ingestSegment.parts = _.sortBy(ingestSegment.parts, part => part.rank)
 
-		const context = new SegmentContext(dbRundown, studio, existingParts)
+		const context = new SegmentContext(dbRundown, studio, existingParts, ingestSegment.name)
 		context.handleNotesExternally = true
 		const res = blueprint.getSegment(context, ingestSegment)
 
@@ -510,7 +510,7 @@ function updateSegmentFromIngestData (
 
 	ingestSegment.parts = _.sortBy(ingestSegment.parts, s => s.rank)
 
-	const context = new SegmentContext(rundown, studio, existingParts)
+	const context = new SegmentContext(rundown, studio, existingParts, ingestSegment.name)
 	context.handleNotesExternally = true
 	const res = blueprint.getSegment(context, ingestSegment)
 

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -40,7 +40,7 @@ import {
 } from '../asRunLog'
 import { Blueprints } from '../../../lib/collections/Blueprints'
 import { getBlueprintOfRundown } from '../blueprints/cache'
-import { PartEventContext, PartContext, RundownContext } from '../blueprints/context'
+import { PartEventContext, RundownContext } from '../blueprints/context'
 import { IngestActions } from '../ingest/actions'
 import { updateTimeline } from './timeline'
 import {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is bug fix for SegmentContext/PartContext in blueprints API


* **What is the current behavior?** (You can also link to an open issue here)
Segment notes have origin name set to the name of the Rundown, resulting in the label in the UI making them indistinguishable from Rundown notes. Also, they make it difficult to make out which segment a given note refers to.


* **What is the new behavior (if this is a feature change)?**
This PR provides the proper contextName for SegmentContexts, using the IngestSegment.name as the context name.


* **Other information**:
