### PR TITLE
feat: add validateBlueprintConfig and notifications in the rundown view

### DIFF
--- a/meteor/client/ui/RundownView/RundownNotifier.ts
+++ b/meteor/client/ui/RundownView/RundownNotifier.ts
@@ -3,7 +3,7 @@ import * as _ from 'underscore'
 import { Meteor } from 'meteor/meteor'
 import { Tracker } from 'meteor/tracker'
 import { NotificationCenter, NotificationList, NotifierHandle, Notification, NoticeLevel } from '../../lib/notifications/notifications'
-import { RundownAPI } from '../../../lib/api/rundown'
+import { RundownAPI, RundownPlaylistValidateBlueprintConfigResult } from '../../../lib/api/rundown'
 import { WithManagedTracker } from '../../lib/reactiveData/reactiveDataHelper'
 import { reactiveData } from '../../lib/reactiveData/reactiveData'
 import { checkPieceContentStatus, getMediaObjectMediaId } from '../../../lib/mediaObjects'
@@ -59,8 +59,10 @@ class RundownViewNotifier extends WithManagedTracker {
 	private _deviceStatusDep: Tracker.Dependency
 
 	private _rundownImportVersionStatus: Notification | undefined = undefined
+	private _rundownShowStyleConfigStatuses: _.Dictionary<Notification | undefined> = {}
+	private _rundownStudioConfigStatus: Notification | undefined = undefined
 	private _rundownImportVersionStatusDep: Tracker.Dependency
-	private _rundownImportVersionInterval: number | undefined = undefined
+	private _rundownImportVersionAndConfigInterval: number | undefined = undefined
 
 	private _unsentExternalMessagesStatus: Notification | undefined = undefined
 	private _unsentExternalMessageStatusDep: Tracker.Dependency
@@ -84,7 +86,7 @@ class RundownViewNotifier extends WithManagedTracker {
 
 			if (playlistId) {
 				this.reactiveRundownStatus(playlistId)
-				this.reactiveVersionStatus(playlistId)
+				this.reactiveVersionAndConfigStatus(playlistId)
 
 				this.autorun(() => {
 					// console.log('RundownViewNotifier 1-1')
@@ -102,6 +104,8 @@ class RundownViewNotifier extends WithManagedTracker {
 				this._deviceStatus = {}
 				this._notes = {}
 				this._rundownImportVersionStatus = undefined
+				this._rundownStudioConfigStatus = undefined
+				this._rundownShowStyleConfigStatuses = {}
 				this._unsentExternalMessagesStatus = undefined
 				this.cleanUpMediaStatus()
 			}
@@ -120,7 +124,7 @@ class RundownViewNotifier extends WithManagedTracker {
 				.concat(_.compact(_.values(this._deviceStatus)))
 				.concat(_.compact(_.values(this._notes)))
 				.concat(_.compact(_.values(this._rundownStatus)))
-				.concat(_.compact([this._rundownImportVersionStatus]))
+				.concat(_.compact([this._rundownImportVersionStatus, this._rundownStudioConfigStatus]), _.compact(_.values(this._rundownShowStyleConfigStatuses)))
 				.concat(_.compact([this._unsentExternalMessagesStatus]))
 
 			this._notificationList.set(
@@ -133,7 +137,7 @@ class RundownViewNotifier extends WithManagedTracker {
 	stop () {
 		super.stop()
 
-		if (this._rundownImportVersionInterval) Meteor.clearInterval(this._rundownImportVersionInterval)
+		if (this._rundownImportVersionAndConfigInterval) Meteor.clearInterval(this._rundownImportVersionAndConfigInterval)
 
 		_.forEach(this._mediaStatusComps, (element, key) => element.stop())
 		this._notifier.stop()
@@ -446,19 +450,19 @@ class RundownViewNotifier extends WithManagedTracker {
 		})
 	}
 
-	private reactiveVersionStatus (playlistId: RundownPlaylistId) {
+	private reactiveVersionAndConfigStatus (playlistId: RundownPlaylistId) {
 
 		const updatePeriod = 30000 // every 30s
 
-		if (this._rundownImportVersionInterval) Meteor.clearInterval(this._rundownImportVersionInterval)
-		this._rundownImportVersionInterval = playlistId ? Meteor.setInterval(() => this.updateVersionStatus(playlistId), updatePeriod) : undefined
+		if (this._rundownImportVersionAndConfigInterval) Meteor.clearInterval(this._rundownImportVersionAndConfigInterval)
+		this._rundownImportVersionAndConfigInterval = playlistId ? Meteor.setInterval(() => this.updateVersionAndConfigStatus(playlistId), updatePeriod) : undefined
 
 		// const rundowns = reactiveData.getRRundowns()
 		this.autorun((comp: Tracker.Computation) => {
 			// console.log('RundownViewNotifier 5')
 
 			// Track the rundown as a dependency of this autorun
-			this.updateVersionStatus(playlistId)
+			this.updateVersionAndConfigStatus(playlistId)
 		})
 	}
 
@@ -479,10 +483,8 @@ class RundownViewNotifier extends WithManagedTracker {
 		})
 	}
 
-	private updateVersionStatus (playlistId: RundownPlaylistId) {
+	private updateVersionAndConfigStatus (playlistId: RundownPlaylistId) {
 		const t = i18nTranslator
-
-		// console.log('update_version_status, ' + rundownId)
 
 		// Doing the check server side, to avoid needing to subscribe to the blueprint and showStyleVariant
 		MeteorCall.rundown.rundownPlaylistNeedsResync(playlistId)
@@ -515,6 +517,71 @@ class RundownViewNotifier extends WithManagedTracker {
 				let newNotification = new Notification('rundown_importVersions', NoticeLevel.WARNING, t('Unable to check the system configuration for changes'), `rundownPlaylist_${playlistId}`, getCurrentTime(), true, undefined, -1)
 				if (!Notification.isEqual(this._rundownImportVersionStatus, newNotification)) {
 					this._rundownImportVersionStatus = newNotification
+					this._rundownImportVersionStatusDep.changed()
+				}
+			})
+
+			// Verify the showstyle & studio config look good
+			MeteorCall.rundown.rundownPlaylistValidateBlueprintConfig(playlistId)
+			.then((configErrors: RundownPlaylistValidateBlueprintConfigResult) => {
+				let newStudioNotification: Notification | undefined = undefined
+				if (configErrors.studio.length > 0) {
+					let message = t('The Studio configuration is missing some required fields:')
+					message += configErrors.studio.join(',')
+					newStudioNotification = new Notification('rundown_validateStudioConfig', NoticeLevel.WARNING, message, `rundownPlaylist_${playlistId}`, getCurrentTime(), true, [], -1)
+				}
+
+				let hasChanges = false
+				if (!Notification.isEqual(this._rundownStudioConfigStatus, newStudioNotification)) {
+					this._rundownStudioConfigStatus = newStudioNotification
+					hasChanges = true
+				}
+
+				// Check show styles for changes
+				const oldShowStyleIds = _.keys(this._rundownShowStyleConfigStatuses)
+				const newShowStyleIds: string[] = []
+				_.each(configErrors.showStyles, showStyleErrors => {
+					let newNotification: Notification | undefined
+					if (showStyleErrors.checkFailed) {
+						const message = t('The Show Style configuration "{{name}}" could not be validated', { name: showStyleErrors.name })
+						newNotification = new Notification('rundown_validateStudioConfig', NoticeLevel.WARNING, message, `rundownPlaylist_${playlistId}`, getCurrentTime(), true, [], -1)
+					} else if (showStyleErrors.fields.length > 0) {
+						let message = t('The ShowStyle "{{name}}" configuration is missing some required fields:', { name: showStyleErrors.name })
+						message += showStyleErrors.fields.join(',')
+						newNotification = new Notification('rundown_validateShowStyleConfig', NoticeLevel.WARNING, message, `rundownPlaylist_${playlistId}`, getCurrentTime(), true, [], -1)
+					}
+					
+					if (!Notification.isEqual(this._rundownShowStyleConfigStatuses[showStyleErrors.id], newNotification)) {
+						if (newNotification) {
+							this._rundownShowStyleConfigStatuses[showStyleErrors.id] = newNotification
+						} else {
+							delete this._rundownShowStyleConfigStatuses[showStyleErrors.id]
+						}
+						hasChanges = true
+					}
+
+					if (newNotification) {
+						newShowStyleIds.push(showStyleErrors.id)
+					}
+				})
+
+				// Track any removed showStyles
+				const removedShowStyleIds = _.difference(oldShowStyleIds, newShowStyleIds)
+				if (removedShowStyleIds.length > 0) {
+					removedShowStyleIds.forEach((id) => {
+						delete this._rundownShowStyleConfigStatuses[id]
+					})
+					hasChanges = true
+				}
+				
+				if (hasChanges) {
+					this._rundownImportVersionStatusDep.changed()
+				}
+			}).catch(err => {
+				const newNotification = new Notification('rundown_validateStudioConfig', NoticeLevel.WARNING, t('Unable to validate the system configuration'), 'rundownPlaylist_' + playlistId, getCurrentTime(), true, undefined, -1)
+				if (_.size(this._rundownShowStyleConfigStatuses) > 0 || !Notification.isEqual(this._rundownStudioConfigStatus, newNotification)) {
+					this._rundownStudioConfigStatus = newNotification
+					this._rundownShowStyleConfigStatuses = {}
 					this._rundownImportVersionStatusDep.changed()
 				}
 			})

--- a/meteor/lib/api/rundown.ts
+++ b/meteor/lib/api/rundown.ts
@@ -4,10 +4,21 @@ import * as _ from 'underscore'
 import { RundownPlaylistId } from '../collections/RundownPlaylists'
 import { ReloadRundownPlaylistResponse, ReloadRundownResponse } from './userActions'
 
+export interface RundownPlaylistValidateBlueprintConfigResult {
+	studio: string[]
+	showStyles: Array<{
+		id: string
+		name: string
+		checkFailed: boolean 
+		fields: string[]
+	}>
+}
+
 export interface NewRundownAPI {
 	removeRundownPlaylist (playlistId: RundownPlaylistId): Promise<void>
 	resyncRundownPlaylist (playlistId: RundownPlaylistId): Promise<ReloadRundownPlaylistResponse>
 	rundownPlaylistNeedsResync (playlistId: RundownPlaylistId): Promise<string[]>
+	rundownPlaylistValidateBlueprintConfig (playlistId: RundownPlaylistId): Promise<RundownPlaylistValidateBlueprintConfigResult>
 	removeRundown (rundownId: RundownId): Promise<void>
 	resyncRundown (rundownId: RundownId): Promise<ReloadRundownResponse>
 	unsyncRundown (rundownId: RundownId): Promise<void>
@@ -17,6 +28,7 @@ export enum RundownAPIMethods {
 	'removeRundownPlaylist' = 'rundown.removeRundownPlaylist',
 	'resyncRundownPlaylist' = 'rundown.resyncRundownPlaylist',
 	'rundownPlaylistNeedsResync' = 'rundown.rundownPlaylistNeedsResync',
+	'rundownPlaylistValidateBlueprintConfig' = 'rundown.rundownPlaylistValidateBlueprintConfig',
 
 	'removeRundown' 		= 'rundown.removeRundown',
 	'resyncRundown' 		= 'rundown.resyncRundown',

--- a/meteor/lib/collections/ShowStyleVariants.ts
+++ b/meteor/lib/collections/ShowStyleVariants.ts
@@ -30,7 +30,9 @@ export function getShowStyleCompound (showStyleVariantId: ShowStyleVariantId): S
 	return createShowStyleCompound(showStyleBase, showStyleVariant)
 }
 
-export function createShowStyleCompound(showStyleBase: ShowStyleBase, showStyleVariant: ShowStyleVariant): ShowStyleCompound {
+export function createShowStyleCompound(showStyleBase: ShowStyleBase, showStyleVariant: ShowStyleVariant): ShowStyleCompound | undefined {
+	if (showStyleBase._id !== showStyleVariant.showStyleBaseId) return undefined
+	
 	let configs: {[id: string]: IConfigItem} = {}
 	_.each(showStyleBase.config, (config: IConfigItem) => {
 		configs[config._id] = config

--- a/meteor/lib/collections/ShowStyleVariants.ts
+++ b/meteor/lib/collections/ShowStyleVariants.ts
@@ -22,11 +22,15 @@ export interface ShowStyleCompound extends ShowStyleBase {
 	showStyleVariantId: ShowStyleVariantId
 }
 export function getShowStyleCompound (showStyleVariantId: ShowStyleVariantId): ShowStyleCompound | undefined {
-	let showStyleVariant = ShowStyleVariants.findOne(showStyleVariantId)
+	const showStyleVariant = ShowStyleVariants.findOne(showStyleVariantId)
 	if (!showStyleVariant) return undefined
-	let showStyleBase = ShowStyleBases.findOne(showStyleVariant.showStyleBaseId)
+	const showStyleBase = ShowStyleBases.findOne(showStyleVariant.showStyleBaseId)
 	if (!showStyleBase) return undefined
 
+	return createShowStyleCompound(showStyleBase, showStyleVariant)
+}
+
+export function createShowStyleCompound(showStyleBase: ShowStyleBase, showStyleVariant: ShowStyleVariant): ShowStyleCompound {
 	let configs: {[id: string]: IConfigItem} = {}
 	_.each(showStyleBase.config, (config: IConfigItem) => {
 		configs[config._id] = config

--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -1,5 +1,5 @@
 import * as _ from 'underscore'
-import { ConfigItemValue } from 'tv-automation-sofie-blueprints-integration'
+import { ConfigItemValue, ConfigManifestEntry, IConfigItem } from 'tv-automation-sofie-blueprints-integration'
 import { Studios, Studio, StudioId } from '../../../lib/collections/Studios'
 import { Meteor } from 'meteor/meteor'
 import { getShowStyleCompound, ShowStyleVariantId } from '../../../lib/collections/ShowStyleVariants'
@@ -83,4 +83,17 @@ export function compileStudioConfig (studio: Studio) {
 	res['SofieHostURL'] = studio.settings.sofieUrl
 
 	return res
+}
+
+export function findMissingConfigs (manifest: ConfigManifestEntry[], config: IConfigItem[]) {
+	const missingKeys: string[] = []
+
+	const configKeys = _.map(config, c => c._id)
+	_.each(manifest, m => {
+		if (m.required && configKeys.indexOf(m.id) === -1) {
+			missingKeys.push(m.name)
+		}
+	})
+
+	return missingKeys
 }

--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -85,8 +85,11 @@ export function compileStudioConfig (studio: Studio) {
 	return res
 }
 
-export function findMissingConfigs (manifest: ConfigManifestEntry[], config: IConfigItem[]) {
+export function findMissingConfigs (manifest: ConfigManifestEntry[] | undefined, config: IConfigItem[]) {
 	const missingKeys: string[] = []
+	if (manifest === undefined) {
+		 return missingKeys
+	}
 
 	const configKeys = _.map(config, c => c._id)
 	_.each(manifest, m => {

--- a/meteor/server/api/blueprints/context.ts
+++ b/meteor/server/api/blueprints/context.ts
@@ -28,7 +28,7 @@ import {
 	IBlueprintAsRunLogEvent
 } from 'tv-automation-sofie-blueprints-integration'
 import { Studio } from '../../../lib/collections/Studios'
-import { ConfigRef, compileStudioConfig } from './config'
+import { ConfigRef, compileStudioConfig, findMissingConfigs } from './config'
 import { Rundown, RundownId } from '../../../lib/collections/Rundowns'
 import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from '../../../lib/collections/ShowStyleBases'
 import { getShowStyleCompound, ShowStyleVariantId } from '../../../lib/collections/ShowStyleVariants'
@@ -39,6 +39,7 @@ import { RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/Run
 import { Segment, SegmentId } from '../../../lib/collections/Segments'
 import { PieceInstances, unprotectPieceInstance } from '../../../lib/collections/PieceInstances'
 import { InternalIBlueprintPartInstance, PartInstanceId, unprotectPartInstance, PartInstance } from '../../../lib/collections/PartInstances'
+import { Blueprints } from '../../../lib/collections/Blueprints'
 
 /** Common */
 
@@ -151,6 +152,16 @@ export class StudioConfigContext implements IStudioConfigContext {
 		return this.studio
 	}
 	getStudioConfig (): Readonly<{[key: string]: ConfigItemValue}> {
+		const studioBlueprint = Blueprints.findOne(this.studio.blueprintId)
+		if (studioBlueprint) {
+			const diffs = findMissingConfigs(studioBlueprint.studioConfigManifest || [], this.studio.config)
+			if (diffs && diffs.length) {
+				logger.warn(`Studio "${this.studio._id}" missing required config: ${diffs.join(', ')}`)
+			}
+		} else {
+			logger.warn(`Studio blueprint "${this.studio.blueprintId}" not found!`)
+		}
+
 		return compileStudioConfig(this.studio)
 	}
 	getStudioConfigRef (configKey: string): string {
@@ -194,6 +205,16 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 	getShowStyleConfig (): {[key: string]: ConfigItemValue} {
 		const showStyleCompound = getShowStyleCompound(this.showStyleVariantId)
 		if (!showStyleCompound) throw new Meteor.Error(404, `no showStyleCompound for "${this.showStyleVariantId}"`)
+
+		const showStyleBlueprint = Blueprints.findOne(showStyleCompound.blueprintId)
+		if (showStyleBlueprint) {
+			const diffs = findMissingConfigs(showStyleBlueprint.showStyleConfigManifest || [], showStyleCompound.config)
+			if (diffs && diffs.length) {
+				logger.warn(`ShowStyle "${showStyleCompound._id}-${showStyleCompound.showStyleVariantId}" missing required config: ${diffs.join(', ')}`)
+			}
+		} else {
+			logger.warn(`ShowStyle blueprint "${showStyleCompound.blueprintId}" not found!`)
+		}
 
 		const res: {[key: string]: ConfigItemValue} = {}
 		_.each(showStyleCompound.config, (c) => {

--- a/meteor/server/api/blueprints/context.ts
+++ b/meteor/server/api/blueprints/context.ts
@@ -154,7 +154,7 @@ export class StudioConfigContext implements IStudioConfigContext {
 	getStudioConfig (): Readonly<{[key: string]: ConfigItemValue}> {
 		const studioBlueprint = Blueprints.findOne(this.studio.blueprintId)
 		if (studioBlueprint) {
-			const diffs = findMissingConfigs(studioBlueprint.studioConfigManifest || [], this.studio.config)
+			const diffs = findMissingConfigs(studioBlueprint.studioConfigManifest, this.studio.config)
 			if (diffs && diffs.length) {
 				logger.warn(`Studio "${this.studio._id}" missing required config: ${diffs.join(', ')}`)
 			}
@@ -208,7 +208,7 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 
 		const showStyleBlueprint = Blueprints.findOne(showStyleCompound.blueprintId)
 		if (showStyleBlueprint) {
-			const diffs = findMissingConfigs(showStyleBlueprint.showStyleConfigManifest || [], showStyleCompound.config)
+			const diffs = findMissingConfigs(showStyleBlueprint.showStyleConfigManifest, showStyleCompound.config)
 			if (diffs && diffs.length) {
 				logger.warn(`ShowStyle "${showStyleCompound._id}-${showStyleCompound.showStyleVariantId}" missing required config: ${diffs.join(', ')}`)
 			}

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -689,7 +689,7 @@ export function isTooCloseToAutonext (currentPartInstance: PartInstance | undefi
 
 	const start = currentPartInstance.part.getLastStartedPlayback()
 	const offset = currentPartInstance.part.getLastPlayOffset()
-	if (start && offset && currentPartInstance.part.expectedDuration) {
+	if (start !== undefined && offset !== undefined && currentPartInstance.part.expectedDuration) {
 		// date.now - start = playback duration, duration + offset gives position in part
 		const playbackDuration = getCurrentTime() - start + offset
 

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -529,13 +529,13 @@ export namespace ClientRundownAPI {
 					id: id,
 					name: compound.name,
 					checkFailed: false,
-					fields: findMissingConfigs(blueprint.showStyleConfigManifest || [], compound.config)
+					fields: findMissingConfigs(blueprint.showStyleConfigManifest, compound.config)
 				}
 			}
 		})
 
 		return {
-			studio: findMissingConfigs(studioBlueprint.studioConfigManifest || [], studio.config),
+			studio: findMissingConfigs(studioBlueprint.studioConfigManifest, studio.config),
 			showStyles: showStyleWarnings
 		}
 	}

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -21,7 +21,7 @@ import { setSystemStatus, StatusCode, removeSystemStatus } from './systemStatus/
 import { Blueprints, Blueprint } from '../lib/collections/Blueprints'
 import * as _ from 'underscore'
 import { ShowStyleBases } from '../lib/collections/ShowStyleBases'
-import { Studios } from '../lib/collections/Studios'
+import { Studios, StudioId } from '../lib/collections/Studios'
 import { logger } from './logging'
 import * as semver from 'semver'
 import { findMissingConfigs } from './api/blueprints/config'
@@ -383,7 +383,7 @@ const checkBlueprintsConfig = syncFunction(function checkBlueprintsConfig () {
 	})
 	lastBlueprintConfigIds = blueprintIds
 })
-function setBlueprintConfigStatus (systemStatusId: string, diff: string[], studioId?: string) {
+function setBlueprintConfigStatus (systemStatusId: string, diff: string[], studioId?: StudioId) {
 	if (diff && diff.length > 0) {
 		setSystemStatus(systemStatusId, {
 			studioId: studioId,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This will make core validate that all the required blueprint config fields are defined for the rundown being viewed.

* **What is the current behavior?** (You can also link to an open issue here)
It is up to the blueprints to do this check. This means that every segment in the show will end up logging a warning for each missing field.

* **What is the new behavior (if this is a feature change)?**
Core now does the check at the same interval as checking if the configuration has changed since the rundown has been imported. It will then present up to 2 notifications to warn of the missing fields.

This is much less repetitive and easier to read then before. Additionally, any blueprint hooks wont log the same warnings to the core log, which will help clean those up a bit.

* **Other information**:

The config missing isnt a major problem, as the blueprints do define defaults for them all, but it indicates that something has been configured wrong. For this reason it is a warning, and doesnt want to be too intrusive as the show will likely work just fine without.

Partner change in blueprints: https://github.com/nrkno/tv-automation-sofie-blueprints/pull/28

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
