### PR TITLE
feat: ignore piece media status

### DIFF
--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -115,7 +115,8 @@ export function checkPieceContentStatus (piece: IBlueprintPieceGeneric, sourceLa
 	let metadata: MediaObject | null = null
 	let message: string | null = null
 
-	if (sourceLayer) {
+	const ignoreMediaStatus = piece.content && piece.content.ignoreMediaObjectStatus
+	if (!ignoreMediaStatus && sourceLayer) {
 		switch (sourceLayer.type) {
 			case SourceLayerType.VT:
 			case SourceLayerType.LIVE_SPEAK:

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -13387,9 +13387,9 @@
       }
     },
     "tv-automation-sofie-blueprints-integration": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.6.0.tgz",
-      "integrity": "sha512-+4mkXPJvUilgHbhT2FO7LV1zN7ekibMrCxxBOodL3RtAou3cQdOcxc7j1fmgVTo4ES1Wt3m/zOVDP8Nmi1FUrA==",
+      "version": "1.7.0-nightly-20191216-161547-344775e.0",
+      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.7.0-nightly-20191216-161547-344775e.0.tgz",
+      "integrity": "sha512-PFP2EEsYNgSJYeFzPl93GA6LjRaTxQeFdWDdfW4gEDcsel01qOyiASCKaJNWBZRAJGMhJnx61Mjja+MMHIYyaQ==",
       "requires": {
         "moment": "2.22.2",
         "timeline-state-resolver-types": "3.16.0",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -84,7 +84,7 @@
     "soap": "^0.24.0",
     "superfly-timeline": "^7.3.1",
     "timecode": "0.0.4",
-    "tv-automation-sofie-blueprints-integration": "^1.6.0",
+    "tv-automation-sofie-blueprints-integration": "^1.7.0-nightly-20191216-161547-344775e.0",
     "underscore": "^1.8.3",
     "velocity-animate": "^1.5.1",
     "velocity-react": "^1.3.3",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds option to VT pieces to allow for media status checks to be ignored

* **What is the current behavior?** (You can also link to an open issue here)
Core assets will show a full status of meaningless issues (eg freeze frames during vignett). These are not useful or relevent to the producer and just add noise

* **What is the new behavior (if this is a feature change)?**
The blueprints can tell core to skip these checks, and always say that the media is online and valid

* **Other information**:
blueprints-integration: https://github.com/nrkno/tv-automation-sofie-blueprints-integration/commit/a7fc8c8254009a14c8e1650675d18c0402395f1b

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
