### PR TITLE
feat: Use source duration as fallback for VT

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -135,12 +135,20 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 			// Check item status
 			if (props.piece.sourceLayer) {
 
-				const { metadata, status } = checkPieceContentStatus(props.piece, props.piece.sourceLayer, props.rundown.getStudio().settings)
+				const { metadata, status, contentDuration } = checkPieceContentStatus(props.piece, props.piece.sourceLayer, props.rundown.getStudio().settings)
 				if (status !== props.piece.status || metadata) {
 					let pieceCopy = (_.clone(overrides.piece || props.piece) as PieceUi)
 
 					pieceCopy.status = status
 					pieceCopy.contentMetaData = metadata
+					
+					if (
+						pieceCopy.content &&
+						pieceCopy.content.sourceDuration === undefined &&
+						contentDuration !== undefined
+					) {
+						pieceCopy.content.sourceDuration = contentDuration
+					}
 
 					overrides.piece = _.extend(overrides.piece || {}, pieceCopy)
 				}


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the new behavior (if this is a feature change)?**
If the source duration of a VT/Server piece is not set by the blueprints, the actual length of the clip from the mediaObjects collection is used.