### PR TITLE
Add settings to support Quantel metadata generation

### DIFF
--- a/meteor/client/ui/Settings/components/MediaManagerSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/MediaManagerSettingsComponent.tsx
@@ -292,7 +292,39 @@ export const MediaManagerSettingsComponent = translate()(class MediaManagerSetti
 												<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.usePolling'} obj={this.props.device} type='checkbox' collection={PeripheralDevices} className='input input-l'></EditAttribute>
 											</label>
 										</div>
-									</React.Fragment>))))}
+									</React.Fragment>)) ||
+										(storage.type === StorageType.QUANTEL_HTTP && ((<React.Fragment>
+											<div className='mod mvs mhs'>
+												<label className='field'>
+													{t('Quantel HTTP Transfomer URL')}
+													<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.transformerUrl'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+												</label>
+											</div>
+											<div className='mod mvs mhs'>
+												<label className='field'>
+													{t('Quantel Gateway URL')}
+													<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.gatewayUrl'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+												</label>
+											</div>
+											<div className='mod mvs mhs'>
+												<label className='field'>
+													{t('Quantel ISA URL')}
+													<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.ISAUrl'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+												</label>
+											</div>
+											<div className='mod mvs mhs'>
+												<label className='field'>
+													{t('Zone ID (leave blank for default)')}
+													<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.zoneId'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+												</label>
+											</div>
+											<div className='mod mvs mhs'>
+												<label className='field'>
+													{t('Quantel Server ID')}
+													<EditAttribute modifiedClassName='bghl' attribute={'settings.storages.' + index + '.options.serverId'} obj={this.props.device} type='int' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+												</label>
+											</div>
+										</React.Fragment>)))))}
 							</div>
 							<div className='mod alright'>
 								<button className={ClassNames('btn btn-primary')} onClick={(e) => this.finishEditStorageItem(storage.id)}>

--- a/meteor/i18n/nb.po
+++ b/meteor/i18n/nb.po
@@ -895,6 +895,9 @@ msgstr "Port for mediascanner"
 msgid "Quantel Gateway URL"
 msgstr "Quantel Gateway-adresse (url)"
 
+msgid "Quantel HTTP Transformer URL"
+msgstr "Quantel HTTP Transformer-adresse (url)"
+
 msgid "Quantel ISA URL"
 msgstr "Quantel ISA-adresse (url)"
 

--- a/meteor/i18n/nn.po
+++ b/meteor/i18n/nn.po
@@ -893,6 +893,9 @@ msgstr "Media Scanner-port"
 msgid "Quantel Gateway URL"
 msgstr ""
 
+msgid "Quantel HTTP Transformer URL"
+msgstr ""
+
 msgid "Quantel ISA URL"
 msgstr ""
 

--- a/meteor/i18n/template.pot
+++ b/meteor/i18n/template.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-16T15:02:27.601Z\n"
-"PO-Revision-Date: 2019-12-16T15:02:27.601Z\n"
+"POT-Creation-Date: 2020-01-21T22:25:06.502Z\n"
+"PO-Revision-Date: 2020-01-21T22:25:06.502Z\n"
 
 msgid "Return to list"
 msgstr ""
@@ -721,6 +721,17 @@ msgstr ""
 msgid "Blueprints updated successfully."
 msgstr ""
 
+msgid "Replace Blueprints?"
+msgstr ""
+
+msgid "Replace"
+msgstr ""
+
+msgid ""
+"Are you sure you want to replace the blueprints with the file "
+"\"{{fileName}}\"?"
+msgstr ""
+
 msgid "Failed to update blueprints: {{errorMessage}}"
 msgstr ""
 
@@ -760,10 +771,51 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
+msgid "Blueprint Id"
+msgstr ""
+
 msgid "Blueprint Version"
 msgstr ""
 
 msgid "Upload Blueprints"
+msgstr ""
+
+msgid "Spreadsheet credentials succesfully uploaded."
+msgstr ""
+
+msgid "Failed to upload spreadsheet credentials: {{errorMessage}}"
+msgstr ""
+
+msgid "Application credentials"
+msgstr ""
+
+msgid "Access token"
+msgstr ""
+
+msgid ""
+"Click on the link below and accept the permissions request. Paste the "
+"received URL below."
+msgstr ""
+
+msgid "Waiting for gateway to generate URL..."
+msgstr ""
+
+msgid "Device ID"
+msgstr ""
+
+msgid "Device Type"
+msgstr ""
+
+msgid "Remove this item?"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+msgid "Are you sure you want to remove {{type}} \"{{deviceId}}\"?"
+msgstr ""
+
+msgid "Attached Subdevices"
 msgstr ""
 
 msgid "URL"
@@ -776,9 +828,6 @@ msgid "Make ready commands"
 msgstr ""
 
 msgid "Remove this command?"
-msgstr ""
-
-msgid "Remove"
 msgstr ""
 
 msgid "Are you sure you want to remove this command?"
@@ -817,6 +866,21 @@ msgstr ""
 msgid "Base path is a network share"
 msgstr ""
 
+msgid "Quantel HTTP Transfomer URL"
+msgstr ""
+
+msgid "Quantel Gateway URL"
+msgstr ""
+
+msgid "Quantel ISA URL"
+msgstr ""
+
+msgid "Zone ID (leave blank for default)"
+msgstr ""
+
+msgid "Quantel Server ID"
+msgstr ""
+
 msgid "Media Flow ID"
 msgstr ""
 
@@ -851,18 +915,6 @@ msgid "Media Scanner Host"
 msgstr ""
 
 msgid "Media Scanner Port"
-msgstr ""
-
-msgid "Quantel Gateway URL"
-msgstr ""
-
-msgid "Quantel ISA URL"
-msgstr ""
-
-msgid "Zone ID (leave blank for default)"
-msgstr ""
-
-msgid "Quantel Server ID"
 msgstr ""
 
 msgid "No. of Available Workers"
@@ -901,12 +953,6 @@ msgstr ""
 msgid "Monitors"
 msgstr ""
 
-msgid "Attached Subdevices"
-msgstr ""
-
-msgid "Device ID"
-msgstr ""
-
 msgid "Primary ID (Newsroom System MOS ID)"
 msgstr ""
 
@@ -932,9 +978,6 @@ msgid "Device id"
 msgstr ""
 
 msgid "Disable"
-msgstr ""
-
-msgid "Device Type"
 msgstr ""
 
 msgid "Thread Usage"
@@ -1009,30 +1052,10 @@ msgstr ""
 msgid "Connect some devices to the playout gateway"
 msgstr ""
 
-msgid "Spreadsheet credentials succesfully uploaded."
-msgstr ""
-
-msgid "Failed to upload spreadsheet credentials: {{errorMessage}}"
-msgstr ""
-
-msgid "Application credentials"
-msgstr ""
-
 msgid ""
 "Go to the url below and click on the \"Enable the Drive API\" button. Then "
 "click on \"Download Client configuration\", save the credentials.json file "
 "and upload it here."
-msgstr ""
-
-msgid "Access token"
-msgstr ""
-
-msgid ""
-"Click on the link below and accept the permissions request. Paste the "
-"received URL below."
-msgstr ""
-
-msgid "Waiting for gateway to generate URL..."
 msgstr ""
 
 msgid "Drive folder name"
@@ -1381,12 +1404,6 @@ msgid "Internal ID"
 msgstr ""
 
 msgid "Source Type"
-msgstr ""
-
-msgid "Is unlimited"
-msgstr ""
-
-msgid "Is on clean PGM"
 msgstr ""
 
 msgid "Is a Live Remote Input"

--- a/meteor/lib/collections/PeripheralDeviceSettings/mediaManager.ts
+++ b/meteor/lib/collections/PeripheralDeviceSettings/mediaManager.ts
@@ -47,6 +47,7 @@ export interface MediaFlow {
 export enum StorageType {
 	LOCAL_FOLDER = 'local_folder',
 	FILE_SHARE = 'file_share',
+	QUANTEL_HTTP = 'quantel_http',
 	UNKNOWN = 'unknown'
 	// FTP = 'ftp',
 	// AWS_S3 = 'aws_s3'
@@ -62,6 +63,17 @@ export interface StorageSettings {
 		/** Only subscribed files can be listened to for changes */
 		onlySelectedFiles?: boolean
 		[key: string]: any
+	}
+}
+export interface QuantelHTTPStorage extends StorageSettings {
+	type: StorageType.QUANTEL_HTTP
+	options: {
+		transformerUrl: string
+		gatewayUrl: string
+		ISAUrl: string
+		zoneId: string | undefined
+		serverId: number
+		onlySelectedFiles: true
 	}
 }
 export interface LocalFolderStorage extends StorageSettings {

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -13387,9 +13387,9 @@
       }
     },
     "tv-automation-sofie-blueprints-integration": {
-      "version": "1.7.0-nightly-20191216-161547-344775e.0",
-      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.7.0-nightly-20191216-161547-344775e.0.tgz",
-      "integrity": "sha512-PFP2EEsYNgSJYeFzPl93GA6LjRaTxQeFdWDdfW4gEDcsel01qOyiASCKaJNWBZRAJGMhJnx61Mjja+MMHIYyaQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.7.0.tgz",
+      "integrity": "sha512-iRRiiN002HB2vSj+0r6V1T2AktmcrbCE8vBNkRaTCYpj5S/yENX8cwsBCEd2DJxD81ANiNXZEvR+/YGkh3D3sA==",
       "requires": {
         "moment": "2.22.2",
         "timeline-state-resolver-types": "3.16.0",

--- a/meteor/public/locales/nb/translations.json
+++ b/meteor/public/locales/nb/translations.json
@@ -267,6 +267,7 @@
     "Media Scanner Host": "Vert for mediascanner",
     "Media Scanner Port": "Port for mediascanner",
     "Quantel Gateway URL": "Quantel Gateway-adresse (url)",
+    "Quantel HTTP Transformer URL": "Quantel HTTP Transformer-adresse (url)",
     "Quantel ISA URL": "Quantel ISA-adresse (url)",
     "Zone ID (leave blank for default)": "Sone-id (la denne være tom for standardvalg)",
     "Quantel Server ID": "Quantel server-id",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature to add peripheral device settings, including configuration of the Quantel HTTP storage device, that allows media manager to connect to a Quantel HTTP transformer.

* **What is the current behavior?** (You can also link to an open issue here)

Quantel HTTP Storage, although provided as a prototype in media manager, is no configurable via Media Manager settings. Setting up this storage and flows will allow the expected media item workflow generator in media manager to create workflows that generate quantel metadata and previews.

* **What is the new behavior (if this is a feature change)?**

This ability to create and configure a Quantel HTTP storage. The ability to create a _media flow_ from the Quantel source storage to the location where previews and other assets are served from.

* **Other information**:

This PR is related to the addition of [Quantel metadata processing](https://github.com/nrkno/tv-automation-media-management/pull/16) in media manager.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
