### PR TITLE
Automatically rewind segment that stopped being live

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -23,6 +23,7 @@ import { NoteType, PartNote } from '../../../lib/api/notes'
 import { getElementWidth } from '../../utils/dimensions'
 import { isMaintainingFocus, scrollToSegment } from '../../lib/viewPort'
 import { PubSub } from '../../../lib/api/pubsub'
+import { Settings } from '../../../lib/Settings'
 
 const SPEAK_ADVANCE = 500
 
@@ -249,6 +250,7 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 		if (this.isLiveSegment === true && this.props.isLiveSegment === false) {
 			this.isLiveSegment = false
 			this.stopLive()
+			if (Settings.autoRewindLeavingSegment) this.onRewindSegment()
 		}
 
 		// rewind all scrollLeft's to 0 on rundown activate

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -4,7 +4,8 @@ import * as _ from 'underscore'
 export interface ISettings {
 	frameRate: number,
 	defaultToCollapsedSegments: boolean,
-	autoExpandCurrentNextSegment: boolean
+	autoExpandCurrentNextSegment: boolean,
+	autoRewindLeavingSegment: boolean
 }
 
 export let Settings: ISettings
@@ -12,7 +13,8 @@ export let Settings: ISettings
 const DEFAULT_SETTINGS: ISettings = {
 	'frameRate': 25,
 	'defaultToCollapsedSegments': false,
-	'autoExpandCurrentNextSegment': false
+	'autoExpandCurrentNextSegment': false,
+	'autoRewindLeavingSegment': false
 }
 
 Settings = _.clone(DEFAULT_SETTINGS)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduces an optional automatic rewind of the segment timeline when leaving a given segment.


* **What is the current behavior?** (You can also link to an open issue here)

Currently, when leaving the segment, the timeline is left in the state as-is, until the SegmentTimeline component is destroyed (when it is outside of the viewport), when the entire component is rebuilt with the scroll position at 0.


* **What is the new behavior (if this is a feature change)?**

When `autoRewindLeavingSegment` setting in the public settings is turned on, the segment will be rewound after it stops being live.


* **Other information**:
