### PR TITLE
Feature/unsync on segment or part removal

### DIFF
--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -1,23 +1,35 @@
 import { Meteor } from 'meteor/meteor'
 import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
-import { setupDefaultStudioEnvironment } from '../../../../__mocks__/helpers/database'
+import { setupDefaultStudioEnvironment, setupMockPeripheralDevice } from '../../../../__mocks__/helpers/database'
 import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
 import { PeripheralDevice } from '../../../../lib/collections/PeripheralDevices'
-import { testInFiber } from '../../../../__mocks__/helpers/jest'
+import { testInFiber, testInFiberOnly } from '../../../../__mocks__/helpers/jest'
 import { Segment, Segments } from '../../../../lib/collections/Segments'
 import { Part, Parts } from '../../../../lib/collections/Parts'
 import { IngestRundown, IngestSegment, IngestPart } from 'tv-automation-sofie-blueprints-integration'
-import { updatePartRanks } from '../../rundown'
+import { updatePartRanks, ServerRundownAPI } from '../../rundown'
+import { ServerPlayoutAPI } from '../../playout/playout'
+import { RundownInput } from '../rundownInput'
 
 require('../api.ts') // include in order to create the Meteor methods needed
 
 describe('Test ingest actions for rundowns and segments', () => {
 
 	let device: PeripheralDevice
+	let device2: PeripheralDevice
 	let externalId = 'abcde'
 	let segExternalId = 'zyxwv'
 	beforeAll(() => {
-		device = setupDefaultStudioEnvironment().ingestDevice
+		const env = setupDefaultStudioEnvironment()
+		device = env.ingestDevice
+
+		device2 = setupMockPeripheralDevice(
+			PeripheralDeviceAPI.DeviceCategory.INGEST,
+			// @ts-ignore
+			'mockDeviceType',
+			PeripheralDeviceAPI.SUBTYPE_PROCESS,
+			env.studio
+		)
 	})
 
 	testInFiber('dataRundownCreate', () => {
@@ -1000,5 +1012,98 @@ describe('Test ingest actions for rundowns and segments', () => {
 		// Meteor.call(PeripheralDeviceAPI.methods.dataSegmentUpdate, device._id, device.token, rundownData.externalId, segmentData)
 		// dynamicPart = Parts.findOne(dynamicPartId) as Part
 		// expect(dynamicPart).toBeFalsy()
+	})
+
+	testInFiberOnly('unsyncing of rundown', () => {
+
+		const rundownData: IngestRundown = {
+			externalId: externalId,
+			name: 'MyMockRundown',
+			type: 'mock',
+			segments: [
+				{
+					externalId: 'segment0',
+					name: 'Segment 0',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part0',
+							name: 'Part 0',
+							rank: 0,
+						},
+						{
+							externalId: 'part1',
+							name: 'Part 1',
+							rank: 0,
+						}
+					]
+				},
+				{
+					externalId: 'segment1',
+					name: 'Segment 1',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part2',
+							name: 'Part 2',
+							rank: 0,
+						}
+					]
+				}
+			]
+		}
+
+		// Preparation: set up rundown
+		expect(Rundowns.findOne()).toBeFalsy()
+		Meteor.call(PeripheralDeviceAPI.methods.dataRundownCreate, device2._id, device2.token, rundownData)
+		const rundown = Rundowns.findOne() as Rundown
+		expect(rundown).toMatchObject({
+			externalId: rundownData.externalId
+		})
+
+		const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
+		const resyncRundown = () => {
+			try {
+				ServerRundownAPI.resyncRundown(rundown._id)
+			} catch (e) {
+				if (e.toString().match(/does not support the method "reloadRundown"/)) {
+					// This is expected
+					return
+				}
+				throw e
+			}
+		}
+
+		const segments = getRundown().getSegments()
+		const parts = getRundown().getParts()
+
+		expect(segments).toHaveLength(2)
+		expect(parts).toHaveLength(3)
+		
+		// Activate the rundown, make data updates and verify that it gets unsynced properly
+		ServerPlayoutAPI.activateRundown(rundown._id, true)
+		expect(getRundown().unsynced).toEqual(false)
+
+		RundownInput.dataRundownDelete({}, device2._id, device2.token, rundownData.externalId)
+		expect(getRundown().unsynced).toEqual(true)
+		
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+
+		ServerPlayoutAPI.takeNextPart(rundown._id)
+		expect(getRundown().currentPartId).toEqual(parts[0]._id)
+
+		RundownInput.dataSegmentDelete({}, device2._id, device2.token, rundownData.externalId, segments[0].externalId)
+		expect(getRundown().unsynced).toEqual(true)
+		
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+
+		RundownInput.dataPartDelete({}, device2._id, device2.token, rundownData.externalId, segments[0].externalId, parts[0].externalId)
+		expect(getRundown().unsynced).toEqual(true)
+		
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+
 	})
 })

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -444,9 +444,18 @@ function handleRemovedSegment (peripheralDevice: PeripheralDevice, rundownExtern
 	return rundownSyncFunction(rundownId, RundownSyncFunctionPriority.Ingest, () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const segmentId = getSegmentId(rundown._id, segmentExternalId)
+
 		if (canBeUpdated(rundown, segmentId)) {
-			if (removeSegments(rundownId, [segmentId]) === 0) {
-				throw new Meteor.Error(404, `Segment ${segmentExternalId} not found`)
+			const currentPlayingPart = rundown.currentPartId && Parts.findOne(rundown.currentPartId)
+
+			if (currentPlayingPart && currentPlayingPart.segmentId === segmentId) {
+				// Don't allow removing currently playing segment
+				logger.warn(`Not allowing removal of currently playing segment "${segmentId}", making rundown unsynced instead`)
+				ServerRundownAPI.unsyncRundown(rundown._id)
+			} else {
+				if (removeSegments(rundownId, [segmentId]) === 0) {
+					throw new Meteor.Error(404, `Segment ${segmentExternalId} not found`)
+				}
 			}
 		}
 	})
@@ -608,25 +617,35 @@ export function handleRemovedPart (peripheralDevice: PeripheralDevice, rundownEx
 		const segmentId = getSegmentId(rundown._id, segmentExternalId)
 		const partId = getPartId(rundown._id, partExternalId)
 
-		if (!canBeUpdated(rundown, segmentId, partId)) return
+		
+		if (canBeUpdated(rundown, segmentId, partId)) {
+			const part = Parts.findOne({
+				_id: partId,
+				segmentId: segmentId,
+				rundownId: rundown._id
+			})
+			if (!part) throw new Meteor.Error(404, 'Part not found')
 
-		const part = Parts.findOne({
-			_id: partId,
-			segmentId: segmentId,
-			rundownId: rundown._id
-		})
-		if (!part) throw new Meteor.Error(404, 'Part not found')
-
-		// Blueprints will handle the deletion of the Part
-		const ingestSegment = loadCachedIngestSegment(rundown._id, rundownExternalId, segmentId, segmentExternalId)
-		ingestSegment.parts = ingestSegment.parts.filter(p => p.externalId !== partExternalId)
-
-		saveSegmentCache(rundown._id, segmentId, ingestSegment)
-
-		const updatedSegmentId = updateSegmentFromIngestData(studio, rundown, ingestSegment)
-		if (updatedSegmentId) {
-			afterIngestChangedData(rundown, [updatedSegmentId])
+			if (rundown.currentPartId && rundown.currentPartId === part._id) {
+				// Don't allow removing currently playing part
+				logger.warn(`Not allowing removal of currently playing part "${part}", making rundown unsynced instead`)
+				ServerRundownAPI.unsyncRundown(rundown._id)
+			} else {
+		
+				// Blueprints will handle the deletion of the Part
+				const ingestSegment = loadCachedIngestSegment(rundown._id, rundownExternalId, segmentId, segmentExternalId)
+				ingestSegment.parts = ingestSegment.parts.filter(p => p.externalId !== partExternalId)
+		
+				saveSegmentCache(rundown._id, segmentId, ingestSegment)
+		
+				const updatedSegmentId = updateSegmentFromIngestData(studio, rundown, ingestSegment)
+				if (updatedSegmentId) {
+					afterIngestChangedData(rundown, [updatedSegmentId])
+				}
+			}
 		}
+
+		
 	})
 }
 export function handleUpdatedPart (peripheralDevice: PeripheralDevice, rundownExternalId: string, segmentExternalId: string, ingestPart: IngestPart) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the feature: "unsync rundown if currently playing segment or part is removed"


* **What is the current behavior?** (You can also link to an open issue here)
When using the data-flow for generic-ingest (not MOS), there was nothing that prevented the currently playing part to be removed.


* **What is the new behavior (if this is a feature change)?**
When using the data-flow for generic-ingest (not MOS), the rundown will beome unsynced if the currently playing part is attempted to be removed


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
