### PR TITLE
Optimization: Lookahead max search distance

### DIFF
--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -634,6 +634,30 @@ const StudioMappings = translate()(class StudioMappings extends React.Component<
 												className='input text-input input-l'></EditAttribute>
 										</label>
 									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Lookahead Target Objects (Default = 1)')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'mappings.' + layerId + '.lookaheadDepth'}
+												obj={this.props.studio}
+												type='int'
+												collection={Studios}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Lookahead Maximum Search Distance (Default = unlimited/-1')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'mappings.' + layerId + '.lookaheadMaxSearchDistance'}
+												obj={this.props.studio}
+												type='int'
+												collection={Studios}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
 									{
 										mappingIsCasparCG(mapping) ?
 											this.renderCasparCGMappingSettings(layerId) :

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -1,4 +1,5 @@
 import { Meteor } from 'meteor/meteor'
+import { Mongo } from 'meteor/mongo'
 import { check } from 'meteor/check'
 import { Random } from 'meteor/random'
 import * as _ from 'underscore'

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -35,8 +35,9 @@ export function getLookeaheadObjects (rundownData: RundownData, studio: Studio):
 	}
 
 	_.each(studio.mappings || {}, (mapping: MappingExt, layerId: string) => {
-		const lookaheadDepth = mapping.lookahead === LookaheadMode.PRELOAD ? mapping.lookaheadDepth || 1 : 1 // TODO - test other modes
-		const lookaheadObjs = findLookaheadForlayer(rundownData, layerId, mapping.lookahead, lookaheadDepth)
+		const lookaheadTargetObjects = mapping.lookahead === LookaheadMode.PRELOAD ? mapping.lookaheadDepth || 1 : 1 // TODO - test other modes
+		const lookaheadMaxSearchDistance = mapping.lookaheadMaxSearchDistance !== undefined && mapping.lookaheadMaxSearchDistance >= 0 ? mapping.lookaheadMaxSearchDistance : undefined
+		const lookaheadObjs = findLookaheadForlayer(rundownData, layerId, mapping.lookahead, lookaheadTargetObjects, lookaheadMaxSearchDistance)
 
 		// Add the objects that have some timing info
 		_.each(lookaheadObjs.timed, (entry, i) => {
@@ -98,7 +99,8 @@ export function findLookaheadForlayer (
 	rundownData: RundownData,
 	layer: string,
 	mode: LookaheadMode,
-	lookaheadDepth: number
+	lookaheadTargetObjects: number,
+	lookaheadMaxSearchDistance?: number
 ): LookaheadResult {
 	let activeRundown: Rundown = rundownData.rundown
 
@@ -149,16 +151,18 @@ export function findLookaheadForlayer (
 		return { timed: [], future: [] }
 	}
 
-
 	const timeOrderedPartsWithPieces: PartInfoWithPieces[] = timeOrderedParts.map(part => ({
 		...part,
 		pieces: piecesUsingLayerByPart[part.partId] || []
 	}))
+	const lastAllowedPartIndex = lookaheadMaxSearchDistance !== undefined
+		? Math.min(currentPartIndex + 1 + lookaheadMaxSearchDistance, timeOrderedPartsWithPieces.length)
+		: timeOrderedPartsWithPieces.length
 
 	// Start by taking the value from the current (if any), or search forwards
 	let startingPartOnLayer: PartInfoWithPieces | undefined
 	let startingPartOnLayerIndex: number = -1
-	for (let i = currentPartIndex; i < timeOrderedPartsWithPieces.length; i++) {
+	for (let i = currentPartIndex; i < lastAllowedPartIndex; i++) {
 		const v = timeOrderedPartsWithPieces[i]
 		if (v.pieces.length > 0) {
 			startingPartOnLayer = v
@@ -203,7 +207,7 @@ export function findLookaheadForlayer (
 
 	// Loop over future parts until we have enough objects, or run out of parts
 	let nextPartOnLayerIndex = startingPartOnLayerIndex
-	while (nextPartOnLayerIndex !== -1 && res.future.length < lookaheadDepth) {
+	while (nextPartOnLayerIndex !== -1 && res.future.length < lookaheadTargetObjects) {
 		nextPartOnLayerIndex = _.findIndex(timeOrderedPartsWithPieces, (v, i) => i > nextPartOnLayerIndex && v.pieces.length > 0)
 
 		if (nextPartOnLayerIndex !== -1) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR adds a setting for "lookahead maxSearchDistance".
This limits how far ahead the lookahead will look for content. Improving performance in long running shows.