### PR TITLE
Hidden Segments

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1088,7 +1088,12 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 	return {
 		rundownId: rundownId,
 		rundown: rundown,
-		segments: rundown ? Segments.find({ rundownId: rundown._id }, {
+		segments: rundown ? Segments.find({
+			rundownId: rundown._id,
+			isHidden: {
+				$ne: true
+			}
+		}, {
 			sort: {
 				'_rank': 1
 			}

--- a/meteor/client/ui/RundownView/RundownOverview.tsx
+++ b/meteor/client/ui/RundownView/RundownOverview.tsx
@@ -125,7 +125,11 @@ withTracker<WithTiming<RundownOverviewProps>, RundownOverviewState, RundownOverv
 	if (props.rundownId) rundown = Rundowns.findOne(props.rundownId)
 	let segments: Array<SegmentUi> = []
 	if (rundown) {
-		segments = _.map(rundown.getSegments(), (segment) => {
+		segments = _.map(rundown.getSegments({
+			isHidden: {
+				$ne: true
+			}
+		}), (segment) => {
 			return extendMandadory<Segment, SegmentUi>(segment, {
 				items: _.map(segment.getParts(), (part) => {
 					let sle = extendMandadory<Part, PartExtended>(part, {

--- a/meteor/lib/collections/Segments.ts
+++ b/meteor/lib/collections/Segments.ts
@@ -33,6 +33,7 @@ export class Segment implements DBSegment {
 	public status?: string
 	public expanded?: boolean
 	public notes?: Array<PartNote>
+	public isHidden?: boolean
 
 	constructor (document: DBSegment) {
 		_.each(_.keys(document), (key) => {


### PR DESCRIPTION
Support of a new feature: "Hidden Segments".
A Segment can now be set as "hidden" in the blueprints.
A Hidden segment will not be shown in the RundownView, but will be shown in the Shelf.

This is useful for example for adding Adlibs without nessesarily having them related to a certain Segment.