### PR TITLE
fix: strip pre-release tags from version number when doing comparisons.

### DIFF
--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -177,7 +177,11 @@ function checkDatabaseVersion (
 	theyName: string
 ): { statusCode: StatusCode, messages: string[] } {
 
-	if (currentVersion) currentVersion = semver.clean(currentVersion)
+	if (currentVersion) {
+		// Strip any patches from the version:
+		const strippedVersion = semver.coerce(currentVersion)
+		if (strippedVersion) currentVersion = semver.valid(strippedVersion)
+	}
 
 	if (expectVersion) {
 		if (currentVersion) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug reported by @gundelsby:
> Using nightly builds results in the following error message:
check blueprintCompability_system: Integration version: Version mismatch: blueprint.integrationVersion version: "1.7.0-nightly-20191216-161547-344775e.0" does not satisfy expected version range of core.tv-automation-sofie-blueprints-integration: ">=1.7.0 <2.0.0" (Blueprint has to be updated)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
