### PR TITLE
Feature: Dashboard panel improvements: timeline view, external frame

### DIFF
--- a/meteor/client/lib/invalidatingTime.ts
+++ b/meteor/client/lib/invalidatingTime.ts
@@ -1,0 +1,17 @@
+import { Tracker } from 'meteor/tracker'
+import { getCurrentTime } from '../../lib/lib'
+
+/** Invalidate a reactive computation after a given amount of time */
+export function invalidateAfter(timeout: number): void {
+	const time = new Tracker.Dependency
+	time.depend()
+	setTimeout(() => {
+		time.changed()
+	}, timeout)
+}
+
+/** Invalidate a reactive computation after when a given time is reached */
+export function invalidateAt(timestamp: number): void {
+	const timeout = Math.max(0, timestamp - getCurrentTime())
+	invalidateAfter(timeout)
+}

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -96,6 +96,34 @@
     	max-height: calc(100% - 12px);
 	}
 
+	.dashboard-panel__panel__group {
+		display: contents;
+
+		.dashboard-panel__panel__group__liveline {
+			display: inline-block;
+			position: relative;
+			margin-right: -2px;
+			width: 2px;
+			height: 6em;
+			margin-bottom: -1em;
+			background: var(--general-live-color);
+			transform: translate(-1px, 0);
+			z-index: 2;
+
+			&::before {
+				content: ' ';
+				display: block;
+				position: absolute;
+				top: 0;
+				left: 2px;
+				border-left: 10px solid var(--general-live-color);
+				border-bottom: 10px solid transparent;
+				border-top: 10px solid transparent;
+				border-right: 10px solid transparent;
+			}
+		}
+	}
+
 	.dashboard-panel__panel__button {
 		display: inline-flex;
   		align-items: flex-end;

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -93,7 +93,12 @@
 		font-size: 0.8em;
 		margin: -4px;
 		overflow: overlay;
-    	max-height: calc(100% - 12px);
+		max-height: calc(100% - 12px);
+		
+		&.dashboard-panel__panel--horizontal {
+			white-space: nowrap;
+			overflow: auto;
+		}
 	}
 
 	.dashboard-panel__panel__group {

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -1,6 +1,9 @@
 @import "../colorScheme";
 @import "../itemTypeColors";
 
+$dashboard-button-width: 6.40625em;
+$dashboard-button-height: 5.625em;
+
 .dashboard {
 	position: absolute;
 	top: 2px;
@@ -111,9 +114,20 @@
 			width: 2px;
 			height: 6em;
 			margin-bottom: -1em;
-			background: var(--general-live-color);
-			transform: translate(-1px, 0);
 			z-index: 2;
+			transform: translate(calc(-1 * #{$dashboard-button-width}), 0);
+			
+			&::after {
+				content: ' ';
+				display: block;
+				position: absolute;
+				background: var(--general-live-color);
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				transform: translate(calc(#{$dashboard-button-width} + -1px), 0);
+			}
 
 			&::before {
 				content: ' ';
@@ -125,6 +139,29 @@
 				border-bottom: 10px solid transparent;
 				border-top: 10px solid transparent;
 				border-right: 10px solid transparent;
+				transform: translate(calc(#{$dashboard-button-width} + -1px), 0);
+			}
+		}
+
+		&.next {
+			.dashboard-panel__panel__group__liveline {
+				&::after {
+					background: var(--general-next-color);
+				}
+				&::before {
+					border-left-color: var(--general-next-color);
+				}
+			}
+		}
+
+		&.live {
+			.dashboard-panel__panel__group__liveline {
+				&::after {
+					background: var(--general-live-color);
+				}
+				&::before {
+					border-left-color: var(--general-live-color);
+				}
 			}
 		}
 	}
@@ -140,8 +177,8 @@
 		white-space: normal;
 		line-break: loose;
 		word-break: break-all;
-		width: 82px;
-		height: 72px;
+		width: $dashboard-button-width;
+		height: $dashboard-button-height;
 		border: none;
 		margin: 4px;
 		vertical-align: top;

--- a/meteor/client/styles/shelf/externalFramePanel.scss
+++ b/meteor/client/styles/shelf/externalFramePanel.scss
@@ -1,0 +1,20 @@
+.external-frame-panel {
+	position: absolute;
+
+	.external-frame-panel__iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		border: none;
+		width: 100%;
+		height: 100%;
+	}
+}
+
+.dashboard {
+	.external-frame-panel {
+    	margin: 0.625rem;
+	}
+}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -64,10 +64,10 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 			if (piece.content) {
 				switch (this.props.layer.type) {
 					case SourceLayerType.VT:
-						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as VTContent).fileName.toUpperCase()
 						break
 					case SourceLayerType.LIVE_SPEAK:
-						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
 						break
 				}
 			}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -61,13 +61,15 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 			const piece = this.props.piece
 			let objId: string | undefined = undefined
 
-			switch (this.props.piece.sourceLayer.type) {
-				case SourceLayerType.VT:
-					objId = (piece.content as VTContent).fileName.toUpperCase()
-					break
-				case SourceLayerType.LIVE_SPEAK:
-					objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
-					break
+			if (piece.content) {
+				switch (this.props.layer.type) {
+					case SourceLayerType.VT:
+						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+					case SourceLayerType.LIVE_SPEAK:
+						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+				}
 			}
 
 			if (objId && objId !== this.objId) {

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -452,6 +452,18 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 								className='mod mas' />
 						</label>
 					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Show panel as a timeline')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.showAsTimeline`}
+								obj={item}
+								type='checkbox'
+								collection={RundownLayouts}
+								className='mod mas' />
+						</label>
+					</div>
 				</React.Fragment>
 			}
 		</React.Fragment>

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -454,6 +454,18 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 					</div>
 					<div className='mod mvs mhs'>
 						<label className='field'>
+							{t('Oveflow horizontally')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.overflowHorizontally`}
+								obj={item}
+								type='checkbox'
+								collection={RundownLayouts}
+								className='mod mas' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
 							{t('Show panel as a timeline')}
 							<EditAttribute
 								modifiedClassName='bghl'

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -7,7 +7,7 @@ import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { faStar, faUpload, faPlus, faCheck, faPencilAlt, faDownload, faTrash } from '@fortawesome/fontawesome-free-solid'
 import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
-import { RundownLayouts, RundownLayout, RundownLayoutType, RundownLayoutBase, RundownLayoutFilter, PieceDisplayStyle, RundownLayoutFilterBase } from '../../../lib/collections/RundownLayouts'
+import { RundownLayouts, RundownLayout, RundownLayoutType, RundownLayoutBase, RundownLayoutFilter, PieceDisplayStyle, RundownLayoutFilterBase, RundownLayoutElementType, RundownLayoutElementBase, RundownLayoutExternalFrame } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { callMethod } from '../../lib/clientAPI'
 import { PubSub } from '../../../lib/api/pubsub'
@@ -71,7 +71,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		)
 	}
 
-	onAddFilter = (item: RundownLayoutBase) => {
+	onAddElement = (item: RundownLayoutBase) => {
 		const { t } = this.props
 
 		const isRundownLayout = RundownLayoutsAPI.isRundownLayout(item)
@@ -81,9 +81,10 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 			$push: {
 				filters: literal<RundownLayoutFilter>({
 					_id: Random.id(),
+					type: RundownLayoutElementType.FILTER,
 					name: isRundownLayout ?
 							t('New Tab') :
-						isDashboardLayout ?
+						  isDashboardLayout ?
 							t('New Panel') :
 							t('New Item'),
 					currentSegment: false,
@@ -108,7 +109,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		})
 	}
 
-	onRemoveFilter = (item: RundownLayoutBase, filter: RundownLayoutFilterBase) => {
+	onRemoveElement = (item: RundownLayoutBase, filter: RundownLayoutElementBase) => {
 		RundownLayouts.update(item._id, {
 			$pull: {
 				filters: {
@@ -168,7 +169,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		})
 	}
 
-	renderFilters (item: RundownLayoutBase) {
+	renderFilter (item: RundownLayoutBase, tab: RundownLayoutFilterBase, index: number, isRundownLayout: boolean, isDashboardLayout: boolean) {
 		const { t } = this.props
 		const rundownBaselineOptions = [
 			{
@@ -185,6 +186,362 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 			}
 		]
 
+		return <React.Fragment>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Name')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.name`}
+						obj={item}
+						type='text'
+						collection={RundownLayouts}
+						className='input text-input input-l' />
+				</label>
+			</div>
+			{isDashboardLayout &&
+				<React.Fragment>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('X')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.x`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Y')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.y`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Width')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.width`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Height')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.height`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Button width scale factor')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.buttonWidthScale`}
+								obj={item}
+								type='float'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Button height scale factor')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.buttonHeightScale`}
+								obj={item}
+								type='float'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+				</React.Fragment>
+			}
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Display Rank')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.rank`}
+						obj={item}
+						type='float'
+						collection={RundownLayouts}
+						className='input text-input input-l' />
+				</label>
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Enable search toolbar')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.enableSearch`}
+						obj={item}
+						type='checkbox'
+						collection={RundownLayouts}
+						className='mod mas' />
+				</label>
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Only Display AdLibs from Current Segment')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.currentSegment`}
+						obj={item}
+						type='checkbox'
+						collection={RundownLayouts}
+						className='mod mas' />
+				</label>
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Include Global AdLibs')}
+				</label>
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.rundownBaseline`}
+					obj={item}
+					options={rundownBaselineOptions}
+					type='dropdown'
+					label={t('Filter Disabled')}
+					collection={RundownLayouts}
+					className='input text-input input-l dropdown' />
+			</div>
+			{isDashboardLayout &&
+				<React.Fragment>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Include Clear Source Layer in Ad-Libs')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.includeClearInRundownBaseline`}
+								obj={item}
+								type='checkbox'
+								collection={RundownLayouts}
+								className='mod mas' />
+						</label>
+					</div>
+				</React.Fragment>
+			}
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Source Layers')}
+				</label>
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.sourceLayerIds`}
+					obj={item}
+					type='checkbox'
+					collection={RundownLayouts}
+					className='mod mas'
+					mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true }
+					mutateUpdateValue={(v) => undefined } />
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.sourceLayerIds`}
+					obj={item}
+					options={this.props.showStyleBase.sourceLayers.map(l => { return { name: l.name, value: l._id } })}
+					type='multiselect'
+					label={t('Filter Disabled')}
+					collection={RundownLayouts}
+					className='input text-input input-l dropdown'
+					mutateUpdateValue={v => v && v.length > 0 ? v : undefined} />
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Source Layer Types')}
+				</label>
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.sourceLayerTypes`}
+					obj={item}
+					type='checkbox'
+					collection={RundownLayouts}
+					className='mod mas'
+					mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
+					mutateUpdateValue={(v) => undefined} />
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.sourceLayerTypes`}
+					obj={item}
+					options={SourceLayerType}
+					type='multiselect'
+					optionsAreNumbers={true}
+					label={t('Filter disabled')}
+					collection={RundownLayouts}
+					className='input text-input input-l dropdown'
+					mutateUpdateValue={(v: string[] | undefined) => v && v.length > 0 ? v.map(a => parseInt(a, 10)) : undefined} />
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Output Channels')}
+				</label>
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.outputLayerIds`}
+					obj={item}
+					type='checkbox'
+					collection={RundownLayouts}
+					className='mod mas'
+					mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
+					mutateUpdateValue={(v) => undefined} />
+				<EditAttribute
+					modifiedClassName='bghl'
+					attribute={`filters.${index}.outputLayerIds`}
+					obj={item}
+					options={this.props.showStyleBase.outputLayers.map(l => { return { name: l.name, value: l._id } })}
+					type='multiselect'
+					label={t('Filter Disabled')}
+					collection={RundownLayouts}
+					className='input text-input input-l dropdown'
+					mutateUpdateValue={v => v && v.length > 0 ? v : undefined} />
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Label contains')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.label`}
+						obj={item}
+						type='checkbox'
+						collection={RundownLayouts}
+						className='mod mas'
+						mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
+						mutateUpdateValue={(v) => undefined} />
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.label`}
+						obj={item}
+						type='text'
+						collection={RundownLayouts}
+						className='input text-input input-l'
+						label={t('Filter Disabled')}
+						mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? undefined : v.join(', ')}
+						mutateUpdateValue={(v) => (v === undefined || v.length === 0) ? undefined : v.split(',').map(i => i.trim())} />
+				</label>
+			</div>
+			{isDashboardLayout &&
+				<React.Fragment>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Register Shortcuts for this Panel')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.assignHotKeys`}
+								obj={item}
+								type='checkbox'
+								collection={RundownLayouts}
+								className='mod mas' />
+						</label>
+					</div>
+				</React.Fragment>
+			}
+		</React.Fragment>
+	}
+
+	renderFrame (item: RundownLayoutBase, tab: RundownLayoutExternalFrame, index: number, isRundownLayout: boolean, isDashboardLayout: boolean) {
+		const { t } = this.props
+		return <React.Fragment>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('Name')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.name`}
+						obj={item}
+						type='text'
+						collection={RundownLayouts}
+						className='input text-input input-l' />
+				</label>
+			</div>
+			<div className='mod mvs mhs'>
+				<label className='field'>
+					{t('URL')}
+					<EditAttribute
+						modifiedClassName='bghl'
+						attribute={`filters.${index}.url`}
+						obj={item}
+						type='text'
+						collection={RundownLayouts}
+						className='input text-input input-l' />
+				</label>
+			</div>
+			{isDashboardLayout &&
+				<React.Fragment>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('X')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.x`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Y')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.y`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Width')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.width`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+					<div className='mod mvs mhs'>
+						<label className='field'>
+							{t('Height')}
+							<EditAttribute
+								modifiedClassName='bghl'
+								attribute={`filters.${index}.height`}
+								obj={item}
+								type='int'
+								collection={RundownLayouts}
+								className='input text-input input-l' />
+						</label>
+					</div>
+				</React.Fragment>
+			}
+		</React.Fragment>
+	}
+
+	renderElements (item: RundownLayoutBase) {
+		const { t } = this.props
+		
 		const isRundownLayout = RundownLayoutsAPI.isRundownLayout(item)
 		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(item)
 
@@ -199,276 +556,37 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 			</h4>
 			{item.filters.map((tab, index) => (
 				<div className='rundown-layout-editor-filter mod pan mas' key={tab._id}>
-					<button className='action-btn right mod man pas' onClick={(e) => this.onRemoveFilter(item, tab)}>
+					<button className='action-btn right mod man pas' onClick={(e) => this.onRemoveElement(item, tab)}>
 						<FontAwesomeIcon icon={faTrash} />
 					</button>
 					{isRundownLayout &&
 						<button className={ClassNames('action-btn right mod man pas', {
-							'star': (tab as RundownLayoutFilter).default
-						})} onClick={(e) => this.onToggleDefault(item as RundownLayout, index, !(tab as RundownLayoutFilter).default)}>
+							'star': (tab as any).default
+						})} onClick={(e) => this.onToggleDefault(item as RundownLayout, index, !(tab as any).default)}>
 							<FontAwesomeIcon icon={faStar} />
 						</button>
 					}
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Name')}
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.name`}
-								obj={item}
-								options={RundownLayoutType}
-								type='text'
-								collection={RundownLayouts}
-								className='input text-input input-l' />
-						</label>
+					<div>
+						<div className='mod mvs mhs'>
+							<label className='field'>
+								{t('Type')}
+								<EditAttribute
+									modifiedClassName='bghl'
+									attribute={`filters.${index}.type`}
+									obj={item}
+									options={RundownLayoutElementType}
+									type='dropdown'
+									mutateDisplayValue={(v) => (v === undefined) ? RundownLayoutElementType.FILTER : v}
+									collection={RundownLayouts}
+									className='input text-input input-l'></EditAttribute>
+							</label>
+						</div>
 					</div>
-					{isDashboardLayout &&
-						<React.Fragment>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('X')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.x`}
-										obj={item}
-										options={RundownLayoutType}
-										type='int'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Y')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.y`}
-										obj={item}
-										options={RundownLayoutType}
-										type='int'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Width')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.width`}
-										obj={item}
-										options={RundownLayoutType}
-										type='int'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Height')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.height`}
-										obj={item}
-										options={RundownLayoutType}
-										type='int'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Button width scale factor')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.buttonWidthScale`}
-										obj={item}
-										options={RundownLayoutType}
-										type='float'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Button height scale factor')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.buttonHeightScale`}
-										obj={item}
-										options={RundownLayoutType}
-										type='float'
-										collection={RundownLayouts}
-										className='input text-input input-l' />
-								</label>
-							</div>
-						</React.Fragment>
-					}
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Display Rank')}
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.rank`}
-								obj={item}
-								options={RundownLayoutType}
-								type='float'
-								collection={RundownLayouts}
-								className='input text-input input-l' />
-						</label>
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Enable search toolbar')}
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.enableSearch`}
-								obj={item}
-								type='checkbox'
-								collection={RundownLayouts}
-								className='mod mas' />
-						</label>
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Only Display AdLibs from Current Segment')}
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.currentSegment`}
-								obj={item}
-								type='checkbox'
-								collection={RundownLayouts}
-								className='mod mas' />
-						</label>
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Include Global AdLibs')}
-						</label>
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.rundownBaseline`}
-							obj={item}
-							options={rundownBaselineOptions}
-							type='dropdown'
-							label={t('Filter Disabled')}
-							collection={RundownLayouts}
-							className='input text-input input-l dropdown' />
-					</div>
-					{isDashboardLayout &&
-						<React.Fragment>
-							<div className='mod mvs mhs'>
-								<label className='field'>
-									{t('Include Clear Source Layer in Ad-Libs')}
-									<EditAttribute
-										modifiedClassName='bghl'
-										attribute={`filters.${index}.includeClearInRundownBaseline`}
-										obj={item}
-										options={RundownLayoutType}
-										type='checkbox'
-										collection={RundownLayouts}
-										className='mod mas' />
-								</label>
-							</div>
-						</React.Fragment>
-					}
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Source Layers')}
-						</label>
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.sourceLayerIds`}
-							obj={item}
-							type='checkbox'
-							collection={RundownLayouts}
-							className='mod mas'
-							mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true }
-							mutateUpdateValue={(v) => undefined } />
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.sourceLayerIds`}
-							obj={item}
-							options={this.props.showStyleBase.sourceLayers.map(l => { return { name: l.name, value: l._id } })}
-							type='multiselect'
-							label={t('Filter Disabled')}
-							collection={RundownLayouts}
-							className='input text-input input-l dropdown'
-							mutateUpdateValue={v => v && v.length > 0 ? v : undefined} />
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Source Layer Types')}
-						</label>
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.sourceLayerTypes`}
-							obj={item}
-							type='checkbox'
-							collection={RundownLayouts}
-							className='mod mas'
-							mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
-							mutateUpdateValue={(v) => undefined} />
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.sourceLayerTypes`}
-							obj={item}
-							options={SourceLayerType}
-							type='multiselect'
-							optionsAreNumbers={true}
-							label={t('Filter disabled')}
-							collection={RundownLayouts}
-							className='input text-input input-l dropdown'
-							mutateUpdateValue={(v: string[] | undefined) => v && v.length > 0 ? v.map(a => parseInt(a, 10)) : undefined} />
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Output Channels')}
-						</label>
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.outputLayerIds`}
-							obj={item}
-							type='checkbox'
-							collection={RundownLayouts}
-							className='mod mas'
-							mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
-							mutateUpdateValue={(v) => undefined} />
-						<EditAttribute
-							modifiedClassName='bghl'
-							attribute={`filters.${index}.outputLayerIds`}
-							obj={item}
-							options={this.props.showStyleBase.outputLayers.map(l => { return { name: l.name, value: l._id } })}
-							type='multiselect'
-							label={t('Filter Disabled')}
-							collection={RundownLayouts}
-							className='input text-input input-l dropdown'
-							mutateUpdateValue={v => v && v.length > 0 ? v : undefined} />
-					</div>
-					<div className='mod mvs mhs'>
-						<label className='field'>
-							{t('Label contains')}
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.label`}
-								obj={item}
-								type='checkbox'
-								collection={RundownLayouts}
-								className='mod mas'
-								mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? false : true}
-								mutateUpdateValue={(v) => undefined} />
-							<EditAttribute
-								modifiedClassName='bghl'
-								attribute={`filters.${index}.label`}
-								obj={item}
-								type='text'
-								collection={RundownLayouts}
-								className='input text-input input-l'
-								label={t('Filter Disabled')}
-								mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? undefined : v.join(', ')}
-								mutateUpdateValue={(v) => (v === undefined || v.length === 0) ? undefined : v.split(',').map(i => i.trim())} />
-						</label>
-					</div>
+					{RundownLayoutsAPI.isFilter(tab) ?
+						this.renderFilter(item, tab, index, isRundownLayout, isDashboardLayout) :
+					 RundownLayoutsAPI.isExternalFrame(tab) ?
+						this.renderFrame(item, tab, index, isRundownLayout, isDashboardLayout) :
+						undefined}
 				</div>
 			))}
 		</React.Fragment>
@@ -531,16 +649,16 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 							</div>
 							<div>
 								{item.type === RundownLayoutType.RUNDOWN_LAYOUT ?
-									this.renderFilters(item) :
+									this.renderElements(item) :
 								 item.type === RundownLayoutType.DASHBOARD_LAYOUT ?
-									this.renderFilters(item)
+									this.renderElements(item)
 									: null}
 							</div>
 							<div className='mod mls'>
 								<button className='btn btn-primary right' onClick={(e) => this.finishEditItem(item)}>
 									<FontAwesomeIcon icon={faCheck} />
 								</button>
-								<button className='btn btn-secondary' onClick={(e) => this.onAddFilter(item)}>
+								<button className='btn btn-secondary' onClick={(e) => this.onAddElement(item)}>
 									<FontAwesomeIcon icon={faPlus} />
 								</button>
 							</div>

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -62,10 +62,10 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 			if (piece.content) {
 				switch (this.props.layer.type) {
 					case SourceLayerType.VT:
-						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as VTContent).fileName.toUpperCase()
 						break
 					case SourceLayerType.LIVE_SPEAK:
-						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
 						break
 				}
 			}

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -59,13 +59,15 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 			const piece = this.props.item as any as AdLibPieceUi
 			let objId: string | undefined = undefined
 
-			switch (this.props.layer.type) {
-				case SourceLayerType.VT:
-					objId = (piece.content as VTContent).fileName.toUpperCase()
-					break
-				case SourceLayerType.LIVE_SPEAK:
-					objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
-					break
+			if (piece.content) {
+				switch (this.props.layer.type) {
+					case SourceLayerType.VT:
+						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+					case SourceLayerType.LIVE_SPEAK:
+						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+				}
 			}
 
 			if (objId && objId !== this.objId) {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -412,6 +412,9 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 					$exists: false
 				}
 			}],
+			playoutDuration: {
+				$exists: false
+			},
 			adLibSourceId: {
 				$exists: true
 			}
@@ -419,8 +422,17 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 
 		let nearestEnd = Number.POSITIVE_INFINITY
 		prospectivePieces = prospectivePieces.filter((piece) => {
-			if (typeof piece.enable.duration === "number") {
-				const end = (piece.startedPlayback! + piece.enable.duration)
+			let duration: number | undefined =
+				(piece.playoutDuration) ?
+					piece.playoutDuration :
+				(piece.userDuration && typeof piece.userDuration.duration === "number") ?
+					piece.userDuration.duration :
+				(typeof piece.enable.duration === "number") ?
+					piece.enable.duration :
+					undefined
+
+			if (duration !== undefined) {
+				const end = (piece.startedPlayback! + duration)
 				if (end > now) {
 					nearestEnd = nearestEnd > end ? end : nearestEnd
 					return true

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -427,6 +427,8 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 					piece.playoutDuration :
 				(piece.userDuration && typeof piece.userDuration.duration === "number") ?
 					piece.userDuration.duration :
+				(piece.userDuration && typeof piece.userDuration.end === "string") ?
+					0 : // TODO: obviously, it would be best to evaluate this, but for now we assume that userDuration of any sort is probably in the past
 				(typeof piece.enable.duration === "number") ?
 					piece.enable.duration :
 					undefined

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -301,7 +301,7 @@ export class DashboardPanelInner extends MeteorReactComponent<Translated<IAdLibP
 			return
 		}
 		if (this.props.rundown && this.props.rundown.currentPartId) {
-			if (!this.isAdLibOnAir(piece)) {
+			if (!this.isAdLibOnAir(piece) || !(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
 				if (!piece.isGlobal) {
 					doUserAction(t, e, UserActionAPI.methods.segmentAdLibPieceStart, [
 						this.props.rundown._id, this.props.rundown.currentPartId, piece._id, queue || false

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -400,25 +400,32 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 		prospectivePieces = Pieces.find({
 			rundownId: rundownId,
 			partId: currentPartId,
-			startedPlayback: {
-				$exists: true
-			},
-			$or: [{
-				stoppedPlayback: {
-					$eq: 0
+			dynamicallyInserted: true,
+			$and: [
+				{
+					$or: [{
+						stoppedPlayback: {
+							$eq: 0
+						}
+					}, {
+						stoppedPlayback: {
+							$exists: false
+						}
+					}],
+				},
+				{
+					definitelyEnded: {
+						$exists: false
+					}
 				}
-			}, {
-				stoppedPlayback: {
-					$exists: false
-				}
-			}],
+			],
 			playoutDuration: {
 				$exists: false
 			},
 			adLibSourceId: {
 				$exists: true
 			}
-		}).fetch()
+		}).fetch().filter(p => !(p.userDuration && p.userDuration.duration))
 
 		let nearestEnd = Number.POSITIVE_INFINITY
 		prospectivePieces = prospectivePieces.filter((piece) => {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -99,34 +99,7 @@ export function dashboardElementPosition(el: DashboardPositionableElement): Reac
 	}
 }
 
-export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboardPanelProps, IState, IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>((props: Translated<IAdLibPanelProps>) => {
-	const unfinishedPieces = _.groupBy(props.rundown.currentPartId ? Pieces.find({
-		rundownId: props.rundown._id,
-		partId: props.rundown.currentPartId,
-		startedPlayback: {
-			$exists: true
-		},
-		$or: [{
-			stoppedPlayback: {
-				$eq: 0
-			}
-		}, {
-			stoppedPlayback: {
-				$exists: false
-			}
-		}],
-		adLibSourceId: {
-			$exists: true
-		}
-	}).fetch() : [], (piece) => piece.adLibSourceId)
-
-	return Object.assign({}, fetchAndFilter(props), {
-		studio: props.rundown.getStudio(),
-		unfinishedPieces
-	})
-}, (data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {
-	return !_.isEqual(props, nextProps)
-})(class DashboardPanel extends MeteorReactComponent<Translated<IAdLibPanelProps & IDashboardPanelProps & IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>, IState> {
+export class DashboardPanelInner extends MeteorReactComponent<Translated<IAdLibPanelProps & IDashboardPanelProps & IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>, IState> {
 	usedHotkeys: Array<string> = []
 
 	constructor (props: Translated<IAdLibPanelProps & IAdLibPanelTrackedProps>) {
@@ -418,4 +391,33 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 		}
 		return null
 	}
-})
+}
+
+export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboardPanelProps, IState, IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>((props: Translated<IAdLibPanelProps>) => {
+	const unfinishedPieces = _.groupBy(props.rundown.currentPartId ? Pieces.find({
+		rundownId: props.rundown._id,
+		partId: props.rundown.currentPartId,
+		startedPlayback: {
+			$exists: true
+		},
+		$or: [{
+			stoppedPlayback: {
+				$eq: 0
+			}
+		}, {
+			stoppedPlayback: {
+				$exists: false
+			}
+		}],
+		adLibSourceId: {
+			$exists: true
+		}
+	}).fetch() : [], (piece) => piece.adLibSourceId)
+
+	return Object.assign({}, fetchAndFilter(props), {
+		studio: props.rundown.getStudio(),
+		unfinishedPieces
+	})
+}, (data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {
+	return !_.isEqual(props, nextProps)
+})(DashboardPanelInner)

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -399,7 +399,6 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 	if (currentPartId) {
 		prospectivePieces = Pieces.find({
 			rundownId: rundownId,
-			partId: currentPartId,
 			dynamicallyInserted: true,
 			startedPlayback: {
 				$exists: true

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -401,6 +401,9 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 			rundownId: rundownId,
 			partId: currentPartId,
 			dynamicallyInserted: true,
+			startedPlayback: {
+				$exists: true
+			},
 			$and: [
 				{
 					$or: [{

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -50,8 +50,6 @@ const BUTTON_GRID_WIDTH = 1
 const BUTTON_GRID_HEIGHT = 0.61803
 
 interface IDashboardPanelProps {
-	searchFilter?: string | undefined
-	mediaPreviewUrl?: string
 }
 
 interface IDashboardPanelTrackedProps {
@@ -363,10 +361,11 @@ export class DashboardPanelInner extends MeteorReactComponent<Translated<IAdLibP
 							<AdLibPanelToolbar
 								onFilterChange={this.onFilterChange} />
 						}
-						<div className='dashboard-panel__panel'>
-							{_.flatten(this.props.uiSegments.map(seg => seg.pieces))
-								.concat(this.props.rundownBaselineAdLibs)
-								.sort((a, b) => a._rank - b._rank)
+						<div className={ClassNames('dashboard-panel__panel', {
+							'dashboard-panel__panel--horizontal': filter.overflowHorizontally
+						})}>
+							{this.props.rundownBaselineAdLibs
+								.concat(_.flatten(this.props.uiSegments.map(seg => seg.pieces)))
 								.filter((item) => matchFilter(item, this.props.showStyleBase, this.props.uiSegments, this.props.filter, this.state.searchFilter))
 								.map((item: AdLibPieceUi) => {
 									return <DashboardPieceButton

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -424,8 +424,20 @@ export function getUnfinishedPiecesReactive(rundownId: string, currentPartId: st
 			},
 			adLibSourceId: {
 				$exists: true
-			}
-		}).fetch().filter(p => !(p.userDuration && p.userDuration.duration))
+			},
+			$or: [
+				{
+					userDuration: {
+						$exists: false
+					}
+				},
+				{
+					'userDuration.duration': {
+						$exists: false
+					}
+				}
+			]
+		}).fetch()
 
 		let nearestEnd = Number.POSITIVE_INFINITY
 		prospectivePieces = prospectivePieces.filter((piece) => {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -61,6 +61,44 @@ interface IDashboardPanelTrackedProps {
 	}
 }
 
+interface DashboardPositionableElement {
+	x: number
+	y: number
+	width: number
+	height: number
+}
+
+export function dashboardElementPosition(el: DashboardPositionableElement): React.CSSProperties {
+	return {
+		width: el.width >= 0 ?
+			`calc((${el.width} * var(--dashboard-button-grid-width)) + var(--dashboard-panel-margin-width))` :
+			undefined,
+		height: el.height >= 0 ?
+			`calc((${el.height} * var(--dashboard-button-grid-height)) + var(--dashboard-panel-margin-height))` :
+			undefined,
+		left: el.x >= 0 ?
+			`calc(${el.x} * var(--dashboard-button-grid-width))` :
+			el.width < 0 ?
+				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
+				undefined,
+		top: el.y >= 0 ?
+			`calc(${el.y} * var(--dashboard-button-grid-height))` :
+			el.height < 0 ?
+				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
+				undefined,
+		right: el.x < 0 ?
+			`calc(${-1 * el.x - 1} * var(--dashboard-button-grid-width))` :
+			el.width < 0 ?
+				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
+				undefined,
+		bottom: el.y < 0 ?
+			`calc(${-1 * el.y - 1} * var(--dashboard-button-grid-height))` :
+			el.height < 0 ?
+				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
+				undefined
+	}
+}
+
 export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboardPanelProps, IState, IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>((props: Translated<IAdLibPanelProps>) => {
 	const unfinishedPieces = _.groupBy(props.rundown.currentPartId ? Pieces.find({
 		rundownId: props.rundown._id,
@@ -343,34 +381,7 @@ export const DashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboard
 			} else {
 				return (
 					<div className='dashboard-panel'
-						style={{
-							width: filter.width >= 0 ?
-								(filter.width * BUTTON_GRID_WIDTH) + 'vw' :
-								undefined,
-							height: filter.height >= 0 ?
-								(filter.height * BUTTON_GRID_HEIGHT) + 'vw' :
-								undefined,
-							left: filter.x >= 0 ?
-								(filter.x * BUTTON_GRID_WIDTH) + 'vw' :
-								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'vw' :
-									undefined,
-							top: filter.y >= 0 ?
-								(filter.y * BUTTON_GRID_HEIGHT) + 'vw' :
-								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
-									undefined,
-							right: filter.x < 0 ?
-								((-1 * filter.x - 1) * BUTTON_GRID_WIDTH) + 'vw' :
-								filter.width < 0 ?
-									((-1 * filter.width - 1) * BUTTON_GRID_WIDTH) + 'vw' :
-									undefined,
-							bottom: filter.y < 0 ?
-								((-1 * filter.y - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
-								filter.height < 0 ?
-									((-1 * filter.height - 1) * BUTTON_GRID_HEIGHT) + 'vw' :
-									undefined
-						}}
+						style={dashboardElementPosition(filter)}
 					>
 						<h4 className='dashboard-panel__header'>
 							{this.props.filter.name}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -64,13 +64,15 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 			const piece = this.props.item as any as AdLibPieceUi
 			let objId: string | undefined = undefined
 
-			switch (this.props.layer.type) {
-				case SourceLayerType.VT:
-					objId = (piece.content as VTContent).fileName.toUpperCase()
-					break
-				case SourceLayerType.LIVE_SPEAK:
-					objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
-					break
+			if (piece.content) {
+				switch (this.props.layer.type) {
+					case SourceLayerType.VT:
+						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+					case SourceLayerType.LIVE_SPEAK:
+						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						break
+				}
 			}
 
 			if (objId && objId !== this.objId) {

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -67,10 +67,10 @@ export const DashboardPieceButton = translateWithTracker<IDashboardButtonProps, 
 			if (piece.content) {
 				switch (this.props.layer.type) {
 					case SourceLayerType.VT:
-						objId = (piece.content as VTContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as VTContent).fileName.toUpperCase()
 						break
 					case SourceLayerType.LIVE_SPEAK:
-						objId = (piece.content as LiveSpeakContent).fileName ? (piece.content as VTContent).fileName.toUpperCase() : undefined
+						objId = (piece.content as LiveSpeakContent).fileName.toUpperCase()
 						break
 				}
 			}

--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -24,7 +24,8 @@ enum SofieExternalMessageType {
 	NAK = 'nak',
 	KEYBOARD_EVENT = 'keyboard_event',
 	CURRENT_PART_CHANGED = 'current_part_changed',
-	NEXT_PART_CHANGED = 'next_part_changed'
+	NEXT_PART_CHANGED = 'next_part_changed',
+	FOCUS_IN = 'focus_in'
 }
 
 interface SofieExternalMessage {
@@ -147,7 +148,16 @@ export class ExternalFramePanel extends React.Component<IProps> {
 						this.sendCurrentState()
 					}
 				}).catch(e => console.warn)
-				break;
+				break
+			case SofieExternalMessageType.FOCUS_IN:
+				this.sendMessage(literal<SofieExternalMessage>({
+					id: Random.id(),
+					replyToId: message.id,
+					type: SofieExternalMessageType.ACK
+				}))
+				const randomEl = document.querySelector('button')
+				if (randomEl) randomEl.focus()
+				break
 		}
 	}
 

--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react'
+import { Random } from 'meteor/random'
+import * as _ from 'underscore'
+import { RundownLayoutExternalFrame, RundownLayoutBase, DashboardLayoutExternalFrame } from '../../../lib/collections/RundownLayouts'
+import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
+import { dashboardElementPosition } from './DashboardPanel'
+import { literal } from '../../../lib/lib'
+
+const PackageInfo = require('../../../package.json')
+
+interface IProps {
+	layout: RundownLayoutBase
+	panel: RundownLayoutExternalFrame
+	visible: boolean
+}
+
+enum SofieExternalMessageType {
+	HELLO = 'hello',
+	WELCOME = 'welcome',
+	ACK = 'ack',
+	NAK = 'nak',
+	KEYBOARD_EVENT = 'keyboard_event'
+}
+
+interface SofieExternalMessage {
+	id: string,
+	replyToId?: string
+	type: SofieExternalMessageType
+	payload?: any
+}
+
+export class ExternalFramePanel extends React.Component<IProps> {
+	frame: HTMLIFrameElement
+	mounted: boolean = false
+	initialized: boolean = false
+
+	awaitingReply: {
+		[key: string]: {
+			resolve: Function
+			reject: Function
+		}
+	} = {}
+
+	setElement = (frame: HTMLIFrameElement) => {
+		this.frame = frame
+		if (this.frame && !this.mounted) {
+			this.registerHandlers()
+			this.mounted = true
+		} else {
+			this.unregisterHandlers()
+			this.mounted = false
+		}
+	}
+
+	onKeyEvent = (e: KeyboardEvent) => {
+		this.sendMessage(literal<SofieExternalMessage>({
+			id: Random.id(),
+			type: SofieExternalMessageType.KEYBOARD_EVENT,
+			// Send the event sanitized to prevent sending huge objects
+			payload: _.extend({}, e, {
+				currentTarget: null,
+				path: null,
+				srcElement: null,
+				target: null,
+				view: null
+			})
+		}))
+	}
+
+	onReceiveMessage = (e: MessageEvent) => {
+		if (e.origin === this.props.panel.url) {
+			try {
+				const data = JSON.parse(e.data || e['message'])
+				this.actMessage(data)
+			} catch (e) {
+				console.error(`ExternalFramePanel: Unable to parse data from: ${e.origin}`, e)
+			}
+		}
+	}
+
+	actMessage = (message: SofieExternalMessage) => {
+		if (!message.type || SofieExternalMessageType[message.type] === undefined) {
+			console.error(`ExternalFramePanel: Unknown message type: ${message.type}`)
+			return
+		}
+
+		if (message.replyToId && this.awaitingReply[message.replyToId]) {
+			this.awaitingReply[message.replyToId].resolve(message)
+			delete this.awaitingReply[message.replyToId]
+			return
+		}
+
+		switch (message.type) {
+			// perform a three-way handshake: HELLO -> WELCOME -> ACK
+			case SofieExternalMessageType.HELLO:
+				this.sendMessageAwaitReply(literal<SofieExternalMessage>({
+					id: Random.id(),
+					replyToId: message.id,
+					type: SofieExternalMessageType.WELCOME,
+					payload: {
+						host: 'Sofie Automation System',
+						version: PackageInfo.version
+					}
+				})).then((e) => {
+					if (e.type === SofieExternalMessageType.ACK) {
+						this.initialized = true
+					}
+				})
+				break;
+		}
+	}
+
+	sendMessageAwaitReply = (message: SofieExternalMessage): Promise<SofieExternalMessage> => {
+		return new Promise((resolve, reject) => {
+			this.awaitingReply[message.id] = { resolve, reject }
+			this.sendMessage(message)
+		})
+	}
+
+	sendMessage = (data: SofieExternalMessage) => {
+		if (this.frame && this.frame.contentWindow && this.initialized) {
+			this.frame.contentWindow.postMessage(JSON.stringify(data), "*")
+		}
+	}
+
+	registerHandlers = () => {
+		document.addEventListener('keydown', this.onKeyEvent)
+		document.addEventListener('keyup', this.onKeyEvent)
+	}
+
+	unregisterHandlers = () => {
+		document.removeEventListener('keydown', this.onKeyEvent)
+		document.removeEventListener('keydown', this.onKeyEvent)
+	}
+
+	componentDidMount () {
+		window.addEventListener('message', this.onReceiveMessage)
+	}
+
+	componentWillUnmount () {
+		// reject all outstanding promises for replies
+		_.each(this.awaitingReply, (promise) => promise.reject())
+		this.unregisterHandlers()
+		window.removeEventListener('message', this.onReceiveMessage)
+	}
+
+	render () {
+		return <div className='external-frame-panel'
+			style={
+				_.extend(
+					RundownLayoutsAPI.isDashboardLayout(this.props.layout) ?
+						dashboardElementPosition(this.props.panel as DashboardLayoutExternalFrame) :
+						{},
+					{
+						'visibility': this.props.visible ? 'visible' : 'hidden'
+					}
+				)
+			}>
+			<iframe
+			ref={this.setElement}
+			className='external-frame-panel__iframe'
+			src={this.props.panel.url}
+			sandbox='allow-forms allow-popups allow-scripts'></iframe>
+		</div> 
+	}
+}

--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -139,7 +139,7 @@ export class ExternalFramePanel extends React.Component<IProps> {
 						version: PackageInfo.version,
 						rundownId: this.props.rundown._id
 					}
-				})).then((e) => {
+				}), true).then((e) => {
 					if (e.type === SofieExternalMessageType.ACK) {
 						this.initialized = true
 						this.sendCurrentState()
@@ -149,15 +149,15 @@ export class ExternalFramePanel extends React.Component<IProps> {
 		}
 	}
 
-	sendMessageAwaitReply = (message: SofieExternalMessage): Promise<SofieExternalMessage> => {
+	sendMessageAwaitReply = (message: SofieExternalMessage, uninitialized?: boolean): Promise<SofieExternalMessage> => {
 		return new Promise((resolve, reject) => {
 			this.awaitingReply[message.id] = { resolve, reject }
-			this.sendMessage(message)
+			this.sendMessage(message, uninitialized)
 		})
 	}
 
-	sendMessage = (data: SofieExternalMessage) => {
-		if (this.frame && this.frame.contentWindow && this.initialized) {
+	sendMessage = (data: SofieExternalMessage, uninitialized?: boolean) => {
+		if (this.frame && this.frame.contentWindow && (this.initialized || uninitialized)) {
 			this.frame.contentWindow.postMessage(JSON.stringify(data), "*")
 		}
 	}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -25,6 +25,7 @@ import { DashboardPanel } from './DashboardPanel'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
 import { ExternalFramePanel } from './ExternalFramePanel';
+import { TimelineDashboardPanel } from './TimelineDashboardPanel';
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
@@ -351,14 +352,23 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 				.sort((a, b) => a.rank - b.rank)
 				.map((panel) =>
 					RundownLayoutsAPI.isFilter(panel) ?
-						<DashboardPanel
-							key={panel._id}
-							includeGlobalAdLibs={true}
-							filter={panel}
-							visible={true}
-							registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
-							{...this.props}
-							/> :
+						(panel as DashboardLayoutFilter).showAsTimeline ?
+							<TimelineDashboardPanel
+								key={panel._id}
+								includeGlobalAdLibs={true}
+								filter={panel}
+								visible={true}
+								registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
+								{...this.props}
+								/> :
+							<DashboardPanel
+								key={panel._id}
+								includeGlobalAdLibs={true}
+								filter={panel}
+								visible={true}
+								registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
+								{...this.props}
+								/> :
 					RundownLayoutsAPI.isExternalFrame(panel) ?
 						<ExternalFramePanel
 							key={panel._id}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -17,13 +17,14 @@ import { RundownViewKbdShortcuts } from '../RundownView'
 import { HotkeyHelpPanel } from './HotkeyHelpPanel'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { getElementDocumentOffset } from '../../utils/positions'
-import { RundownLayout, RundownLayoutBase, RundownLayoutType, DashboardLayout, DashboardLayoutFilter } from '../../../lib/collections/RundownLayouts'
+import { RundownLayout, RundownLayoutBase, RundownLayoutType, DashboardLayout, DashboardLayoutFilter, RundownLayoutFilter } from '../../../lib/collections/RundownLayouts'
 import { OverflowingContainer } from './OverflowingContainer'
 import { UIStateStorage } from '../../lib/UIStateStorage'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { DashboardPanel } from './DashboardPanel'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
+import { ExternalFramePanel } from './ExternalFramePanel';
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
@@ -169,7 +170,7 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 
 	restoreDefaultTab () {
 		if (this.state.selectedTab === undefined && this.props.rundownLayout && RundownLayoutsAPI.isRundownLayout(this.props.rundownLayout)) {
-			const defaultTab = this.props.rundownLayout.filters.find(i => i.default)
+			const defaultTab = this.props.rundownLayout.filters.find(i => (i as RundownLayoutFilter).default)
 			if (defaultTab) {
 				this.setState({
 					selectedTab: `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${defaultTab._id}`
@@ -318,14 +319,24 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 					visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.ADLIB}
 					registerHotkeys={true}
 					{...this.props}></AdLibPanel>
-				{rundownLayout && rundownLayout.filters.map(f =>
-					<AdLibPanel
-						key={f._id}
-						visible={(this.state.selectedTab || DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${f._id}`}
-						includeGlobalAdLibs={true}
-						filter={f}
-						{...this.props}
-						/>
+				{rundownLayout && rundownLayout.filters.map(panel =>
+					RundownLayoutsAPI.isFilter(panel) ?
+						<AdLibPanel
+							key={panel._id}
+							visible={(this.state.selectedTab || DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
+							includeGlobalAdLibs={true}
+							filter={panel}
+							{...this.props}
+							/> :
+					RundownLayoutsAPI.isExternalFrame(panel) ?
+						<ExternalFramePanel
+							key={panel._id}
+							panel={panel}
+							layout={rundownLayout}
+							visible={(this.state.selectedTab || DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
+							{...this.props}
+							/> :
+						undefined
 				)}
 				<GlobalAdLibPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.GLOBAL_ADLIB} {...this.props}></GlobalAdLibPanel>
 				<HotkeyHelpPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS} {...this.props}></HotkeyHelpPanel>
@@ -338,15 +349,25 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 		return <div className='dashboard'>
 			{rundownLayout.filters
 				.sort((a, b) => a.rank - b.rank)
-				.map((f: DashboardLayoutFilter) =>
-					<DashboardPanel
-						key={f._id}
-						includeGlobalAdLibs={true}
-						filter={f}
-						visible={true}
-						registerHotkeys={true}
-						{...this.props}
-						/>
+				.map((panel) =>
+					RundownLayoutsAPI.isFilter(panel) ?
+						<DashboardPanel
+							key={panel._id}
+							includeGlobalAdLibs={true}
+							filter={panel}
+							visible={true}
+							registerHotkeys={(panel as DashboardLayoutFilter).assignHotKeys}
+							{...this.props}
+							/> :
+					RundownLayoutsAPI.isExternalFrame(panel) ?
+						<ExternalFramePanel
+							key={panel._id}
+							panel={panel}
+							layout={rundownLayout}
+							visible={true}
+							{...this.props}
+							/> :
+						undefined
 			)}
 		</div>
 	}

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -35,7 +35,7 @@ import { DashboardPieceButton } from './DashboardPieceButton'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
 import { Piece, Pieces } from '../../../lib/collections/Pieces'
-import { DashboardPanel, DashboardPanelInner } from './DashboardPanel';
+import { DashboardPanel, DashboardPanelInner, dashboardElementPosition } from './DashboardPanel';
 
 interface IState {
 	outputLayers: {
@@ -48,52 +48,12 @@ interface IState {
 }
 
 interface IDashboardPanelProps {
-	searchFilter?: string | undefined
-	mediaPreviewUrl?: string
 }
 
 interface IDashboardPanelTrackedProps {
 	studio?: Studio
 	unfinishedPieces: {
 		[key: string]: Piece[]
-	}
-}
-
-interface DashboardPositionableElement {
-	x: number
-	y: number
-	width: number
-	height: number
-}
-
-export function dashboardElementPosition(el: DashboardPositionableElement): React.CSSProperties {
-	return {
-		width: el.width >= 0 ?
-			`calc((${el.width} * var(--dashboard-button-grid-width)) + var(--dashboard-panel-margin-width))` :
-			undefined,
-		height: el.height >= 0 ?
-			`calc((${el.height} * var(--dashboard-button-grid-height)) + var(--dashboard-panel-margin-height))` :
-			undefined,
-		left: el.x >= 0 ?
-			`calc(${el.x} * var(--dashboard-button-grid-width))` :
-			el.width < 0 ?
-				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
-				undefined,
-		top: el.y >= 0 ?
-			`calc(${el.y} * var(--dashboard-button-grid-height))` :
-			el.height < 0 ?
-				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
-				undefined,
-		right: el.x < 0 ?
-			`calc(${-1 * el.x - 1} * var(--dashboard-button-grid-width))` :
-			el.width < 0 ?
-				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
-				undefined,
-		bottom: el.y < 0 ?
-			`calc(${-1 * el.y - 1} * var(--dashboard-button-grid-height))` :
-			el.height < 0 ?
-				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
-				undefined
 	}
 }
 
@@ -142,7 +102,7 @@ export const TimelineDashboardPanel = translateWithTracker<IAdLibPanelProps & ID
 			this.liveLine.scrollIntoView({
 				behavior: 'smooth',
 				block: 'start',
-				inline: 'nearest'
+				inline: 'start'
 			})
 		}
 	}
@@ -165,7 +125,9 @@ export const TimelineDashboardPanel = translateWithTracker<IAdLibPanelProps & ID
 							<AdLibPanelToolbar
 								onFilterChange={this.onFilterChange} />
 						}
-						<div className='dashboard-panel__panel'>
+						<div className={ClassNames('dashboard-panel__panel', {
+							'dashboard-panel__panel--horizontal': filter.overflowHorizontally
+						})}>
 							{filteredRudownBaselineAdLibs.length > 0 &&
 								<div className='dashboard-panel__panel__group'>
 									{filteredRudownBaselineAdLibs.map((item: AdLibPieceUi) => {

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -106,7 +106,6 @@ export const TimelineDashboardPanel = translateWithTracker<IAdLibPanelProps & ID
 				block: 'start',
 				inline: 'start'
 			})
-			console.log('Scrolling into view')
 		}
 	}, 250)
 	render () {

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -35,7 +35,7 @@ import { DashboardPieceButton } from './DashboardPieceButton'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
 import { Piece, Pieces } from '../../../lib/collections/Pieces'
-import { DashboardPanel, DashboardPanelInner, dashboardElementPosition } from './DashboardPanel';
+import { DashboardPanel, DashboardPanelInner, dashboardElementPosition, getUnfinishedPiecesReactive } from './DashboardPanel';
 
 interface IState {
 	outputLayers: {
@@ -58,29 +58,9 @@ interface IDashboardPanelTrackedProps {
 }
 
 export const TimelineDashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboardPanelProps, IState, IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>((props: Translated<IAdLibPanelProps>) => {
-	const unfinishedPieces = _.groupBy(props.rundown.currentPartId ? Pieces.find({
-		rundownId: props.rundown._id,
-		partId: props.rundown.currentPartId,
-		startedPlayback: {
-			$exists: true
-		},
-		$or: [{
-			stoppedPlayback: {
-				$eq: 0
-			}
-		}, {
-			stoppedPlayback: {
-				$exists: false
-			}
-		}],
-		adLibSourceId: {
-			$exists: true
-		}
-	}).fetch() : [], (piece) => piece.adLibSourceId)
-
 	return Object.assign({}, fetchAndFilter(props), {
 		studio: props.rundown.getStudio(),
-		unfinishedPieces
+		unfinishedPieces: getUnfinishedPiecesReactive(props.rundown._id, props.rundown.currentPartId)
 	})
 }, (data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {
 	return !_.isEqual(props, nextProps)

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -1,0 +1,229 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import * as Velocity from 'velocity-animate'
+import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
+import { translate } from 'react-i18next'
+import { Rundown } from '../../../lib/collections/Rundowns'
+import { Segment } from '../../../lib/collections/Segments'
+import { Part } from '../../../lib/collections/Parts'
+import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
+import { AdLibListItem } from './AdLibListItem'
+import * as ClassNames from 'classnames'
+import { mousetrapHelper } from '../../lib/mousetrapHelper'
+
+import * as faTh from '@fortawesome/fontawesome-free-solid/faTh'
+import * as faList from '@fortawesome/fontawesome-free-solid/faList'
+import * as faTimes from '@fortawesome/fontawesome-free-solid/faTimes'
+import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+import { Spinner } from '../../lib/Spinner'
+import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { RundownViewKbdShortcuts } from '../RundownView'
+import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
+import { IOutputLayer, ISourceLayer } from 'tv-automation-sofie-blueprints-integration'
+import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { doUserAction } from '../../lib/userAction'
+import { UserActionAPI } from '../../../lib/api/userActions'
+import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications'
+import { RundownLayoutFilter, DashboardLayoutFilter } from '../../../lib/collections/RundownLayouts'
+import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBaselineAdLibPieces'
+import { Random } from 'meteor/random'
+import { literal } from '../../../lib/lib'
+import { RundownAPI } from '../../../lib/api/rundown'
+import { IAdLibPanelProps, IAdLibPanelTrackedProps, fetchAndFilter, AdLibPieceUi, matchFilter, AdLibPanelToolbar } from './AdLibPanel'
+import { DashboardPieceButton } from './DashboardPieceButton'
+import { ensureHasTrailingSlash } from '../../lib/lib'
+import { Studio } from '../../../lib/collections/Studios'
+import { Piece, Pieces } from '../../../lib/collections/Pieces'
+import { DashboardPanel, DashboardPanelInner } from './DashboardPanel';
+
+interface IState {
+	outputLayers: {
+		[key: string]: IOutputLayer
+	}
+	sourceLayers: {
+		[key: string]: ISourceLayer
+	},
+	searchFilter: string | undefined
+}
+
+interface IDashboardPanelProps {
+	searchFilter?: string | undefined
+	mediaPreviewUrl?: string
+}
+
+interface IDashboardPanelTrackedProps {
+	studio?: Studio
+	unfinishedPieces: {
+		[key: string]: Piece[]
+	}
+}
+
+interface DashboardPositionableElement {
+	x: number
+	y: number
+	width: number
+	height: number
+}
+
+export function dashboardElementPosition(el: DashboardPositionableElement): React.CSSProperties {
+	return {
+		width: el.width >= 0 ?
+			`calc((${el.width} * var(--dashboard-button-grid-width)) + var(--dashboard-panel-margin-width))` :
+			undefined,
+		height: el.height >= 0 ?
+			`calc((${el.height} * var(--dashboard-button-grid-height)) + var(--dashboard-panel-margin-height))` :
+			undefined,
+		left: el.x >= 0 ?
+			`calc(${el.x} * var(--dashboard-button-grid-width))` :
+			el.width < 0 ?
+				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
+				undefined,
+		top: el.y >= 0 ?
+			`calc(${el.y} * var(--dashboard-button-grid-height))` :
+			el.height < 0 ?
+				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
+				undefined,
+		right: el.x < 0 ?
+			`calc(${-1 * el.x - 1} * var(--dashboard-button-grid-width))` :
+			el.width < 0 ?
+				`calc(${-1 * el.width - 1} * var(--dashboard-button-grid-width))` :
+				undefined,
+		bottom: el.y < 0 ?
+			`calc(${-1 * el.y - 1} * var(--dashboard-button-grid-height))` :
+			el.height < 0 ?
+				`calc(${-1 * el.height - 1} * var(--dashboard-button-grid-height))` :
+				undefined
+	}
+}
+
+export const TimelineDashboardPanel = translateWithTracker<IAdLibPanelProps & IDashboardPanelProps, IState, IAdLibPanelTrackedProps & IDashboardPanelTrackedProps>((props: Translated<IAdLibPanelProps>) => {
+	const unfinishedPieces = _.groupBy(props.rundown.currentPartId ? Pieces.find({
+		rundownId: props.rundown._id,
+		partId: props.rundown.currentPartId,
+		startedPlayback: {
+			$exists: true
+		},
+		$or: [{
+			stoppedPlayback: {
+				$eq: 0
+			}
+		}, {
+			stoppedPlayback: {
+				$exists: false
+			}
+		}],
+		adLibSourceId: {
+			$exists: true
+		}
+	}).fetch() : [], (piece) => piece.adLibSourceId)
+
+	return Object.assign({}, fetchAndFilter(props), {
+		studio: props.rundown.getStudio(),
+		unfinishedPieces
+	})
+}, (data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {
+	return !_.isEqual(props, nextProps)
+})(class TimelineDashboardPanel extends DashboardPanelInner {
+	liveLine: HTMLDivElement
+	setRef = (el: HTMLDivElement) => {
+		this.liveLine = el
+	}
+	componentDidUpdate (prevProps) {
+		super.componentDidUpdate(prevProps)
+		this.ensureLiveLineVisible()
+	}
+	componentDidMount () {
+		super.componentDidMount()
+		this.ensureLiveLineVisible()
+	}
+	ensureLiveLineVisible () {
+		if (this.liveLine) {
+			this.liveLine.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start',
+				inline: 'nearest'
+			})
+		}
+	}
+	render () {
+		if (this.props.visible && this.props.showStyleBase && this.props.filter) {
+			const filter = this.props.filter as DashboardLayoutFilter
+			if (!this.props.uiSegments || !this.props.rundown) {
+				return <Spinner />
+			} else {
+				const filteredRudownBaselineAdLibs = this.props.rundownBaselineAdLibs.filter((item) => matchFilter(item, this.props.showStyleBase, this.props.uiSegments, this.props.filter, this.state.searchFilter))
+
+				return (
+					<div className='dashboard-panel dashboard-panel--timeline-style'
+						style={dashboardElementPosition(filter)}
+					>
+						<h4 className='dashboard-panel__header'>
+							{this.props.filter.name}
+						</h4>
+						{ filter.enableSearch &&
+							<AdLibPanelToolbar
+								onFilterChange={this.onFilterChange} />
+						}
+						<div className='dashboard-panel__panel'>
+							{filteredRudownBaselineAdLibs.length > 0 &&
+								<div className='dashboard-panel__panel__group'>
+									{filteredRudownBaselineAdLibs.map((item: AdLibPieceUi) => {
+										return <DashboardPieceButton
+													key={item._id}
+													item={item}
+													layer={this.state.sourceLayers[item.sourceLayerId]}
+													outputLayer={this.state.outputLayers[item.outputLayerId]}
+													onToggleAdLib={this.onToggleAdLib}
+													rundown={this.props.rundown}
+													isOnAir={this.isAdLibOnAir(item)}
+													mediaPreviewUrl={this.props.studio ? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || '' : ''}
+													widthScale={filter.buttonWidthScale}
+													heightScale={filter.buttonHeightScale}
+												>
+													{item.name}
+										</DashboardPieceButton>
+									})}
+								</div>
+							}
+							{this.props.uiSegments.map((seg) => {
+								const filteredPieces = seg.pieces ?
+									seg.pieces.filter((item) => matchFilter(item, this.props.showStyleBase, this.props.uiSegments, this.props.filter, this.state.searchFilter)) :
+									[]
+								
+								return filteredPieces.length > 0 || seg.isLive ?
+									<div key={seg._id}
+										id={'dashboard-panel__panel__group__' + seg._id}
+										className={ClassNames('dashboard-panel__panel__group', {
+											'live': seg.isLive
+										})}>
+										{seg.isLive && 
+											<div className='dashboard-panel__panel__group__liveline' ref={this.setRef}></div>
+										}
+										{filteredPieces.map((item: AdLibPieceUi) => {
+											return <DashboardPieceButton
+														key={item._id}
+														item={item}
+														layer={this.state.sourceLayers[item.sourceLayerId]}
+														outputLayer={this.state.outputLayers[item.outputLayerId]}
+														onToggleAdLib={this.onToggleAdLib}
+														rundown={this.props.rundown}
+														isOnAir={this.isAdLibOnAir(item)}
+														mediaPreviewUrl={this.props.studio ? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || '' : ''}
+														widthScale={filter.buttonWidthScale}
+														heightScale={filter.buttonHeightScale}
+													>
+														{item.name}
+											</DashboardPieceButton>
+										})}
+									</div> :
+									undefined
+							})}
+						</div>
+					</div>
+				)
+			}
+		}
+		return null
+	}
+})

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -1,4 +1,4 @@
-import { RundownLayoutBase, RundownLayout, DashboardLayout, RundownLayoutType } from '../collections/RundownLayouts'
+import { RundownLayoutBase, RundownLayout, DashboardLayout, RundownLayoutType, RundownLayoutElementBase, RundownLayoutFilter, RundownLayoutElementType, RundownLayoutFilterBase, RundownLayoutExternalFrame } from '../collections/RundownLayouts'
 
 export namespace RundownLayoutsAPI {
 	export enum methods {
@@ -12,5 +12,13 @@ export namespace RundownLayoutsAPI {
 
 	export function isDashboardLayout (layout: RundownLayoutBase): layout is DashboardLayout {
 		return layout.type === RundownLayoutType.DASHBOARD_LAYOUT
+	}
+
+	export function isFilter (element: RundownLayoutElementBase): element is RundownLayoutFilterBase {
+		return element.type === undefined || element.type === RundownLayoutElementType.FILTER
+	}
+
+	export function isExternalFrame (element: RundownLayoutElementBase): element is RundownLayoutExternalFrame {
+		return element.type === RundownLayoutElementType.EXTERNAL_FRAME
 	}
 }

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -92,6 +92,8 @@ export interface DashboardLayoutFilter extends RundownLayoutFilterBase {
 	buttonHeightScale: number
 
 	includeClearInRundownBaseline: boolean
+	assignHotKeys: boolean
+	showAsTimeline?: boolean
 }
 
 export interface RundownLayoutBase {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -93,6 +93,7 @@ export interface DashboardLayoutFilter extends RundownLayoutFilterBase {
 
 	includeClearInRundownBaseline: boolean
 	assignHotKeys: boolean
+	overflowHorizontally?: boolean
 	showAsTimeline?: boolean
 }
 

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -29,6 +29,23 @@ export enum PieceDisplayStyle {
 	BUTTONS = 'buttons'
 }
 
+export enum RundownLayoutElementType {
+	FILTER = 'filter',
+	EXTERNAL_FRAME = 'external_frame'
+}
+
+export interface RundownLayoutElementBase {
+	_id: string
+	name: string
+	rank: number
+	type?: RundownLayoutElementType // if not set, the value is RundownLayoutElementType.FILTER
+}
+
+export interface RundownLayoutExternalFrame extends RundownLayoutElementBase {
+	type: RundownLayoutElementType.EXTERNAL_FRAME
+	url: string
+}
+
 /**
  * A filter to be applied against the AdLib Pieces. If a member is undefined, the pool is not tested
  * against that filter. A member must match all of the sub-filters to be included in a filter view
@@ -36,10 +53,8 @@ export enum PieceDisplayStyle {
  * @export
  * @interface RundownLayoutFilter
  */
-export interface RundownLayoutFilterBase {
-	_id: string
-	name: string
-	rank: number
+export interface RundownLayoutFilterBase extends RundownLayoutElementBase {
+	type: RundownLayoutElementType.FILTER
 	sourceLayerIds: string[] | undefined
 	sourceLayerTypes: SourceLayerType[] | undefined
 	outputLayerIds: string[] | undefined
@@ -57,6 +72,13 @@ export interface RundownLayoutFilterBase {
 
 export interface RundownLayoutFilter extends RundownLayoutFilterBase {
 	default: boolean
+}
+
+export interface DashboardLayoutExternalFrame extends RundownLayoutExternalFrame {
+	x: number
+	y: number
+	width: number
+	height: number
 }
 
 export interface DashboardLayoutFilter extends RundownLayoutFilterBase {
@@ -79,12 +101,12 @@ export interface RundownLayoutBase {
 	userId?: string
 	name: string
 	type: RundownLayoutType.RUNDOWN_LAYOUT | RundownLayoutType.DASHBOARD_LAYOUT
-	filters: RundownLayoutFilterBase[]
+	filters: RundownLayoutElementBase[]
 }
 
 export interface RundownLayout extends RundownLayoutBase {
 	type: RundownLayoutType.RUNDOWN_LAYOUT
-	filters: RundownLayoutFilter[]
+	filters: RundownLayoutElementBase[]
 }
 
 export enum ActionButtonType {
@@ -113,7 +135,7 @@ export interface DashboardLayoutActionButton {
 export interface DashboardLayout extends RundownLayoutBase {
 	// TODO: Interface to be defined later
 	type: RundownLayoutType.DASHBOARD_LAYOUT
-	filters: DashboardLayoutFilter[]
+	filters: RundownLayoutElementBase[]
 	actionButtons: DashboardLayoutActionButton[]
 }
 

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -251,7 +251,7 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 
 	let ps: Array<Promise<any>> = []
 	for (const piece of pieces) {
-		if (!piece.userDuration || !piece.userDuration.duration) {
+		if (!piece.userDuration || (!piece.userDuration.duration && !piece.userDuration.end)) {
 			ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
 				userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
 				definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION + (newPiece.adlibPreroll || 0),

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -251,11 +251,14 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 
 	let ps: Array<Promise<any>> = []
 	for (const piece of pieces) {
-		ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
-			userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
-			infiniteMode: PieceLifespan.Normal,
-			originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
-		}}))
+		if (!piece.userDuration || !piece.userDuration.duration) {
+			ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
+				userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
+				definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION + (newPiece.adlibPreroll || 0),
+				infiniteMode: PieceLifespan.Normal,
+				originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
+			}}))
+		}
 	}
 	waitForPromiseAll(ps)
 })

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -168,7 +168,9 @@ export function createPieceGroup (
 }
 export function getResolvedPieces (part: Part): Piece[] {
 	// TODO - was this mangled for endState and could it have broken something else?
-	const pieces = part.getAllPieces()
+	let pieces = allPieces ? allPieces.filter(p => p.partId === part._id) : part.getAllPieces()
+
+	pieces = pieces.filter(p => !p.stoppedPlayback)
 
 	const itemMap: { [key: string]: Piece } = {}
 	pieces.forEach(piece => itemMap[piece._id] = piece)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
* **What is the new behavior (if this is a feature change)?**
- Improves dashboard / shelf layouts to allow for "toggling" adlibs.
- Provides a "timeline" view whereby an indicator is given of which adlibs belong to a particular piont in a show.
- Adds an option of using an "External frame" panel, that is an iframe with an API to exchange events with Sofie

Timeline view:
![image](https://user-images.githubusercontent.com/10697525/73760837-d5a74680-4765-11ea-96af-a14958c6339b.png)

Adlib toggle:
![image](https://user-images.githubusercontent.com/10697525/73760922-f7a0c900-4765-11ea-8309-7a5e348d2cb9.png)
![image](https://user-images.githubusercontent.com/10697525/73760971-0d15f300-4766-11ea-8eb3-d47e04235778.png)
