### PR TITLE
fix: don't emit status.BAD for messages in queue. 

### DIFF
--- a/meteor/server/api/ExternalMessageQueue.ts
+++ b/meteor/server/api/ExternalMessageQueue.ts
@@ -202,9 +202,7 @@ function updateExternalMessageQueueStatus (): void {
 				const messagesOnQueueExample = messagesOnQueueCursor.fetch()[0]
 				status = {
 					statusCode: (
-						messagesOnQueueCount > 10 ?
-						StatusCode.BAD :
-						StatusCode.WARNING_MINOR
+						StatusCode.WARNING_MAJOR
 					),
 					messages: [
 						`There are ${messagesOnQueueCount} unsent messages on queue (one of the unsent messages has the error message: "${messagesOnQueueExample.errorMessage}", to receiver "${messagesOnQueueExample.type}", "${JSON.stringify(messagesOnQueueExample.receiver)}")`

--- a/meteor/server/api/ExternalMessageQueue.ts
+++ b/meteor/server/api/ExternalMessageQueue.ts
@@ -198,7 +198,7 @@ function updateExternalMessageQueueStatus (): void {
 			let status: StatusObject = {
 				statusCode: StatusCode.GOOD
 			}
-			if (messagesOnQueueCount > 1) {
+			if (messagesOnQueueCount > 0) {
 				const messagesOnQueueExample = messagesOnQueueCursor.fetch()[0]
 				status = {
 					statusCode: (


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes what the system-status will be when there are unsent items in the externalMessageQueue.
We no longer consider these to be critical to the broadcast.


* **What is the current behavior?** (You can also link to an open issue here)
System status is BAD when there are more than 10 items on queue
System status is WARNING_MINOR when there are less than 10 items on queue

* **What is the new behavior (if this is a feature change)?**
System status is WARNING_MAJOR when there are any items on queue.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
