### PR TITLE
Fix/looping migrations

### DIFF
--- a/meteor/server/migration/0_1_0.ts
+++ b/meteor/server/migration/0_1_0.ts
@@ -49,7 +49,9 @@ addMigrationSteps('0.1.0', [
 		validate: () => {
 
 			let missing: string | boolean = false
-			PeripheralDevices.find().forEach((device) => {
+			PeripheralDevices.find({
+				parentDeviceId: { $exists: false }
+			}).forEach((device) => {
 				if (!device.studioId) missing = `PeripheralDevice ${device._id} has no studio`
 			})
 			return missing
@@ -60,7 +62,9 @@ addMigrationSteps('0.1.0', [
 				const studio = studios[0]
 
 				let missing: string | boolean = false
-				PeripheralDevices.find().forEach((device) => {
+				PeripheralDevices.find({
+					parentDeviceId: { $exists: false }
+				}).forEach((device) => {
 					if (!device.studioId) PeripheralDevices.update(device._id, { $set: { studioId: studio._id } })
 				})
 			} else {

--- a/meteor/server/migration/databaseMigration.ts
+++ b/meteor/server/migration/databaseMigration.ts
@@ -582,6 +582,7 @@ export function runMigration (
 				if (res.migrationCompleted) {
 					return res
 				}
+				_.each(res.warnings, w => warningMessages.push(w))
 			} catch (e) {
 				warningMessages.push(`When running next chunk: ${e}`)
 				migration.partialMigration = true


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue that caused the migrations to run in a loop.
It also adds a safeguard in the migration


* **What is the current behavior?** (You can also link to an open issue here)
Migrations run in a loop, due to:
* a migration step in 0_1_0 incorrectly setting studioId of ALL devices
* a migration step in 0_10_0 removing the studioId of the devices that has a parent
* repeat


* **What is the new behavior (if this is a feature change)?**
0_1_0 only sets the studio id of devices with no parent.
no looping.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
