### PR TITLE
fix: meteor build error in jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:experimental
 # BUILD IMAGE
 FROM node:8.11.4
-RUN curl https://install.meteor.com/ | sh
+RUN curl "https://install.meteor.com/?release=1.6.1.4" | sh
 COPY meteor /opt/core/meteor
 WORKDIR /opt/core/meteor
 # Temporary change the NODE_ENV env variable, so that all libraries are installed:
 ENV NODE_ENV_TMP $NODE_ENV
 ENV NODE_ENV anythingButProduction
+# Force meteor to setup the runtime
+RUN meteor --version --allow-superuser
 RUN meteor npm install
 # Restore the NODE_ENV variable:
 ENV NODE_ENV $NODE_ENV_TMP


### PR DESCRIPTION
Doing a fresh install of meteor installs 1.9, which is using node12.
This affects the version of meteor-tools installed, until meteor has been setup for our project.

The steps in the Dockerfile are not invoking a true meteor command until after the `meteor npm install` and so meteor was not being setup to the version we needed.
This meant it was trying to install our dependencies on node12, and failing.

Doing a `meteor --version` triggers meteor to setup the tools to the correct versions, allowing `meteor npm install` to run happily.

The change to the curl line may not be needed, and may not even help. But I dont see any harm in having it there too.

I don't quite understand why it broke today (perhaps it was triggered by #151 changing something for itself?)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
