### PR TITLE
Various GUI fixes

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -89,9 +89,9 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 
 	handleKey = (e: KeyboardEvent) => {
 		if (this.props.show) {
-			if (e.code === 'Enter') {
+			if (e.key === 'Enter') {
 				if (!this.props.warning) this.handleAccept(e)
-			} else if (e.code === 'Escape') {
+			} else if (e.key === 'Escape') {
 				if (this.props.secondaryText) {
 					this.handleSecondary(e)
 				} else {

--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -90,7 +90,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 	handleKey = (e: KeyboardEvent) => {
 		if (this.props.show) {
 			if (e.code === 'Enter') {
-				this.handleAccept(e)
+				if (!this.props.warning) this.handleAccept(e)
 			} else if (e.code === 'Escape') {
 				if (this.props.secondaryText) {
 					this.handleSecondary(e)
@@ -203,7 +203,8 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 													}))
 												}
 												<button className={ClassNames('btn btn-primary', {
-													'right': this.props.secondaryText !== undefined
+													'right': this.props.secondaryText !== undefined,
+													'btn-warn': this.props.warning
 												})} onClick={this.handleAccept}>{this.props.acceptText}</button>
 											</div>
 										</dialog>
@@ -215,7 +216,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 				: null
 	}
 
-	private preventDefault (e: KeyboardEvent) {
+	private preventDefault = (e: KeyboardEvent) => {
 		e.preventDefault()
 		e.stopPropagation()
 	}
@@ -332,7 +333,9 @@ class ModalDialogGlobalContainer0 extends React.Component<Translated<IModalDialo
 				}
 			})
 			return (
-			<ModalDialog title	= {onQueue.title}
+			<ModalDialog
+				key				= {this.state.queue.length}
+				title			= {onQueue.title}
 				acceptText		= {onQueue.yes || t('Yes')}
 				secondaryText	= {onQueue.no || (!onQueue.acceptOnly ? t('No') : undefined)}
 				onAccept		= {this.onAccept}

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -142,5 +142,6 @@ mousetrap.addKeycodes({
 	107: 'numAdd',
 	109: 'numSub',
 	110: 'numDot',
-	111: 'numDiv'
+	111: 'numDiv',
+	187: 'add'
 })

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -143,5 +143,6 @@ mousetrap.addKeycodes({
 	109: 'numSub',
 	110: 'numDot',
 	111: 'numDiv',
-	187: 'add'
+	187: 'add',
+	188: 'comma'
 })

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -3,9 +3,15 @@ import * as _ from 'underscore'
 import { isEventInInputField } from './lib'
 import { isModalShowing } from './ModalDialog'
 
+interface IWrappedCallback {
+	allowInModal: boolean
+	isGlobal: boolean
+	original: (e: Event) => void
+}
+
 export namespace mousetrapHelper {
 	const _boundHotkeys: {
-		[key: string]: ((e: Event) => void)[]
+		[key: string]: IWrappedCallback[]
 	} = {}
 	const _callbackTags: {
 		[key: string]: (e: Event) => void
@@ -16,36 +22,41 @@ export namespace mousetrapHelper {
 			return
 		}
 		// console.log(`Handling key combo "${keys}"`)
-		_boundHotkeys[keys].forEach((i) => {
-			i(e)
+		_boundHotkeys[keys].forEach((handler) => {
+			if (!handler.isGlobal && isEventInInputField(e)) return
+			e.preventDefault()
+			if (!handler.allowInModal && isModalShowing()) return
+			handler.original(e)
 		})
 	}
 
 	export function bindGlobal (keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
 		let index = keys
 		if (action) index = keys + '_' + action
-		if (_boundHotkeys[index] === undefined) {
-			_boundHotkeys[index] = []
+		if (
+			// if not yet bound
+			_boundHotkeys[index] === undefined ||
+			// or bound so far were not globals
+			_boundHotkeys[index].reduce((mem, i) => mem || i.isGlobal, false) === false
+		) {
+			if (_boundHotkeys[index] === undefined) _boundHotkeys[index] = []
 			mousetrap.bindGlobal(keys, (e: ExtendedKeyboardEvent) => {
 				handleKey(index, e)
 			}, action)
 		}
 		// console.log(`Registering callback for key combo "${keys}"`)
 
-		const callbackWrap = (e: Event) => {
-			if (isEventInInputField(e)) return
-			e.preventDefault()
-			if (!allowInModal && isModalShowing()) return
-
-			callback(e)
-		}
-		_boundHotkeys[index].push(callbackWrap)
+		_boundHotkeys[index].push({
+			isGlobal: true,
+			allowInModal: !!allowInModal,
+			original: callback
+		})
 
 		if (tag) {
 			if (_callbackTags[index + '_' + tag]) {
 				throw new Error(`Globalbind: Callback with tag "${tag}" already exists for ${index}!`)
 			}
-			_callbackTags[index + '_' + tag] = callbackWrap
+			_callbackTags[index + '_' + tag] = callback
 		}
 	}
 
@@ -60,20 +71,17 @@ export namespace mousetrapHelper {
 		}
 		// console.log(`Registering callback for key combo "${keys}"`)
 
-		const callbackWrap = (e: Event) => {
-			if (isEventInInputField(e)) return
-			e.preventDefault()
-			if (!allowInModal && isModalShowing()) return
-
-			callback(e)
-		}
-		_boundHotkeys[index].push(callbackWrap)
+		_boundHotkeys[index].push({
+			isGlobal: false,
+			allowInModal: !!allowInModal,
+			original: callback
+		})
 
 		if (tag) {
 			if (_callbackTags[index + '_' + tag]) {
 				throw new Error(`Bind: Callback with tag "${tag}" already exists for ${index}!`)
 			}
-			_callbackTags[index + '_' + tag] = callbackWrap
+			_callbackTags[index + '_' + tag] = callback
 		}
 	}
 
@@ -101,14 +109,18 @@ export namespace mousetrapHelper {
 			}
 		}
 
+		if (!callback) throw new Error(`Callback could not be located`)
+
 		if (_boundHotkeys[index] === undefined) return
-		const callbackIndex = _boundHotkeys[index].findIndex(val => val === callback)
+		const callbackIndex = _boundHotkeys[index].findIndex((i) => i.original === callback)
 		if (callbackIndex >= 0) {
 			_boundHotkeys[index].splice(callbackIndex, 1)
 			if (tag) {
 				// cleanup callback tags to avoid memory leaks
 				delete _callbackTags[index + '_' + tag]
 			}
+		} else {
+			console.log('Callback not found in list for ', index)
 		}
 		if (_boundHotkeys[index].length === 0) {
 			delete _boundHotkeys[index]

--- a/meteor/client/lib/viewPort.ts
+++ b/meteor/client/lib/viewPort.ts
@@ -48,7 +48,8 @@ export function scrollToPart (partId: string, forceScroll?: boolean, noAnimation
 	return Promise.reject('Could not find part')
 }
 
-const HEADER_HEIGHT = 175
+export const HEADER_HEIGHT = 54 // was: 150
+export const HEADER_MARGIN = 15
 
 export function scrollToSegment (elementToScrollToOrSegmentId: HTMLElement | string, forceScroll?: boolean, noAnimation?: boolean): Promise<boolean> {
 	let elementToScrollTo: HTMLElement | null = (
@@ -68,7 +69,7 @@ export function scrollToSegment (elementToScrollToOrSegmentId: HTMLElement | str
 	// check if the item is in viewport
 	if (forceScroll ||
 		bottom > window.scrollY + window.innerHeight ||
-		top < window.scrollY + HEADER_HEIGHT) {
+		top < window.scrollY + HEADER_HEIGHT + HEADER_MARGIN) {
 
 		return scrollToPosition(top, noAnimation).then(() => true)
 	}
@@ -80,7 +81,7 @@ export function scrollToPosition (scrollPosition: number, noAnimation?: boolean)
 	if (noAnimation) {
 		return new Promise((resolve, reject) => {
 			window.scroll({
-				top: Math.max(0, scrollPosition - HEADER_HEIGHT),
+				top: Math.max(0, scrollPosition - HEADER_HEIGHT - HEADER_MARGIN),
 				left: 0
 			})
 			resolve()
@@ -89,7 +90,7 @@ export function scrollToPosition (scrollPosition: number, noAnimation?: boolean)
 		return new Promise((resolve, reject) => {
 			window.requestIdleCallback(() => {
 				window.scroll({
-					top: Math.max(0, scrollPosition - HEADER_HEIGHT),
+					top: Math.max(0, scrollPosition - HEADER_HEIGHT - HEADER_MARGIN),
 					left: 0,
 					behavior: 'smooth'
 				})

--- a/meteor/client/main.js
+++ b/meteor/client/main.js
@@ -10,7 +10,13 @@ import App from './ui/App.js';
 if ('serviceWorker' in navigator) {
   // Use the window load event to keep the page load performant
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+    // in some versions of Chrome, registering the Service Worker over HTTP throws
+    // an arror
+    if (window.location.protocol === 'https:') {
+      navigator.serviceWorker.register('/sw.js').catch((err) => {
+        console.error(err)
+      });
+    }
   });
 }
  

--- a/meteor/client/styles/modalDialog.scss
+++ b/meteor/client/styles/modalDialog.scss
@@ -14,3 +14,14 @@
 .dark .border-box {
 	color: #fff;
 }
+
+.btn.btn-primary.btn-warn {
+	background: #E62421;
+	border-color: #E62421;
+	color: #FFFFFF;
+}
+
+.btn.btn-secondary.btn-warn {
+	border-color: #E62421;
+	color: #E62421;
+}

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -197,5 +197,13 @@
 			text-shadow: 1px 1px 0 rgba(0,0,0,0.5);
 			z-index: 2;
 		}
+
+		> svg {
+			position: absolute;
+			top: 0;
+			left: 0;
+			height: 100%;
+			width: 100%;
+		}
 	}
 }

--- a/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
+++ b/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Piece } from '../../../../lib/collections/Pieces'
+import { PieceGeneric } from '../../../../lib/collections/Pieces'
 import { SplitsContent, SourceLayerType } from 'tv-automation-sofie-blueprints-integration'
 
 // @todo: use colours from the scss
 // @todo: split can use any source (rather than cam + live)
-export default class SplitInputIcon extends React.Component<{ abbreviation?: string, piece?: Piece }> {
-	getCameraLabel (piece: Piece | undefined) {
+export default class SplitInputIcon extends React.Component<{ abbreviation?: string, piece?: PieceGeneric, hideLabel?: boolean }> {
+	getCameraLabel (piece: PieceGeneric | undefined) {
 		if (piece && piece.content) {
 			let c = piece.content as SplitsContent
 			const camera = c.boxSourceConfiguration.find(i => i.type === SourceLayerType.CAMERA)
@@ -35,7 +35,7 @@ export default class SplitInputIcon extends React.Component<{ abbreviation?: str
 		return ''
 	}
 
-	getLeftSourceType (piece: Piece | undefined): string {
+	getLeftSourceType (piece: PieceGeneric | undefined): string {
 		if (piece && piece.content) {
 			let c = piece.content as SplitsContent
 			const left = (c.boxSourceConfiguration[0] || {}).type || SourceLayerType.CAMERA
@@ -44,7 +44,7 @@ export default class SplitInputIcon extends React.Component<{ abbreviation?: str
 		return 'camera'
 	}
 
-	getRightSourceType (piece: Piece | undefined): string {
+	getRightSourceType (piece: PieceGeneric | undefined): string {
 		if (piece && piece.content) {
 			let c = piece.content as SplitsContent
 			const right = (c.boxSourceConfiguration[1] || {}).type || SourceLayerType.REMOTE
@@ -56,14 +56,14 @@ export default class SplitInputIcon extends React.Component<{ abbreviation?: str
 
 	render () {
 		return (
-			<svg className='piece_icon' version='1.1' viewBox='0 0 126.5 89' xmlns='http://www.w3.org/2000/svg'>
+			<svg className='piece_icon' version='1.1' viewBox='0 0 126.5 89' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'>
 				<rect width='126.5' height='44.5' className={this.getLeftSourceType(this.props.piece)} />
 				<rect width='126.5' height='44.5' y='44.5' className={this.getRightSourceType(this.props.piece)} />
-				<text x='9.6414976' textLength='106.5' y='71.513954' textAnchor='middle' style={{ fill: '#ffffff', 'fontFamily': 'open-sans', 'fontSize': '40px', 'letterSpacing': '0px', 'lineHeight': '1.25', 'wordSpacing': '0px', 'textShadow': '0 2px 9px rgba(0, 0, 0, 0.5)' }} xmlSpace='preserve'>
+				{!this.props.hideLabel && <text x='9.6414976' textLength='106.5' y='71.513954' textAnchor='middle' style={{ fill: '#ffffff', 'fontFamily': 'open-sans', 'fontSize': '40px', 'letterSpacing': '0px', 'lineHeight': '1.25', 'wordSpacing': '0px', 'textShadow': '0 2px 9px rgba(0, 0, 0, 0.5)' }} xmlSpace='preserve'>
 					<tspan x='63.25' y='71.513954' textLength='106.5' lengthAdjust='spacingAndGlyphs' style={{ fill: '#ffffff', 'fontFamily': 'Roboto', 'fontSize': '75px', 'fontWeight': 100 }}>{
 						this.getCameraLabel(this.props.piece)
 					}</tspan>
-				</text>
+				</text>}
 			</svg>
 		)
 	}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -253,13 +253,17 @@ class extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 							{RundownUtils.formatDiffToTimecode(this.props.rundown.startedPlayback - this.props.rundown.expectedStart, true, false, true, true, true)}
 						</span>
 					:
-					this.props.rundown.expectedStart &&
+					(this.props.rundown.expectedStart ?
 						<span className={ClassNames('timing-clock countdown plan-start left', {
 							'heavy': getCurrentTime() > this.props.rundown.expectedStart
 						})}>
 							<span className='timing-clock-label left hide-overflow rundown-name' title={this.props.rundown.name}>{this.props.rundown.name}</span>
 							{RundownUtils.formatDiffToTimecode(getCurrentTime() - this.props.rundown.expectedStart, true, false, true, true, true)}
 						</span>
+						:
+						<span className={ClassNames('timing-clock countdown plan-start left')}>
+							<span className='timing-clock-label left hide-overflow rundown-name' title={this.props.rundown.name}>{this.props.rundown.name}</span>
+						</span>) || undefined
 				}
 				<span className='timing-clock time-now'>
 					<Moment interval={0} format='HH:mm:ss' date={getCurrentTime()} />

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -247,11 +247,14 @@ class extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 					</span>
 				}
 				{ this.props.rundown.startedPlayback && (this.props.rundown.active && !this.props.rundown.rehearsal) ?
-					this.props.rundown.expectedStart &&
+					(this.props.rundown.expectedStart ?
 						<span className='timing-clock countdown playback-started left'>
 							<span className='timing-clock-label left hide-overflow rundown-name' title={this.props.rundown.name}>{this.props.rundown.name}</span>
 							{RundownUtils.formatDiffToTimecode(this.props.rundown.startedPlayback - this.props.rundown.expectedStart, true, false, true, true, true)}
-						</span>
+						</span> :
+						<span className='timing-clock countdown playback-started left'>
+							<span className='timing-clock-label left hide-overflow rundown-name' title={this.props.rundown.name}>{this.props.rundown.name}</span>
+						</span>)
 					:
 					(this.props.rundown.expectedStart ?
 						<span className={ClassNames('timing-clock countdown plan-start left', {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -820,6 +820,7 @@ const RundownHeader = translate()(class extends React.Component<Translated<IRund
 					doModalDialog({
 						title: this.props.rundown.name,
 						message: t('Are you sure you want to deactivate this Rundown?\n(This will clear the outputs)'),
+						warning: true,
 						onAccept: () => {
 							doUserAction(t, e, UserActionAPI.methods.deactivate, [this.props.rundown._id])
 						}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1109,9 +1109,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		}).fetch()) || undefined,
 		rundownLayoutId: String(params['layout'])
 	}
-})(
-class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
-
+})(class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
+		private readonly LIVELINE_HISTORY_SIZE = 100
+		
 	private bindKeys: Array<{
 		key: string,
 		up?: (e: KeyboardEvent) => any,
@@ -1356,21 +1356,21 @@ class extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		if (this.props.showStyleBase) {
 			_.each(this.props.showStyleBase.runtimeArguments, (i) => {
 				const combos = i.hotkeys.split(',')
-				_.each(combos, (combo: string) => {
-					const handler = (e: KeyboardEvent) => {
-						if (this.props.rundown && this.props.rundown.active && this.props.rundown.nextPartId) {
-							doUserAction(t, e, UserActionAPI.methods.togglePartArgument, [
-								this.props.rundown._id, this.props.rundown.nextPartId, i.property, i.value
-							])
-						}
+				const handler = (e: KeyboardEvent) => {
+					if (this.props.rundown && this.props.rundown.active && this.props.rundown.nextPartId) {
+						doUserAction(t, e, UserActionAPI.methods.togglePartArgument, [
+							this.props.rundown._id, this.props.rundown.nextPartId, i.property, i.value
+						])
 					}
+				}
+				_.each(combos, (combo: string) => {
+					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
+					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
 					this.usedArgumentKeys.push({
 						up: handler,
 						key: combo,
 						label: i.label || ''
 					})
-					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
-					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
 				})
 			})
 		}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -392,8 +392,8 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 					key={this.props.segment._id + '-liveline-shade'}
 					style={{
 						'width': (this.props.followLiveLine ?
-							Math.min(pixelPostion, this.props.liveLineHistorySize).toString() :
-							pixelPostion.toString()
+							Math.min(Math.max(0, pixelPostion), this.props.liveLineHistorySize).toString() :
+							Math.max(0, pixelPostion).toString()
 						) + 'px'
 					}} />,
 				<div className='segment-timeline__liveline'

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -513,7 +513,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 					<h2>
 						{this.props.segment.name}
 					</h2>
-					<div className='segment-timeline__title__notes'>
+					{(criticalNotes > 0 || warningNotes > 0) && <div className='segment-timeline__title__notes'>
 						{criticalNotes > 0 && <div className='segment-timeline__title__notes__note'
 							onClick={(e) => this.props.onHeaderNoteClick && this.props.onHeaderNoteClick(NoteType.ERROR)}>
 							<img className='icon' src='/icons/warning_icon.svg' />
@@ -534,7 +534,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 								</b>
 							</div>
 						</div>}
-					</div>
+					</div>}
 				</ContextMenuTrigger>
 				<div className='segment-timeline__duration' tabIndex={0}
 					onClick={(e) => this.props.onCollapseSegmentToggle && this.props.onCollapseSegmentToggle(e)}>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -264,6 +264,10 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 	setSegmentRef = (el: HTMLDivElement) => {
 		this.segmentBlock = el
 		if (typeof this.props.segmentRef === 'function') this.props.segmentRef(this as any, this.props.segment._id)
+
+		if (this.segmentBlock) {
+			this.segmentBlock.addEventListener('wheel', this.onTimelineWheel, { passive: false, capture: true })
+		}
 	}
 
 	setTimelineRef = (el: HTMLDivElement) => {
@@ -565,9 +569,11 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 				<TimelineGrid {...this.props}
 					onResize={this.onTimelineResize} />
 				<div className='segment-timeline__timeline-container'
-					onTouchStartCapture={this.onTimelineTouchStart}
-					onWheelCapture={this.onTimelineWheel}>
-					<div className='segment-timeline__timeline' key={this.props.segment._id + '-timeline'} ref={this.setTimelineRef} style={this.timelineStyle()}>
+					onTouchStartCapture={this.onTimelineTouchStart}>
+					<div className='segment-timeline__timeline'
+						key={this.props.segment._id + '-timeline'}
+						ref={this.setTimelineRef}
+						style={this.timelineStyle()}>
 						<ErrorBoundary>
 							{this.renderTimeline()}
 							{this.renderEndOfSegment()}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -21,7 +21,7 @@ import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { getSpeakingMode } from '../../lib/localStorage'
 import { NoteType, PartNote } from '../../../lib/api/notes'
 import { getElementWidth } from '../../utils/dimensions'
-import { isMaintainingFocus, scrollToSegment } from '../../lib/viewPort'
+import { isMaintainingFocus, scrollToSegment, HEADER_HEIGHT } from '../../lib/viewPort'
 import { PubSub } from '../../../lib/api/pubsub'
 
 const SPEAK_ADVANCE = 500
@@ -352,7 +352,7 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 			// As of Chrome 76, IntersectionObserver rootMargin works in screen pixels when root
 			// is viewport. This seems like an implementation bug and IntersectionObserver is
 			// an Experimental Feature in Chrome, so this might change in the future.
-			rootMargin: `-${150 * zoomFactor}px 0px -${20 * zoomFactor}px 0px`,
+			rootMargin: `-${HEADER_HEIGHT * zoomFactor}px 0px -${20 * zoomFactor}px 0px`,
 			threshold: [0, 0.25, 0.5, 0.75, 0.98]
 		})
 		this.intersectionObserver.observe(this.timelineDiv.parentElement!.parentElement!)

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -374,7 +374,14 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 					}
 					<div className='mod mvs mhs'>
 						<label className='field'>
-							{t('Source Layers')}
+							{t('Overflow horizontally')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.overflowHorizontally`}
+								obj={item}
+								type='checkbox'
+								collection={RundownLayouts}
+								className='mod mas' />
 						</label>
 						<EditAttribute
 							modifiedClassName='bghl'

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -54,6 +54,18 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 		super(props)
 	}
 
+	componentDidMount () {
+		Meteor.defer(() => {
+			this.updateMediaObjectSubscription()
+		})
+	}
+
+	componentDidUpdate () {
+		Meteor.defer(() => {
+			this.updateMediaObjectSubscription()
+		})
+	}
+
 	updateMediaObjectSubscription () {
 		if (this.props.item && this.props.layer) {
 			const piece = this.props.item as any as AdLibPieceUi

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -559,7 +559,8 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 	}
 
 	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		if (this.props.liveSegment && this.props.liveSegment !== prevProps.liveSegment && this.state.followLive) {
@@ -573,8 +574,8 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -583,28 +584,28 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 		if (!this.props.studioMode) return
 		if (!this.props.registerHotkeys) return
 
-		let preventDefault = (e) => {
+		const preventDefault = (e) => {
 			e.preventDefault()
 		}
 
 		if (this.props.liveSegment && this.props.liveSegment.pieces) {
 			this.props.liveSegment.pieces.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -168,7 +168,8 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 	}
 
 	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		this.refreshKeyboardHotkeys()
@@ -176,8 +177,8 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -200,21 +201,21 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 		if (this.props.liveSegment && this.props.liveSegment.pieces) {
 			this.props.liveSegment.pieces.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -224,21 +225,21 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 		if (this.props.rundownBaselineAdLibs) {
 			this.props.rundownBaselineAdLibs.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -249,11 +250,11 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 			_.each(this.props.sourceLayerLookup, (item) => {
 				if (item.clearKeyboardHotkey) {
 					item.clearKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onClearAllSourceLayer(item, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 
@@ -261,11 +262,11 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 
 				if (item.isSticky && item.activateStickyKeyboardHotkey) {
 					item.activateStickyKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleSticky(item._id, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 				}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -8,12 +8,13 @@ import { DefaultListItemRenderer } from './Renderers/DefaultLayerItemRenderer'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { mousetrapHelper } from '../../lib/mousetrapHelper'
 import { RundownUtils } from '../../lib/rundown'
-import { ISourceLayer, IOutputLayer, SourceLayerType, VTContent, LiveSpeakContent } from 'tv-automation-sofie-blueprints-integration'
+import { ISourceLayer, IOutputLayer, SourceLayerType, VTContent, LiveSpeakContent, SplitsContent } from 'tv-automation-sofie-blueprints-integration'
 import { AdLibPieceUi } from './AdLibPanel'
 import { MediaObject } from '../../../lib/collections/MediaObjects'
 import { checkPieceContentStatus } from '../../../lib/mediaObjects'
 import { Rundown } from '../../../lib/collections/Rundowns'
 import { PubSub } from '../../../lib/api/pubsub'
+import SplitInputIcon from '../PieceIcons/Renderers/SplitInput'
 
 export interface IAdLibListItem {
 	_id: string,
@@ -121,6 +122,16 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 		}
 	}
 
+	renderSplits () {
+		const splitAdLib = this.props.item as AdLibPieceUi
+		if (splitAdLib && splitAdLib.content) {
+			const splitContent = splitAdLib.content as SplitsContent
+			return (
+				<SplitInputIcon abbreviation={this.props.layer.abbreviation} piece={splitAdLib} hideLabel={true} />
+			)
+		}
+	}
+
 	render () {
 		return (
 			<div className={ClassNames('dashboard-panel__panel__button', {
@@ -140,8 +151,10 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 				data-obj-id={this.props.item._id}
 				>
 				{
-					(this.props.layer.type === SourceLayerType.VT || this.props.layer.type === SourceLayerType.LIVE_SPEAK || true) ?
+					(this.props.layer.type === SourceLayerType.VT || this.props.layer.type === SourceLayerType.LIVE_SPEAK) ?
 						this.renderVTLiveSpeak() :
+					(this.props.layer.type === SourceLayerType.SPLITS) ?
+						this.renderSplits() :
 						null
 				}
 				<span className='dashboard-panel__panel__button__label'>{this.props.item.name}</span>

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -59,6 +59,18 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 		super(props)
 	}
 
+	componentDidMount () {
+		Meteor.defer(() => {
+			this.updateMediaObjectSubscription()
+		})
+	}
+
+	componentDidUpdate () {
+		Meteor.defer(() => {
+			this.updateMediaObjectSubscription()
+		})
+	}
+
 	updateMediaObjectSubscription () {
 		if (this.props.item && this.props.layer) {
 			const piece = this.props.item as any as AdLibPieceUi

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -339,7 +339,8 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 	}
 
 	componentDidUpdate (prevProps: IProps & ITrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 		this.usedHotkeys.length = 0
 
 		this.refreshKeyboardHotkeys()
@@ -347,8 +348,8 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 
 	componentWillUnmount () {
 		this._cleanUp()
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup')
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown')
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.constructor.name)
+		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', this.constructor.name)
 
 		this.usedHotkeys.length = 0
 	}
@@ -363,21 +364,21 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		if (this.props.rundownAdLibs) {
 			this.props.rundownAdLibs.forEach((item) => {
 				if (item.hotkey) {
-					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown')
+					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', this.constructor.name)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
 						this.onToggleAdLib(item, false, e)
-					}, 'keyup')
+					}, 'keyup', this.constructor.name)
 					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
-						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown')
+						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleAdLib(item, true, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(queueHotkey)
 					}
 				}
@@ -388,11 +389,11 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 			_.each(this.props.sourceLayerLookup, (item) => {
 				if (item.clearKeyboardHotkey) {
 					item.clearKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onClearAllSourceLayer(item, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 
@@ -400,11 +401,11 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 
 				if (item.isSticky && item.activateStickyKeyboardHotkey) {
 					item.activateStickyKeyboardHotkey.split(',').forEach(element => {
-						mousetrapHelper.bind(element, preventDefault, 'keydown')
+						mousetrapHelper.bind(element, preventDefault, 'keydown', this.constructor.name)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
 							this.onToggleSticky(item._id, e)
-						}, 'keyup')
+						}, 'keyup', this.constructor.name)
 						this.usedHotkeys.push(element)
 					})
 				}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -24,6 +24,8 @@ import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { DashboardPanel } from './DashboardPanel'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
+import { ExternalFramePanel } from './ExternalFramePanel'
+import { TimelineDashboardPanel } from './TimelineDashboardPanel'
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
@@ -338,15 +340,34 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 		return <div className='dashboard'>
 			{rundownLayout.filters
 				.sort((a, b) => a.rank - b.rank)
-				.map((f: DashboardLayoutFilter) =>
-					<DashboardPanel
-						key={f._id}
-						includeGlobalAdLibs={true}
-						filter={f}
-						visible={true}
-						registerHotkeys={true}
-						{...this.props}
-						/>
+				.map((panel) =>
+					RundownLayoutsAPI.isFilter(panel) ?
+						(panel as DashboardLayoutFilter).showAsTimeline ?
+							<TimelineDashboardPanel
+								key={panel._id}
+								includeGlobalAdLibs={true}
+								filter={panel}
+								visible={!(panel as DashboardLayoutFilter).hide}
+								registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
+								{...this.props}
+								/> :
+							<DashboardPanel
+								key={panel._id}
+								includeGlobalAdLibs={true}
+								filter={panel}
+								visible={!(panel as DashboardLayoutFilter).hide}
+								registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
+								{...this.props}
+								/> :
+					RundownLayoutsAPI.isExternalFrame(panel) ?
+						<ExternalFramePanel
+							key={panel._id}
+							panel={panel}
+							layout={rundownLayout}
+							visible={true}
+							{...this.props}
+							/> :
+						undefined
 			)}
 		</div>
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR features various GUI fixes and minor features:

**Minor features**
* Use both numpad enter and normal enter to accept ModalDialogs (#9b767795)
* Display rundown name if no start-time set (#4f39a852)

**Bug fixes**
* Segment viewport manipulation using scroll wheel (#2760997d)
* Segment notes: don't take up space if not present (#be78315f)
* Guard against negative width of liveline shade (#0bf16a40)
* Shelf hiding (#d23586f0)
* In-viewport detection and scrolling (#e7d9ec7b)
* Resolve issues with hotkeys in ModialDialogs (#b3fd84c0)
* Update mediaObject subscriptions for AdLibListItems and DashboardPieceButtons (#2e69fe8d)
* Check if loaded over https before trying to register service worker (#c4b98037)
* Hotkey overlap crash (#135) (#b9399bf1)
* Adds comma mapping for mousetrap (#afa3cd0e)
* Add support for nun-numeric plus, code 187/"Minus" (#3d132267)
* Show Split preview in dashboard button (#8fc3fcc9)