### PR TITLE
fix: support rundown layouts in snapshots

### DIFF
--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -52,6 +52,7 @@ import { IngestDataCacheObj, IngestDataCache } from '../../lib/collections/Inges
 import { ingestMOSRundown } from './ingest/http'
 import { RundownBaselineObj, RundownBaselineObjs } from '../../lib/collections/RundownBaselineObjs'
 import { RundownBaselineAdLibItem, RundownBaselineAdLibPieces } from '../../lib/collections/RundownBaselineAdLibPieces'
+import { RundownLayouts, RundownLayoutBase } from '../../lib/collections/RundownLayouts'
 
 interface RundownSnapshot {
 	version: string
@@ -77,6 +78,7 @@ interface SystemSnapshot {
 	showStyleBases: Array<ShowStyleBase>
 	showStyleVariants: Array<ShowStyleVariant>
 	blueprints?: Array<Blueprint> // optional, to be backwards compatible
+	rundownLayouts?: Array<RundownLayoutBase> // optional, to be backwards compatible
 	devices: Array<PeripheralDevice>
 	deviceCommands: Array<PeripheralDeviceCommand>
 	coreSystem: ICoreSystem
@@ -168,6 +170,7 @@ function createSystemSnapshot (studioId: string | null): SystemSnapshot {
 
 	let queryShowStyleBases: MongoSelector<ShowStyleBase> = {}
 	let queryShowStyleVariants: MongoSelector<ShowStyleVariant> = {}
+	let queryRundownLayouts: MongoSelector<RundownLayoutBase> = {}
 	let queryDevices: MongoSelector<PeripheralDevice> = {}
 	let queryBlueprints: MongoSelector<Blueprint> = {}
 
@@ -183,10 +186,14 @@ function createSystemSnapshot (studioId: string | null): SystemSnapshot {
 		queryShowStyleVariants = {
 			showStyleBaseId: { $in: showStyleBaseIds }
 		}
+		queryRundownLayouts = {
+			showStyleBaseId: { $in: showStyleBaseIds }
+		}
 		queryDevices = { studioId: studioId }
 	}
 	const showStyleBases 	= ShowStyleBases	.find(queryShowStyleBases).fetch()
 	const showStyleVariants = ShowStyleVariants	.find(queryShowStyleVariants).fetch()
+	const rundownLayouts	= RundownLayouts	.find(queryRundownLayouts).fetch()
 	const devices 			= PeripheralDevices	.find(queryDevices).fetch()
 
 	if (studioId) {
@@ -219,6 +226,7 @@ function createSystemSnapshot (studioId: string | null): SystemSnapshot {
 		showStyleBases,
 		showStyleVariants,
 		blueprints,
+		rundownLayouts,
 		devices,
 		coreSystem,
 		deviceCommands: deviceCommands,
@@ -447,6 +455,7 @@ function restoreFromSystemSnapshot (snapshot: SystemSnapshot) {
 		saveIntoDb(ShowStyleBases, {}, snapshot.showStyleBases),
 		saveIntoDb(ShowStyleVariants, {}, snapshot.showStyleVariants),
 		(snapshot.blueprints ? saveIntoDb(Blueprints, {}, snapshot.blueprints) : null),
+		(snapshot.rundownLayouts ? saveIntoDb(RundownLayouts, {}, snapshot.rundownLayouts) : null),
 		saveIntoDb(PeripheralDevices, (studioId ? { studioId: studioId } : {}), snapshot.devices),
 		saveIntoDb(CoreSystem, {}, [snapshot.coreSystem])
 	)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

Rundown layouts are not included in system snapshots.

* **What is the new behavior (if this is a feature change)?**

Adds rundown layouts as an optional field in the snapshot, so as to be backwards-compatible.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
