### PR TITLE
Feat: restart core from status

### DIFF
--- a/meteor/client/styles/systemStatus.scss
+++ b/meteor/client/styles/systemStatus.scss
@@ -135,6 +135,9 @@
 	> .value {
 		> .pill {
 			margin-right: 0;
+			a {
+				color: inherit;
+			}
 		}
 	}
 	

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -7,7 +7,7 @@ import {
 import * as i18next from 'react-i18next'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import Moment from 'react-moment'
-import { getCurrentTime } from '../../../lib/lib'
+import { getCurrentTime, getHash } from '../../../lib/lib'
 import { Link } from 'react-router-dom'
 const Tooltip = require('rc-tooltip')
 import * as faTrash from '@fortawesome/fontawesome-free-solid/faTrash'
@@ -18,10 +18,14 @@ import { ModalDialog, doModalDialog } from '../../lib/ModalDialog'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { callMethod, callPeripheralDeviceFunction, PeripheralDevicesAPI } from '../../lib/clientAPI'
 import { NotificationCenter, NoticeLevel, Notification } from '../../lib/notifications/notifications'
-import { getAllowConfigure, getAllowDeveloper, getHelpMode } from '../../lib/localStorage'
+import { getAllowConfigure, getAllowDeveloper, getHelpMode, getAllowService } from '../../lib/localStorage'
 import { PubSub } from '../../../lib/api/pubsub'
 import * as ClassNames from 'classnames'
 import { TSR } from 'tv-automation-sofie-blueprints-integration'
+import { CoreSystem, ICoreSystem } from '../../../lib/collections/CoreSystem'
+import { SystemStatusAPI, StatusResponse } from '../../../lib/api/systemStatus'
+import { doUserAction } from '../../lib/userAction'
+import { UserActionAPI } from '../../../lib/api/userActions'
 
 interface IDeviceItemProps {
 	// key: string,
@@ -346,12 +350,131 @@ export const DeviceItem = i18next.translate()(class extends React.Component<Tran
 	}
 })
 
+interface ICoreItemProps {
+	systemStatus: StatusResponse | undefined
+	coreSystem: ICoreSystem
+}
+
+interface ICoreItemState {
+	showKillCoreConfirm: boolean
+}
+
+const PackageInfo = require('../../../package.json')
+
+export const CoreItem = i18next.translate()(class extends React.Component<Translated<ICoreItemProps>, ICoreItemState> {
+	constructor (props: Translated<ICoreItemProps>) {
+		super(props)
+		this.state = {
+			showKillCoreConfirm: false,
+		}
+	}
+	
+	onKillCore () {
+		this.setState({
+			showKillCoreConfirm: true
+		})
+	}
+	handleConfirmKillAccept = (e) => {
+		const { t } = this.props
+		if (this.state.showKillCoreConfirm) {
+			doUserAction(t, e, UserActionAPI.methods.generateRestartToken, [], (err, res) => {
+				if (err || !res || !res.result) {
+					NotificationCenter.push(new Notification(undefined, NoticeLevel.CRITICAL, t('Could not generate restart token!'), 'SystemStatus'))	
+					return
+				}
+
+				const restartToken = getHash(UserActionAPI.RESTART_SALT + res.result)
+
+				doUserAction(t, {}, UserActionAPI.methods.restartCore, [ restartToken ], (err, res) => {
+					if (err || !res || !res.result) {
+						NotificationCenter.push(new Notification(undefined, NoticeLevel.CRITICAL, t('Could not generate restart core: {{err}}', { err }), 'SystemStatus'))	
+						return
+					}
+					let time = 'unknown';
+					const match = res.result.match(/([\d\.]+)s/)
+					if (match) {
+						time = match[1] 
+					}
+					NotificationCenter.push(new Notification(undefined, NoticeLevel.WARNING, t('Sofie Automation Server Core will restart in {{time}}s...', { time }), 'SystemStatus'))
+				})
+			})
+		}
+		this.setState({
+			showKillCoreConfirm: false
+		})
+	}
+
+	handleConfirmKillCancel = (e) => {
+		this.setState({
+			showKillCoreConfirm: false
+		})
+	}
+
+	render () {
+		const { t } = this.props
+
+		return (
+			<div key={this.props.coreSystem._id} className='device-item'>
+				<div className='status-container'>
+					<div className={ClassNames('device-status',
+							this.props.systemStatus && this.props.systemStatus.status && {
+								'device-status--unknown': this.props.systemStatus.status === 'UNDEFINED',
+								'device-status--good': this.props.systemStatus.status === 'OK',
+								'device-status--warning': this.props.systemStatus.status === 'WARNING',
+								'device-status--fatal': this.props.systemStatus.status === 'FAIL',
+							}
+						)}>
+						<div className='value'>
+							<span className='pill device-status__label'>
+								<a href="#" title={(this.props.systemStatus && this.props.systemStatus._internal.messages) ? this.props.systemStatus._internal.messages.join('\n') : undefined}>{this.props.systemStatus && this.props.systemStatus.status}</a>
+							</span>
+						</div>
+					</div>
+				</div>
+				<div className='device-item__id'>
+					<div className='value'>{t('Sofie Automation Server Core: {{name}}', {name: this.props.coreSystem.name || 'unnamed'})}</div>
+				</div>
+				<div className='device-item__version'>
+					<label>{t('Version')}: </label>
+					<div className='value'>
+						{PackageInfo.version || 'UNSTABLE'}
+					</div>
+				</div>
+
+				{(getAllowConfigure() || getAllowDeveloper() || getAllowService()) && <div className='actions-container'>
+					<div className='device-item__actions'>
+						<ModalDialog key='modal-device' title={t('Restart this system?')} acceptText={t('Restart')}
+							secondaryText={t('Cancel')}
+							show={!!this.state.showKillCoreConfirm}
+							onAccept={(e) => this.handleConfirmKillAccept(e)}
+							onSecondary={(e) => this.handleConfirmKillCancel(e)}>
+							<p>{t('Are you sure you want to restart this Core Sofie System: {{name}}?', {name: this.props.coreSystem.name || 'unnamed'})}</p>
+						</ModalDialog>
+						<button className='btn btn-secondary' onClick={
+							(e) => {
+								e.preventDefault()
+								e.stopPropagation()
+								this.onKillCore()
+							}
+						}>
+							{t('Restart')}
+						</button>
+					</div>
+				</div>}
+
+				<div className='clear'></div>
+			</div>
+		)
+	}
+})
+
 interface ISystemStatusProps {
 }
 interface ISystemStatusState {
-	devices: Array<PeripheralDevice>
+	systemStatus: StatusResponse | undefined
 }
 interface ISystemStatusTrackedProps {
+	coreSystem: ICoreSystem | undefined
 	devices: Array<PeripheralDevice>
 }
 
@@ -365,15 +488,51 @@ export default translateWithTracker<ISystemStatusProps, ISystemStatusState, ISys
 	// console.log('PeripheralDevices.find({}).fetch()',PeripheralDevices.find({}, { sort: { created: -1 } }).fetch());
 
 	return {
+		coreSystem: CoreSystem.findOne(),
 		devices: PeripheralDevices.find({}, { sort: { lastConnected: -1 } }).fetch()
 	}
 })(class SystemStatus extends MeteorReactComponent<Translated<ISystemStatusProps & ISystemStatusTrackedProps>, ISystemStatusState> {
-	componentWillMount () {
+	private refreshInterval: NodeJS.Timer | undefined = undefined
+	private destroyed: boolean = false
+
+	constructor (props) {
+		super(props)
+
+		this.state = {
+			systemStatus: undefined
+		}
+	}
+
+	componentDidMount () {
+		this.refreshSystemStatus()
+		this.refreshInterval = setInterval(this.refreshSystemStatus, 5000)		
+
 		// Subscribe to data:
 		this.subscribe(PubSub.peripheralDevices, {})
 	}
-	renderPeripheralDevices () {
 
+	componentWillUnmount () {
+		if (this.refreshInterval) clearInterval(this.refreshInterval)
+		this.destroyed = true
+	}
+
+	refreshSystemStatus = () => {
+		const { t } = this.props
+		Meteor.call(SystemStatusAPI.getSystemStatus, (err: any, systemStatus: StatusResponse) => {
+			if (this.destroyed) return
+			if (err) {
+				// console.error(err)
+				NotificationCenter.push(new Notification('systemStatus_failed', NoticeLevel.CRITICAL, t('Could not get system status. Please consult system administrator.'), 'RundownList'))
+				return
+			}
+
+			this.setState({
+				systemStatus: systemStatus
+			})
+		})
+	}
+
+	renderPeripheralDevices () {
 		let devices: Array<DeviceInHierarchy> = []
 		let refs = {}
 		let devicesToAdd = {}
@@ -401,7 +560,7 @@ export default translateWithTracker<ISystemStatusProps, ISystemStatusState, ISys
 			}
 		})
 
-		let getDeviceContent = (d: DeviceInHierarchy, toplevel: boolean): JSX.Element => {
+		const getDeviceContent = (d: DeviceInHierarchy, toplevel: boolean): JSX.Element => {
 			let content: JSX.Element[] = [
 				<DeviceItem key={'device' + d.device._id } device={d.device} toplevel={toplevel} hasChildren={d.children.length !== 0} />
 			]
@@ -428,7 +587,11 @@ export default translateWithTracker<ISystemStatusProps, ISystemStatusState, ISys
 				</div>
 			)
 		}
-		return _.map(devices, (d) => getDeviceContent(d, true))
+
+		return <React.Fragment>
+			{this.props.coreSystem && <CoreItem coreSystem={this.props.coreSystem} systemStatus={this.state.systemStatus} />}
+			{_.map(devices, (d) => getDeviceContent(d, true))}
+		</React.Fragment>
 	}
 
 	render () {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -448,7 +448,7 @@ export const CoreItem = i18next.translate()(class extends React.Component<Transl
 							show={!!this.state.showKillCoreConfirm}
 							onAccept={(e) => this.handleConfirmKillAccept(e)}
 							onSecondary={(e) => this.handleConfirmKillCancel(e)}>
-							<p>{t('Are you sure you want to restart this Core Sofie System: {{name}}?', {name: this.props.coreSystem.name || 'unnamed'})}</p>
+							<p>{t('Are you sure you want to restart this Sofie Automation Server Core: {{name}}?', {name: this.props.coreSystem.name || 'unnamed'})}</p>
 						</ModalDialog>
 						<button className='btn btn-secondary' onClick={
 							(e) => {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -441,7 +441,7 @@ export const CoreItem = i18next.translate()(class extends React.Component<Transl
 					</div>
 				</div>
 
-				{(getAllowConfigure() || getAllowDeveloper() || getAllowService()) && <div className='actions-container'>
+				{(getAllowConfigure() || getAllowDeveloper()) && <div className='actions-container'>
 					<div className='device-item__actions'>
 						<ModalDialog key='modal-device' title={t('Restart this system?')} acceptText={t('Restart')}
 							secondaryText={t('Cancel')}

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -51,7 +51,10 @@ export namespace UserActionAPI {
 		'mediaAbortAllWorkflows'				= 'userAction.mediamanager.abortAllWorkflows',
 		'mediaPrioritizeWorkflow'				= 'userAction.mediamanager.mediaPrioritizeWorkflow',
 
-		'regenerateRundown'					= 'userAction.ingest.regenerateRundown'
+		'regenerateRundown'					= 'userAction.ingest.regenerateRundown',
+
+		'generateRestartToken'				= 'userAction.system.generateRestartToken',
+		'restartCore'						= 'userAction.system.restartCore'
 	}
 
 	export enum ReloadRundownResponse {
@@ -62,4 +65,6 @@ export namespace UserActionAPI {
 		/** When reloading cannot continue, because the rundown is missing */
 		MISSING = 'missing'
 	}
+
+	export const RESTART_SALT = 'clientRestart_'
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds Restart Core from status page feature


* **What is the current behavior?** (You can also link to an open issue here)

There is no way to restart Core from within the application itself.

* **What is the new behavior (if this is a feature change)?**

Allows users with the developer or configure access level to restart core from the status page. Also, Core status and version number is shown on the status page.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
