### PR TITLE
Better Ingest-data management & unsync handling

### DIFF
--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -91,13 +91,41 @@ export function saveIntoDb<DocClass extends DBInterface, DBInterface extends DBO
 	collection: TransformedCollection<DocClass, DBInterface>,
 	filter: MongoSelector<DBInterface>,
 	newData: Array<DBInterface>,
-	optionsOrg?: SaveIntoDbOptions<DocClass, DBInterface>
+	options?: SaveIntoDbOptions<DocClass, DBInterface>
 ): Changes {
-	let change: Changes = {
-		added: 0,
-		updated: 0,
-		removed: 0
+
+	const preparedChanges = prepareSaveIntoDb(
+		collection,
+		filter,
+		newData,
+		options
+	)
+
+	return savePreparedChanges(
+		preparedChanges,
+		collection,
+		options
+	)
+}
+export interface PreparedChanges<T> {
+	inserted: T[]
+	changed: {doc: T, oldId: string}[]
+	removed: T[]
+	unchanged: T[]
+}
+export function prepareSaveIntoDb<DocClass extends DBInterface, DBInterface extends DBObj> (
+	collection: TransformedCollection<DocClass, DBInterface>,
+	filter: MongoSelector<DBInterface>,
+	newData: Array<DBInterface>,
+	optionsOrg?: SaveIntoDbOptions<DocClass, DBInterface>
+): PreparedChanges<DBInterface> {
+	let preparedChanges: PreparedChanges<DBInterface> = {
+		inserted: [],
+		changed: [],
+		removed: [],
+		unchanged: []
 	}
+
 	const options: SaveIntoDbOptions<DocClass, DBInterface> = optionsOrg || {}
 
 	const identifier = '_id'
@@ -107,23 +135,18 @@ export function saveIntoDb<DocClass extends DBInterface, DBInterface extends DBO
 	const newObjIds: {[identifier: string]: true} = {}
 	_.each(newData, (o) => {
 		if (newObjIds[o[identifier]]) {
-			throw new Meteor.Error(500, `saveIntoDb into collection "${collection.rawCollection.name}": Duplicate identifier ${identifier}: "${o[identifier]}"`)
+			throw new Meteor.Error(500, `prepareSaveIntoDb into collection "${(collection as any)._name}": Duplicate identifier ${identifier}: "${o[identifier]}"`)
 		}
 		newObjIds[o[identifier]] = true
 	})
 
 	const oldObjs: Array<DocClass> = waitForPromise(pOldObjs)
 
-	const ps: Array<Promise<any>> = []
-
 	const removeObjs: {[id: string]: DocClass} = {}
-	_.each(oldObjs,function (o: DocClass) {
-
+	_.each(oldObjs, (o: DocClass) => {
 		if (removeObjs['' + o[identifier]]) {
 			// duplicate id:
-			// collection.remove(o._id)
-			ps.push(asyncCollectionRemove(collection, o._id))
-			change.removed++
+			preparedChanges.removed.push(o)
 		} else {
 			removeObjs['' + o[identifier]] = o
 		}
@@ -138,42 +161,16 @@ export function saveIntoDb<DocClass extends DBInterface, DBInterface extends DBO
 			const eql = compareObjs(oldObj, o2)
 
 			if (!eql) {
-				let p: Promise<any> | undefined
 				let oUpdate = (options.beforeUpdate ? options.beforeUpdate(o, oldObj) : o)
-				if (options.update) {
-					options.update(oldObj._id, oUpdate)
-				} else {
-					p = asyncCollectionUpdate(collection, oldObj._id, oUpdate)
-				}
-				if (options.afterUpdate) {
-					p = Promise.resolve(p)
-					.then(() => {
-						if (options.afterUpdate) options.afterUpdate(oUpdate)
-					})
-				}
-
-				if (p) ps.push(p)
-				change.updated++
+				preparedChanges.changed.push({ doc: oUpdate, oldId: oldObj._id})
 			} else {
-				if (options.unchanged) options.unchanged(oldObj)
+				preparedChanges.unchanged.push(oldObj)
 			}
 		} else {
 			if (!_.isNull(oldObj)) {
 				let p: Promise<any> | undefined
 				let oInsert = (options.beforeInsert ? options.beforeInsert(o) : o)
-				if (options.insert) {
-					options.insert(oInsert)
-				} else {
-					p = asyncCollectionInsert(collection, oInsert)
-				}
-				if (options.afterInsert) {
-					p = Promise.resolve(p)
-					.then(() => {
-						if (options.afterInsert) options.afterInsert(oInsert)
-					})
-				}
-				if (p) ps.push(p)
-				change.added++
+				preparedChanges.inserted.push(oInsert)
 			}
 		}
 		delete removeObjs['' + o[identifier]]
@@ -182,23 +179,94 @@ export function saveIntoDb<DocClass extends DBInterface, DBInterface extends DBO
 		if (obj) {
 			let p: Promise<any> | undefined
 			let oRemove: DBInterface = (options.beforeRemove ? options.beforeRemove(obj) : obj)
-			if (options.remove) {
-				options.remove(oRemove)
-			} else {
-				p = asyncCollectionRemove(collection, oRemove._id)
-			}
-
-			if (options.afterRemove) {
-				Promise.resolve(p)
-				.then(() => {
-					// console.log('+++ lib/lib.ts +++', Fiber.current)
-					if (options.afterRemove) options.afterRemove(oRemove)
-				})
-			}
-			change.removed++
-
+			preparedChanges.removed.push(oRemove)
 		}
 	})
+	return preparedChanges
+}
+export function savePreparedChanges<DocClass extends DBInterface, DBInterface extends DBObj> (
+	preparedChanges: PreparedChanges<DBInterface>,
+	collection: TransformedCollection<DocClass, DBInterface>,
+	optionsOrg?: SaveIntoDbOptions<DocClass, DBInterface>
+) {
+	let change: Changes = {
+		added: 0,
+		updated: 0,
+		removed: 0
+	}
+	const options: SaveIntoDbOptions<DocClass, DBInterface> = optionsOrg || {}
+
+	const ps: Array<Promise<any>> = []
+
+	const removeObjs: {[id: string]: DocClass} = {}
+
+	const newObjIds: {[identifier: string]: true} = {}
+	const checkInsertId = (id) => {
+		if (newObjIds[id]) {
+			throw new Meteor.Error(500, `savePreparedChanges into collection "${(collection as any)._name}": Duplicate identifier "${id}"`)
+		}
+		newObjIds[id] = true
+	}
+
+	_.each(preparedChanges.changed || [], oUpdate => {
+		checkInsertId(oUpdate.doc._id)
+		let p: Promise<any> | undefined
+		if (options.update) {
+			options.update(oUpdate.oldId, oUpdate.doc)
+		} else {
+			p = asyncCollectionUpdate(collection, oUpdate.oldId, oUpdate.doc)
+		}
+		if (options.afterUpdate) {
+			p = Promise.resolve(p)
+			.then(() => {
+				if (options.afterUpdate) options.afterUpdate(oUpdate.doc)
+			})
+		}
+
+		if (p) ps.push(p)
+		change.updated++
+	})
+
+	_.each(preparedChanges.inserted || [], oInsert => {
+		checkInsertId(oInsert._id)
+		let p: Promise<any> | undefined
+		if (options.insert) {
+			options.insert(oInsert)
+		} else {
+			p = asyncCollectionInsert(collection, oInsert)
+		}
+		if (options.afterInsert) {
+			p = Promise.resolve(p)
+			.then(() => {
+				if (options.afterInsert) options.afterInsert(oInsert)
+			})
+		}
+		if (p) ps.push(p)
+		change.added++
+	})
+
+	_.each(preparedChanges.removed || [], oRemove => {
+		let p: Promise<any> | undefined
+		if (options.remove) {
+			options.remove(oRemove)
+		} else {
+			p = asyncCollectionRemove(collection, oRemove._id)
+		}
+
+		if (options.afterRemove) {
+			p = Promise.resolve(p)
+			.then(() => {
+				if (options.afterRemove) options.afterRemove(oRemove)
+			})
+		}
+		if (p) ps.push(p)
+		change.removed++
+	})
+	if (options.unchanged) {
+		_.each(preparedChanges.unchanged || [], o => {
+			if (options.unchanged) options.unchanged(o)
+		})
+	}
 	waitForPromiseAll(ps)
 
 	if (options.afterRemoveAll) {

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -455,6 +455,7 @@ function diffAndApplyChanges (
 			return
 		} else {
 			// TODO: add logic for determining whether to allow changes to the currently playing Part.
+			// TODO: use isUpdateAllowed()
 		}
 	}
 

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -628,6 +628,7 @@ export function handleUpdatedPart (peripheralDevice: PeripheralDevice, rundownEx
 	})
 }
 export function handleUpdatedPartInner (studio: Studio, rundown: Rundown, segmentExternalId: string, ingestPart: IngestPart) {
+	// Updated OR created part
 	const segmentId = getSegmentId(rundown._id, segmentExternalId)
 	const partId = getPartId(rundown._id, ingestPart.externalId)
 
@@ -638,9 +639,9 @@ export function handleUpdatedPartInner (studio: Studio, rundown: Rundown, segmen
 		segmentId: segmentId,
 		rundownId: rundown._id
 	})
-	if (!part) throw new Meteor.Error(404, 'Part not found')
 
-	if (!isUpdateAllowed(rundown, {}, {}, { changed: [{ doc: part, oldId: part._id }] })) {
+	if (
+		part && !isUpdateAllowed(rundown, {}, {}, { changed: [{ doc: part, oldId: part._id }] })) {
 		ServerRundownAPI.unsyncRundown(rundown._id)
 	} else {
 

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -821,6 +821,19 @@ export function isUpdateAllowed (
 			}
 		}
 	}
+	if (!allowed) {
+		logger.debug(`rundownChanges: ${printChanges(rundownChanges)}`)
+		logger.debug(`segmentChanges: ${printChanges(segmentChanges)}`)
+		logger.debug(`partChanges: ${printChanges(partChanges)}`)
+	}
 	return allowed
 }
+function printChanges (changes: Optional<PreparedChanges<{_id: string}>>): string {
+	let str = ''
 
+	if (changes.changed)	str += _.map(changes.changed,	doc => 'change:' + doc.doc._id).join(',')
+	if (changes.inserted)	str += _.map(changes.inserted,	doc => 'insert:' + doc._id).join(',')
+	if (changes.removed)	str += _.map(changes.removed,	doc => 'remove:' + doc._id).join(',')
+
+	return str
+}

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -510,24 +510,23 @@ function updateSegmentFromIngestData (
 		rundownId: rundown._id
 	}, newSegment)
 
-		// Update segment info:
-		asyncCollectionUpsert(Segments, {
-			_id: segmentId,
-			rundownId: rundown._id
-		}, newSegment),
+	// Update segment info:
+	asyncCollectionUpsert(Segments, {
+		_id: segmentId,
+		rundownId: rundown._id
+	}, newSegment),
 
-		// Move over parts from other segments:
-		asyncCollectionUpdate(Parts, {
-			rundownId: rundown._id,
-			segmentId: { $ne: segmentId },
-			dynamicallyInserted: { $ne: true },
-			_id: { $in: _.pluck(parts, '_id') }
-		}, { $set: {
-			segmentId: segmentId
-		}}, {
-			multi: true
-		})
-	]))
+	// Move over parts from other segments:
+	asyncCollectionUpdate(Parts, {
+		rundownId: rundown._id,
+		segmentId: { $ne: segmentId },
+		dynamicallyInserted: { $ne: true },
+		_id: { $in: _.pluck(parts, '_id') }
+	}, { $set: {
+		segmentId: segmentId
+	}}, {
+		multi: true
+	})
 
 	const prepareSaveParts = prepareSaveIntoDb<Part, DBPart>(Parts, {
 		rundownId: rundown._id,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -298,10 +298,14 @@ export namespace ServerRundownAPI {
 		let rundown = Rundowns.findOne(rundownId)
 		if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
 
-		Rundowns.update(rundown._id, {$set: {
-			unsynced: true,
-			unsyncedTime: getCurrentTime()
-		}})
+		if (!rundown.unsynced) {
+			Rundowns.update(rundown._id, {$set: {
+				unsynced: true,
+				unsyncedTime: getCurrentTime()
+			}})
+		} else {
+			logger.info(`Rundown "${rundownId}" was already unsynced`)
+		}
 	}
 }
 export namespace ClientRundownAPI {


### PR DESCRIPTION
This PR contains some code updates for how ingest-data is handled.
It improves on how "unsynced" is determined and fixes some crucial bugs along the way.
This PR paves the path for the future "protecting primaries"-feature (that can be started on after PartInstances).
