### PR TITLE
Hotfix for looping between 2 parts

### DIFF
--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -65,6 +65,8 @@ export interface DBRundown extends IBlueprintRundownDB {
 	nextPartManual?: boolean
 	/** the id of the Previous Part */
 	previousPartId: string | null
+	/** Timestamp for the last time an incorrect part was reported as started */
+	lastIncorrectPartPlaybackReported?: Time
 
 	/** Actual time of playback starting */
 	startedPlayback?: Time
@@ -116,6 +118,7 @@ export class Rundown implements DBRundown {
 	public nextPartManual?: boolean
 	public previousPartId: string | null
 	public startedPlayback?: Time
+	public lastIncorrectPartPlaybackReported?: Time
 	public unsynced?: boolean
 	public unsyncedTime?: Time
 	public notifiedCurrentPlayingPartExternalId?: string

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -235,10 +235,11 @@ export namespace ServerPlayoutAPI {
 
 				const offset = currentPart.getLastPlayOffset()
 				if (start && offset && currentPart.expectedDuration) {
-					const t = Date.now() - start! + offset!
+					// date.now - start = playback duration, duration + offset gives position in part
+					const playbackDuration = Date.now() - start! + offset!
 
 					// If there is an auto next planned
-					if (currentPart.autoNext && t > currentPart.expectedDuration - AUTOTAKE_DEBOUNCE) {
+					if (currentPart.autoNext && Math.abs(currentPart.expectedDuration - playbackDuration) < AUTOTAKE_DEBOUNCE) {
 						return ClientAPI.responseError('Cannot take shortly before an autoTake')
 					}
 				}

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -65,6 +65,11 @@ import { ServerPlayoutAdLibAPI } from './adlib'
 import { transformTimeline } from '../../../lib/timeline'
 import * as SuperTimeline from 'superfly-timeline'
 
+/**
+ * debounce time in ms before we accept another report of "Part started playing that was not selected by core"
+ */
+const INCORRECT_PLAYING_PART_DEBOUNCE = 5000
+
 export namespace ServerPlayoutAPI {
 	/**
 	 * Prepare the rundown for transmission
@@ -893,28 +898,34 @@ export namespace ServerPlayoutAPI {
 						libSetNextPart(rundown, nextPart)
 					} else {
 						// a part is being played that has not been selected for playback by Core
-						// show must go on, so find next part and update the Rundown, but log an error
-						let partsAfter = rundown.getParts({
-							_rank: {
-								$gt: playingPart._rank,
-							},
-							_id: { $ne: playingPart._id }
-						})
+						const previousReported = rundown.lastIncorrectPartPlaybackReported
 
-						let nextPart: Part | null = partsAfter[0] || null
+						if (previousReported && Date.now() - previousReported > INCORRECT_PLAYING_PART_DEBOUNCE) {
+							// first time this has happened for a while, let's try to progress the show:
 
-						setRundownStartedPlayback(rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
-
-						const rundownChange = {
-							previousPartId: null,
-							currentPartId: playingPart._id,
+							let partsAfter = rundown.getParts({
+								_rank: {
+									$gt: playingPart._rank,
+								},
+								_id: { $ne: playingPart._id }
+							})
+	
+							let nextPart: Part | null = partsAfter[0] || null
+	
+							setRundownStartedPlayback(rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
+	
+							const rundownChange = {
+								previousPartId: null,
+								currentPartId: playingPart._id,
+								lastIncorrectPartPlaybackReported: Date.now() // save the time to prevent the system to go in a loop
+							}
+	
+							Rundowns.update(rundown._id, {
+								$set: rundownChange
+							})
+							rundown = _.extend(rundown, rundownChange) as Rundown
+							libSetNextPart(rundown, nextPart)
 						}
-
-						Rundowns.update(rundown._id, {
-							$set: rundownChange
-						})
-						rundown = _.extend(rundown, rundownChange) as Rundown
-						libSetNextPart(rundown, nextPart)
 
 						logger.error(`Part "${playingPart._id}" has started playback by the playout gateway, but has not been selected for playback!`)
 					}


### PR DESCRIPTION
This PR introduces two fixes in order to prevent a bad state where the system will keep looping between 2 parts. One is the prevention of doing a manual take shortly before an autotake and the other is to prevent agressive measures when the playout gateway reports the wrong part has started playback.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
