### PR TITLE
Feat/blueprint warn when replacing

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -236,7 +236,7 @@ export function setupMockStudioBlueprint (showStyleBaseId: string): Blueprint {
 	const blueprintId = 'mockBlueprint' + (dbI++)
 	const blueprintName = 'mockBlueprint'
 
-	return uploadBlueprint(blueprintId, code, blueprintName)
+	return uploadBlueprint(blueprintId, code, blueprintName, true)
 }
 export function setupMockShowStyleBlueprint (showStyleVariantId: string): Blueprint {
 
@@ -346,7 +346,7 @@ export function setupMockShowStyleBlueprint (showStyleVariantId: string): Bluepr
 	const blueprintId = 'mockBlueprint' + (dbI++)
 	const blueprintName = 'mockBlueprint'
 
-	return uploadBlueprint(blueprintId, code, blueprintName)
+	return uploadBlueprint(blueprintId, code, blueprintName, true)
 }
 export interface DefaultEnvironment {
 	showStyleBaseId: string

--- a/meteor/lib/collections/Blueprints.ts
+++ b/meteor/lib/collections/Blueprints.ts
@@ -12,6 +12,7 @@ export interface Blueprint {
 	modified: number
 	created: number
 
+	blueprintId: string
 	blueprintType?: BlueprintManifestType
 
 	studioConfigManifest?: ConfigManifestEntry[]

--- a/meteor/server/api/blueprints/__tests__/lib.ts
+++ b/meteor/server/api/blueprints/__tests__/lib.ts
@@ -14,6 +14,7 @@ export function generateFakeBlueprint (
 		created: 0,
 		modified: 0,
 
+		blueprintId: '',
 		blueprintType: type,
 
 		studioConfigManifest: [],

--- a/meteor/server/api/blueprints/http.ts
+++ b/meteor/server/api/blueprints/http.ts
@@ -20,6 +20,7 @@ postJsRoute.route('/blueprints/restore/:blueprintId', (params, req: IncomingMess
 
 	const blueprintId = params.blueprintId
 	const url = parseUrl(req.url || '', true)
+	const force = url.query.force === '1' || url.query.force === 'true'
 
 	const blueprintNames = url.query['name'] || undefined
 	const blueprintName: string | undefined = (
@@ -38,7 +39,7 @@ postJsRoute.route('/blueprints/restore/:blueprintId', (params, req: IncomingMess
 
 		if (!_.isString(body) || body.length < 10) throw new Meteor.Error(400, 'Restore Blueprint: Invalid request body')
 
-		uploadBlueprint(blueprintId, body, blueprintName)
+		uploadBlueprint(blueprintId, body, blueprintName, force)
 
 		res.statusCode = 200
 	} catch (e) {

--- a/meteor/server/migration/1_5_0.ts
+++ b/meteor/server/migration/1_5_0.ts
@@ -47,4 +47,27 @@ addMigrationSteps('1.5.0', [
 			})
 		}
 	},
+
+	{
+		id: 'Blueprints.blueprintId default',
+		canBeRunAutomatically: true,
+		validate: () => {
+			let blueprints = Blueprints.find({
+				blueprintId: { $exists: false }
+			}).count()
+			if (blueprints) {
+				return 'Blueprints.blueprintId is "undefined"'
+			}
+			return false
+		},
+		migrate: () => {
+			Blueprints.update({
+				blueprintId: { $exists: false }
+			}, {
+				$set: {
+					blueprintId: ''
+				}
+			})
+		}
+	},
 ])


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When uploading a new blueprint, a blueprintId field is used to determine if the blueprint is the same (dk or rk10). If the new one is different to the one stored, then the upload is rejected unless `?force=1` is set in the upload url.

The UI will handle the first upload rejection and show a confirmation prompt to the user to get them to confirm the force

* **What is the current behavior?** (You can also link to an open issue here)

It is possible to upload a rk10 blueprint over a dk blueprint by accident.

* **Other information**:
Needs blueprint-integration update (will be done in another PR)

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
