### PR TITLE
fix: check if loaded over https before trying to register service worker

### DIFF
--- a/meteor/client/main.js
+++ b/meteor/client/main.js
@@ -12,7 +12,7 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     // in some versions of Chrome, registering the Service Worker over HTTP throws
     // an arror
-    if (window.location.protocol === 'https:') {
+    if (window.location.protocol === 'https:' || window.location.hostname === 'localhost') {
       navigator.serviceWorker.register('/sw.js').catch((err) => {
         console.error(err)
       });

--- a/meteor/client/main.js
+++ b/meteor/client/main.js
@@ -10,7 +10,13 @@ import App from './ui/App.js';
 if ('serviceWorker' in navigator) {
   // Use the window load event to keep the page load performant
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+    // in some versions of Chrome, registering the Service Worker over HTTP throws
+    // an arror
+    if (window.location.protocol === 'https:') {
+      navigator.serviceWorker.register('/sw.js').catch((err) => {
+        console.error(err)
+      });
+    }
   });
 }
  


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Registering the service worker from a non-https and non-localhost server will cause an exception that wasn't handled.

* **What is the new behavior (if this is a feature change)?**

The promise is handled and protocol and hostname is checked before trying to register the ServiceWorker.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
