### PR TITLE
Optimization when doing many Adlibs 

### DIFF
--- a/meteor/lib/collections/Pieces.ts
+++ b/meteor/lib/collections/Pieces.ts
@@ -61,6 +61,8 @@ export interface Piece extends PieceGeneric, IBlueprintPieceDB {
 	userDuration?: Pick<Timeline.TimelineEnable, 'duration' | 'end'>
 	/** This is set when the piece is infinite, to deduplicate the contents on the timeline, while allowing out of order */
 	infiniteMode?: PieceLifespan
+	/** [timestamp) After this time, the piece has definitely ended and its content can be omitted from the timeline */
+	definitelyEnded?: number
 	/** This is a backup of the original infiniteMode of the piece, so that the normal field can be modified during playback and restored afterwards */
 	originalInfiniteMode?: PieceLifespan
 	// /** This is the id of the original segment of an infinite piece chain. If it matches the id of itself then it is the first in the chain */

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -8,8 +8,11 @@ import { Part } from '../../../lib/collections/Parts'
 import { syncFunctionIgnore, syncFunction } from '../../codeControl'
 import { Piece, Pieces } from '../../../lib/collections/Pieces'
 import { getOrderedPiece, PieceResolved } from './pieces'
-import { asyncCollectionUpdate, waitForPromiseAll, asyncCollectionRemove, asyncCollectionInsert, normalizeArray, toc, makePromise, waitForPromise } from '../../../lib/lib'
+import { asyncCollectionUpdate, waitForPromiseAll, asyncCollectionRemove, asyncCollectionInsert, normalizeArray, toc, makePromise, waitForPromise, getCurrentTime } from '../../../lib/lib'
 import { logger } from '../../../lib/logging'
+
+/** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
+const DEFINITELY_ENDED_FUTURE_DURATION = 10 * 1000
 
 export const updateSourceLayerInfinitesAfterPart: (rundown: Rundown, previousPart?: Part, runUntilEnd?: boolean) => void
 = syncFunctionIgnore(updateSourceLayerInfinitesAfterPartInner)
@@ -253,6 +256,7 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 	for (const piece of pieces) {
 		ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
 			userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
+			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION,
 			infiniteMode: PieceLifespan.Normal,
 			originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
 		}}))

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -256,7 +256,7 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 	for (const piece of pieces) {
 		ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
 			userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
-			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION,
+			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION + (newPiece.adlibPreroll || 0),
 			infiniteMode: PieceLifespan.Normal,
 			originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
 		}}))

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -91,6 +91,7 @@ export function resetRundown (rundown: Rundown) {
 			playoutDuration: 1,
 			startedPlayback: 1,
 			userDuration: 1,
+			definitelyEnded: 1,
 			disabled: 1,
 			hidden: 1
 		}
@@ -231,6 +232,7 @@ function resetPart (part: DBPart): Promise<void> {
 		$unset: {
 			startedPlayback: 1,
 			userDuration: 1,
+			definitelyEnded: 1,
 			disabled: 1,
 			hidden: 1
 		}

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -688,6 +688,7 @@ function transformPartIntoTimeline (
 		if (piece.isTransition && (!allowTransition || isHold)) {
 			return
 		}
+		if (piece.definitelyEnded && piece.definitelyEnded < getCurrentTime()) return
 
 		if (piece.infiniteId && piece.infiniteId !== piece._id) {
 			piece._id = piece.infiniteId


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR adds an optimization for the situation where many adlibs are played while staying in one part.
This is fixed by adding a filter in Core that removes old-and-stopped-adlibs after a while, making calculations and timeline to run faster.
* **What is the current behavior?**
System slows down to a crawl after 15-30 adlibs (we experienced this when cutting between cameras)
* **What is the new behavior?**
Adds the property "definitelyEnded" to pieces to allow for efficient trimming of pieces that no longer need to be evaluated to calculate the current state, increasing performance.
