### PR TITLE
Fix/next on float bug

### DIFF
--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -18,8 +18,7 @@ import {
 	RundownSyncFunctionPriority,
 	handleUpdatedRundownInner,
 	handleUpdatedPartInner,
-	updateSegmentsFromIngestData,
-	afterIngestChangedData
+	updateSegmentsFromIngestData
 } from '../rundownInput'
 import {
 	loadCachedRundownData,
@@ -521,14 +520,6 @@ function diffAndApplyChanges (
 			..._.values(segmentDiff.added),
 			..._.values(segmentDiff.changed)
 		], se => se.rank)
-	)
-
-	afterIngestChangedData(
-		rundown,
-		[
-			..._.keys(segmentDiff.added),
-			..._.keys(segmentDiff.changed)
-		]
 	)
 }
 

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -262,8 +262,6 @@ export function handleMosDeleteStory (
 		logger.debug(`handleMosDeleteStory, new part count ${filteredParts.length} (was ${ingestParts.length})`)
 
 		diffAndApplyChanges(studio, rundown, ingestRundown, filteredParts)
-
-		UpdateNext.ensureNextPartIsValid(rundown)
 	})
 }
 
@@ -376,8 +374,6 @@ export function handleSwapStories (
 		ingestParts[story1Index] = tmp
 
 		diffAndApplyChanges(studio, rundown, ingestRundown, ingestParts)
-
-		UpdateNext.ensureNextPartIsValid(rundown)
 	})
 }
 export function handleMoveStories (
@@ -429,8 +425,6 @@ export function handleMoveStories (
 		filteredParts.splice(insertIndex, 0, ...movingParts)
 
 		diffAndApplyChanges(studio, rundown, ingestRundown, filteredParts)
-
-		UpdateNext.ensureNextPartIsValid(rundown)
 	})
 }
 

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -590,13 +590,13 @@ function updateSegmentFromIngestData (
 	)
 	return anythingChanged(changes) ? segmentId : null
 }
-export function afterIngestChangedData (rundown: Rundown, segmentIds: string[]) {
+export function afterIngestChangedData (rundown: Rundown, changedSegmentIds: string[]) {
 	// To be called after rundown has been changed
 	updateExpectedMediaItemsOnRundown(rundown._id)
 	updatePartRanks(rundown._id)
 	updateSourceLayerInfinitesAfterPart(rundown)
 	UpdateNext.ensureNextPartIsValid(rundown)
-	triggerUpdateTimelineAfterIngestData(rundown._id, segmentIds)
+	triggerUpdateTimelineAfterIngestData(rundown._id, changedSegmentIds)
 }
 
 export function handleRemovedPart (peripheralDevice: PeripheralDevice, rundownExternalId: string, segmentExternalId: string, partExternalId: string) {

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -13,7 +13,7 @@ import { logger } from '../../../lib/logging'
 
 export const updateSourceLayerInfinitesAfterPart: (rundown: Rundown, previousPart?: Part, runUntilEnd?: boolean) => void
 = syncFunctionIgnore(updateSourceLayerInfinitesAfterPartInner)
-export function updateSourceLayerInfinitesAfterPartInner (rundown: Rundown, previousPart?: Part, runUntilEnd?: boolean): string {
+export function updateSourceLayerInfinitesAfterPartInner (rundown: Rundown, previousPart?: Part, runUntilEnd?: boolean): void {
 	let activeInfinitePieces: { [layer: string]: Piece } = {}
 	let activeInfiniteItemsSegmentId: { [layer: string]: string } = {}
 
@@ -113,7 +113,7 @@ export function updateSourceLayerInfinitesAfterPartInner (rundown: Rundown, prev
 		   // TODO - this guard is useless, as all shows have klokke and logo as infinites throughout...
 		   // This should instead do a check after each iteration to check if anything changed (even fields such as name on the piece)
 		   // If nothing changed, then it is safe to assume that it doesnt need to go further
-		   return part._id
+		   return
 	   }
 
 	   // figure out what infinites are to be extended
@@ -235,7 +235,6 @@ export function updateSourceLayerInfinitesAfterPartInner (rundown: Rundown, prev
 	}
 
 	waitForPromiseAll(ps)
-	return ''
 }
 
 export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (rundown: Rundown, part: Part, newPiece: Piece) {

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1295,15 +1295,15 @@ interface UpdateTimelineFromIngestDataTimeout {
 let updateTimelineFromIngestDataTimeouts: {
 	[id: string]: UpdateTimelineFromIngestDataTimeout
 } = {}
-export function triggerUpdateTimelineAfterIngestData (rundownId: string, changedSegments: Array<string>) {
+export function triggerUpdateTimelineAfterIngestData (rundownId: string, changedSegmentIds: Array<string>) {
 	// Lock behind a timeout, so it doesnt get executed loads when importing a rundown or there are large changes
 	let data: UpdateTimelineFromIngestDataTimeout = updateTimelineFromIngestDataTimeouts[rundownId]
 	if (data) {
 		if (data.timeout) Meteor.clearTimeout(data.timeout)
-		data.changedSegments = data.changedSegments.concat(changedSegments)
+		data.changedSegments = data.changedSegments.concat(changedSegmentIds)
 	} else {
 		data = {
-			changedSegments: changedSegments
+			changedSegments: changedSegmentIds
 		}
 	}
 

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -151,12 +151,6 @@ export function afterRemoveParts (rundownId: string, removedParts: DBPart[]) {
 		// TODO - batch?
 		updateExpectedMediaItemsOnPart(part.rundownId, part._id)
 	})
-
-	const rundown = Rundowns.findOne(rundownId)
-	if (rundown && rundown.active) {
-		// Ensure the next-part is still valid
-		UpdateNext.ensureNextPartIsValid(rundown)
-	}
 }
 /**
  * Update the ranks of all parts.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue with the Next point being wrongly moved to the beginning of the rundown when floating a Part in the current playing segment.


* **What is the current behavior?** (You can also link to an open issue here)
* Having a segment with three parts: A, B & C.
* A is currently playing, B is Next.
* C is removed from the NRCS
* The Next point now is moved to the beginning of the rundown

* **What is the new behavior (if this is a feature change)?**
The Next-point shouldn't be moved at all.

* **Other information**:
I've concluded that this bug was due to the `ensureNextPartIsValid` being called multiple times, one before the `updatePartRanks` had run, resulting in a bad operation on parts with wrong ranks.
This is a bug that would have been prevented by #117 , but I think it's still good to clean up the function calls a bit.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
