### PR TITLE
fix: bugfix: not able to reset rundown when first part was playing

### DIFF
--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -109,13 +109,19 @@ function resetRundownPlayhead (rundown: Rundown) {
 		$set: {
 			previousPartId: null,
 			currentPartId: null,
-			updateStoryStatus: null,
 			holdState: RundownHoldState.NONE,
 		}, $unset: {
 			startedPlayback: 1,
 			previousPersistentState: 1
 		}
 	})
+	// Also update locally:
+	rundown.previousPartId = null
+	rundown.currentPartId = null
+	rundown.holdState = RundownHoldState.NONE
+	delete rundown.startedPlayback
+	delete rundown.previousPersistentState
+
 
 	if (rundown.active) {
 		// put the first on queue:


### PR DESCRIPTION
_Note: This PR is happily contributed from TV2 Denmark!_ 😀

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue where it was not possible to "Reset Rundown" when the _first_ Part is playing.


* **What is the current behavior?** (You can also link to an open issue here)
Core threw an error "Not allowed to Next the currently playing Part"


* **What is the new behavior (if this is a feature change)?**
No error thrown, rundown is reset


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
