### PR TITLE
fix: hotkey overlap crash

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -90,7 +90,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 	handleKey = (e: KeyboardEvent) => {
 		if (this.props.show) {
 			if (e.code === 'Enter') {
-				this.handleAccept(e)
+				if (!this.props.warning) this.handleAccept(e)
 			} else if (e.code === 'Escape') {
 				if (this.props.secondaryText) {
 					this.handleSecondary(e)
@@ -203,7 +203,8 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 													}))
 												}
 												<button className={ClassNames('btn btn-primary', {
-													'right': this.props.secondaryText !== undefined
+													'right': this.props.secondaryText !== undefined,
+													'btn-warn': this.props.warning
 												})} onClick={this.handleAccept}>{this.props.acceptText}</button>
 											</div>
 										</dialog>
@@ -215,7 +216,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 				: null
 	}
 
-	private preventDefault (e: KeyboardEvent) {
+	private preventDefault = (e: KeyboardEvent) => {
 		e.preventDefault()
 		e.stopPropagation()
 	}
@@ -332,7 +333,9 @@ class ModalDialogGlobalContainer0 extends React.Component<Translated<IModalDialo
 				}
 			})
 			return (
-			<ModalDialog title	= {onQueue.title}
+			<ModalDialog
+				key				= {this.state.queue.length}
+				title			= {onQueue.title}
 				acceptText		= {onQueue.yes || t('Yes')}
 				secondaryText	= {onQueue.no || (!onQueue.acceptOnly ? t('No') : undefined)}
 				onAccept		= {this.onAccept}

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -3,9 +3,15 @@ import * as _ from 'underscore'
 import { isEventInInputField } from './lib'
 import { isModalShowing } from './ModalDialog'
 
+interface IWrappedCallback {
+	allowInModal: boolean
+	isGlobal: boolean
+	original: (e: Event) => void
+}
+
 export namespace mousetrapHelper {
 	const _boundHotkeys: {
-		[key: string]: ((e: Event) => void)[]
+		[key: string]: IWrappedCallback[]
 	} = {}
 	const _callbackTags: {
 		[key: string]: (e: Event) => void
@@ -16,36 +22,41 @@ export namespace mousetrapHelper {
 			return
 		}
 		// console.log(`Handling key combo "${keys}"`)
-		_boundHotkeys[keys].forEach((i) => {
-			i(e)
+		_boundHotkeys[keys].forEach((handler) => {
+			if (!handler.isGlobal && isEventInInputField(e)) return
+			e.preventDefault()
+			if (!handler.allowInModal && isModalShowing()) return
+			handler.original(e)
 		})
 	}
 
 	export function bindGlobal (keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
 		let index = keys
 		if (action) index = keys + '_' + action
-		if (_boundHotkeys[index] === undefined) {
-			_boundHotkeys[index] = []
+		if (
+			// if not yet bound
+			_boundHotkeys[index] === undefined ||
+			// or bound so far were not globals
+			_boundHotkeys[index].reduce((mem, i) => mem || i.isGlobal, false) === false
+		) {
+			if (_boundHotkeys[index] === undefined) _boundHotkeys[index] = []
 			mousetrap.bindGlobal(keys, (e: ExtendedKeyboardEvent) => {
 				handleKey(index, e)
 			}, action)
 		}
 		// console.log(`Registering callback for key combo "${keys}"`)
 
-		const callbackWrap = (e: Event) => {
-			// if (isEventInInputField(e)) return - global hotkeys need to work everywhere, including input fields
-			e.preventDefault()
-			if (!allowInModal && isModalShowing()) return
-
-			callback(e)
-		}
-		_boundHotkeys[index].push(callbackWrap)
+		_boundHotkeys[index].push({
+			isGlobal: true,
+			allowInModal: !!allowInModal,
+			original: callback
+		})
 
 		if (tag) {
 			if (_callbackTags[index + '_' + tag]) {
 				throw new Error(`Globalbind: Callback with tag "${tag}" already exists for ${index}!`)
 			}
-			_callbackTags[index + '_' + tag] = callbackWrap
+			_callbackTags[index + '_' + tag] = callback
 		}
 	}
 
@@ -60,20 +71,17 @@ export namespace mousetrapHelper {
 		}
 		// console.log(`Registering callback for key combo "${keys}"`)
 
-		const callbackWrap = (e: Event) => {
-			if (isEventInInputField(e)) return
-			e.preventDefault()
-			if (!allowInModal && isModalShowing()) return
-
-			callback(e)
-		}
-		_boundHotkeys[index].push(callbackWrap)
+		_boundHotkeys[index].push({
+			isGlobal: false,
+			allowInModal: !!allowInModal,
+			original: callback
+		})
 
 		if (tag) {
 			if (_callbackTags[index + '_' + tag]) {
 				throw new Error(`Bind: Callback with tag "${tag}" already exists for ${index}!`)
 			}
-			_callbackTags[index + '_' + tag] = callbackWrap
+			_callbackTags[index + '_' + tag] = callback
 		}
 	}
 
@@ -101,14 +109,18 @@ export namespace mousetrapHelper {
 			}
 		}
 
+		if (!callback) throw new Error(`Callback could not be located`)
+
 		if (_boundHotkeys[index] === undefined) return
-		const callbackIndex = _boundHotkeys[index].findIndex(val => val === callback)
+		const callbackIndex = _boundHotkeys[index].findIndex((i) => i.original === callback)
 		if (callbackIndex >= 0) {
 			_boundHotkeys[index].splice(callbackIndex, 1)
 			if (tag) {
 				// cleanup callback tags to avoid memory leaks
 				delete _callbackTags[index + '_' + tag]
 			}
+		} else {
+			console.log('Callback not found in list for ', index)
 		}
 		if (_boundHotkeys[index].length === 0) {
 			delete _boundHotkeys[index]

--- a/meteor/client/lib/userAction.ts
+++ b/meteor/client/lib/userAction.ts
@@ -25,8 +25,6 @@ export function doUserAction (
 		NotificationCenter.push(timeoutMessage)
 	}, 2000)
 
-	console.log(method, ...params)
-
 	callMethod(event, method, ...params, (err, res) => {
 
 		if (!timeoutMessage) {

--- a/meteor/client/lib/userAction.ts
+++ b/meteor/client/lib/userAction.ts
@@ -25,6 +25,8 @@ export function doUserAction (
 		NotificationCenter.push(timeoutMessage)
 	}, 2000)
 
+	console.log(method, ...params)
+
 	callMethod(event, method, ...params, (err, res) => {
 
 		if (!timeoutMessage) {

--- a/meteor/client/styles/modalDialog.scss
+++ b/meteor/client/styles/modalDialog.scss
@@ -14,3 +14,14 @@
 .dark .border-box {
 	color: #fff;
 }
+
+.btn.btn-primary.btn-warn {
+	background: #E62421;
+	border-color: #E62421;
+	color: #FFFFFF;
+}
+
+.btn.btn-secondary.btn-warn {
+	border-color: #E62421;
+	color: #E62421;
+}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1118,7 +1118,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		rundownLayoutId: String(params['layout'])
 	}
 })(
-class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 
 	private bindKeys: Array<{
 		key: string,
@@ -1364,21 +1364,21 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		if (this.props.showStyleBase) {
 			_.each(this.props.showStyleBase.runtimeArguments, (i) => {
 				const combos = i.hotkeys.split(',')
-				_.each(combos, (combo: string) => {
-					const handler = (e: KeyboardEvent) => {
-						if (this.props.rundown && this.props.rundown.active && this.props.rundown.nextPartId) {
-							doUserAction(t, e, UserActionAPI.methods.togglePartArgument, [
-								this.props.rundown._id, this.props.rundown.nextPartId, i.property, i.value
-							])
-						}
+				const handler = (e: KeyboardEvent) => {
+					if (this.props.rundown && this.props.rundown.active && this.props.rundown.nextPartId) {
+						doUserAction(t, e, UserActionAPI.methods.togglePartArgument, [
+							this.props.rundown._id, this.props.rundown.nextPartId, i.property, i.value
+						])
 					}
+				}
+				_.each(combos, (combo: string) => {
+					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
+					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
 					this.usedArgumentKeys.push({
 						up: handler,
 						key: combo,
 						label: i.label || ''
 					})
-					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
-					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
 				})
 			})
 		}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -826,6 +826,7 @@ const RundownHeader = translate()(class extends React.Component<Translated<IRund
 					doModalDialog({
 						title: this.props.rundown.name,
 						message: t('Are you sure you want to deactivate this Rundown?\n(This will clear the outputs)'),
+						warning: true,
 						onAccept: () => {
 							doUserAction(t, e, UserActionAPI.methods.deactivate, [this.props.rundown._id])
 						}

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -571,7 +571,8 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 	}
 
 	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		if (this.props.liveSegment && this.props.liveSegment !== prevProps.liveSegment && this.state.followLive) {
@@ -585,8 +586,8 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -595,28 +596,28 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 		if (!this.props.studioMode) return
 		if (!this.props.registerHotkeys) return
 
-		let preventDefault = (e) => {
+		const preventDefault = (e) => {
 			e.preventDefault()
 		}
 
 		if (this.props.liveSegment && this.props.liveSegment.pieces) {
 			this.props.liveSegment.pieces.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -165,7 +165,8 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 	}
 
 	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		this.refreshKeyboardHotkeys()
@@ -173,8 +174,8 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -197,21 +198,21 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 		if (this.props.liveSegment && this.props.liveSegment.pieces) {
 			this.props.liveSegment.pieces.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -221,21 +222,21 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 		if (this.props.rundownBaselineAdLibs) {
 			this.props.rundownBaselineAdLibs.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -246,11 +247,11 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 			_.each(this.props.sourceLayerLookup, (item) => {
 				if (item.clearKeyboardHotkey) {
 					item.clearKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onClearAllSourceLayer(item, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 
@@ -258,11 +259,11 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 
 				if (item.isSticky && item.activateStickyKeyboardHotkey) {
 					item.activateStickyKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleSticky(item._id, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 				}

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -339,7 +339,8 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 	}
 
 	componentDidUpdate (prevProps: IProps & ITrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		this.refreshKeyboardHotkeys()
@@ -347,8 +348,8 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -363,21 +364,21 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		if (this.props.rundownAdLibs) {
 			this.props.rundownAdLibs.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -388,11 +389,11 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 			_.each(this.props.sourceLayerLookup, (item) => {
 				if (item.clearKeyboardHotkey) {
 					item.clearKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onClearAllSourceLayer(item, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 
@@ -400,11 +401,11 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 
 				if (item.isSticky && item.activateStickyKeyboardHotkey) {
 					item.activateStickyKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleSticky(item._id, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 				}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When certain kinds of hotkeys overlap (for example Rundown Arguments and Source Layer activators), the view will crash completely.

* **What is the new behavior (if this is a feature change)?**

Overlapping hotkeys will not cause a crash.

* **Other information**:

Binding and unbinding hotkeys using mousetrapHelper have been generally improved.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
