### PR TITLE
Snapshots handling

### DIFF
--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -42,6 +42,7 @@ export interface DBRundown extends IBlueprintRundownDB {
 	showStyleBaseId: string
 	/** The peripheral device the rundown originates from */
 	peripheralDeviceId: string
+	restoredFromSnapshotId?: string
 	created: Time
 	modified: Time
 
@@ -103,6 +104,7 @@ export class Rundown implements DBRundown {
 	public studioId: string
 	public showStyleBaseId: string
 	public peripheralDeviceId: string
+	public restoredFromSnapshotId?: string
 	public created: Time
 	public modified: Time
 	public importVersions: RundownImportVersions

--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -110,14 +110,14 @@ function generateCacheForRundown (rundownId: string, ingestRundown: IngestRundow
 	return cacheEntries
 }
 function generateCacheForSegment (rundownId: string, ingestSegment: IngestSegment): IngestDataCacheObj[] {
-	const segmentExternalId = getSegmentId(rundownId, ingestSegment.externalId)
+	const segmentId = getSegmentId(rundownId, ingestSegment.externalId)
 	const cacheEntries: Array<IngestDataCacheObjSegment | IngestDataCacheObjPart> = []
 
 	const segment: IngestDataCacheObjSegment = {
-		_id: `${rundownId}_${segmentExternalId}`,
+		_id: `${rundownId}_${segmentId}`,
 		type: IngestCacheType.SEGMENT,
 		rundownId: rundownId,
-		segmentId: segmentExternalId,
+		segmentId: segmentId,
 		modified: getCurrentTime(),
 		data: {
 			...ingestSegment,
@@ -127,18 +127,18 @@ function generateCacheForSegment (rundownId: string, ingestSegment: IngestSegmen
 	cacheEntries.push(segment)
 
 	_.each(ingestSegment.parts, part => {
-		cacheEntries.push(generateCacheForPart(rundownId, segmentExternalId, part))
+		cacheEntries.push(generateCacheForPart(rundownId, segmentId, part))
 	})
 
 	return cacheEntries
 }
-function generateCacheForPart (rundownId: string, segmentExternalId: string, part: IngestPart): IngestDataCacheObjPart {
+function generateCacheForPart (rundownId: string, segmentId: string, part: IngestPart): IngestDataCacheObjPart {
 	const partId = getPartId(rundownId, part.externalId)
 	return {
 		_id: `${rundownId}_${partId}`,
 		type: IngestCacheType.PART,
 		rundownId: rundownId,
-		segmentId: segmentExternalId,
+		segmentId: segmentId,
 		partId: partId,
 		modified: getCurrentTime(),
 		data: part

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -20,6 +20,7 @@ import { updateSegmentsFromIngestData } from '../ingest/rundownInput'
 import { updateSourceLayerInfinitesAfterPart } from './infinites'
 import { Studios } from '../../../lib/collections/Studios'
 import { DBSegment, Segments } from '../../../lib/collections/Segments'
+import { TimelineEnable } from 'superfly-timeline'
 
 /**
  * Reset the rundown:
@@ -304,6 +305,25 @@ export function onPartHasStoppedPlaying (part: Part, stoppedPlayingTime: Time) {
 		// logger.warn(`Part "${part._id}" has never started playback on rundown "${rundownId}".`)
 	}
 }
+
+export function substituteObjectIds (rawEnable: TimelineEnable, idMap: { [oldId: string]: string | undefined }) {
+	const replaceIds = (str: string) => {
+		return str.replace(/#([a-zA-Z0-9_]+)/g, (m) => {
+			const id = m.substr(1, m.length - 1)
+			return `#${idMap[id] || id}`
+		})
+	}
+
+	const enable = clone(rawEnable)
+
+	for (const key of _.keys(enable)) {
+		if (typeof enable[key] === 'string') {
+			enable[key] = replaceIds(enable[key])
+		}
+	}
+
+	return enable
+}
 export function prefixAllObjectIds<T extends TimelineObjGeneric> (objList: T[], prefix: string, ignoreOriginal?: boolean): T[] {
 	const getUpdatePrefixedId = (o: T) => {
 		let id = o.id
@@ -321,27 +341,16 @@ export function prefixAllObjectIds<T extends TimelineObjGeneric> (objList: T[], 
 		idMap[o.id] = getUpdatePrefixedId(o)
 	})
 
-	const replaceIds = (str: string) => {
-		return str.replace(/#([a-zA-Z0-9_]+)/g, (m) => {
-			const id = m.substr(1, m.length - 1)
-			return `#${idMap[id] || id}`
-		})
-	}
+	return objList.map(rawObj => {
+		const obj = clone(rawObj)
 
-	return objList.map(i => {
-		const o = clone(i)
-		o.id = getUpdatePrefixedId(o)
+		obj.id = getUpdatePrefixedId(obj)
+		obj.enable = substituteObjectIds(obj.enable, idMap)
 
-		for (const key of _.keys(o.enable)) {
-			if (typeof o.enable[key] === 'string') {
-				o.enable[key] = replaceIds(o.enable[key])
-			}
+		if (typeof obj.inGroup === 'string') {
+			obj.inGroup = idMap[obj.inGroup] || obj.inGroup
 		}
 
-		if (typeof o.inGroup === 'string') {
-			o.inGroup = idMap[o.inGroup] || o.inGroup
-		}
-
-		return o
+		return obj
 	})
 }

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -390,48 +390,82 @@ function restoreFromSnapshot (snapshot: AnySnapshot) {
 
 function restoreFromRundownSnapshot (snapshot: RundownSnapshot) {
 	logger.info(`Restoring from rundown snapshot "${snapshot.snapshot.name}"`)
-	let rundownId = snapshot.rundownId
+	const oldRundownId = snapshot.rundownId
 
 	if (!isVersionSupported(parseVersion(snapshot.version || '0.18.0'))) {
 		throw new Meteor.Error(400, `Cannot restore, the snapshot comes from an older, unsupported version of Sofie`)
 	}
 
-	if (rundownId !== snapshot.rundown._id) throw new Meteor.Error(500, `Restore snapshot: rundownIds don\'t match, "${rundownId}", "${snapshot.rundown._id}!"`)
-
-	let dbRundown = Rundowns.findOne(rundownId)
-
-	if (dbRundown && !dbRundown.unsynced) throw new Meteor.Error(500, `Not allowed to restore into synked Rundown!`)
+	if (oldRundownId !== snapshot.rundown._id) throw new Meteor.Error(500, `Restore snapshot: rundownIds don\'t match, "${oldRundownId}", "${snapshot.rundown._id}!"`)
 
 	if (!snapshot.rundown.unsynced) {
 		snapshot.rundown.unsynced = true
 		snapshot.rundown.unsyncedTime = getCurrentTime()
 	}
 
-	snapshot.rundown.active					= (dbRundown ? dbRundown.active : false)
-	snapshot.rundown.currentPartId		= (dbRundown ? dbRundown.currentPartId : null)
-	snapshot.rundown.nextPartId			= (dbRundown ? dbRundown.nextPartId : null)
-	snapshot.rundown.notifiedCurrentPlayingPartExternalId = (dbRundown ? dbRundown.notifiedCurrentPlayingPartExternalId : undefined)
+	const rundownId = snapshot.rundown._id = Random.id()
+	snapshot.rundown.restoredFromSnapshotId = snapshot.rundownId
+	snapshot.rundown.peripheralDeviceId = ''
+	snapshot.rundown.active = false
+	snapshot.rundown.currentPartId = null
+	snapshot.rundown.nextPartId = null
+	snapshot.rundown.notifiedCurrentPlayingPartExternalId = undefined
 
 	const studios = Studios.find().fetch()
-	if (studios.length === 1) snapshot.rundown.studioId = studios[0]._id
+	if (studios.length >= 1) snapshot.rundown.studioId = studios[0]._id
 
 	const showStyleVariants = ShowStyleVariants.find().fetch()
-	if (showStyleVariants.length === 1) {
+	if (showStyleVariants.length >= 1) {
 		snapshot.rundown.showStyleBaseId = showStyleVariants[0].showStyleBaseId
 		snapshot.rundown.showStyleVariantId = showStyleVariants[0]._id
 	}
 
+	// List any ids that need updating on other documents
+	const partIdMap: { [key: string]: string } = {}
+	_.each(snapshot.parts, part => {
+		const oldId = part._id
+		partIdMap[oldId] = part._id = Random.id()
+	})
+	const segmentIdMap: { [key: string]: string } = {}
+	_.each(snapshot.segments, segment => {
+		const oldId = segment._id
+		segmentIdMap[oldId] = segment._id = Random.id()
+	})
+
+	// Apply the updates of any properties to any document
+	function updateItemIds<T extends { _id: string, rundownId: string, partId?: string, segmentId?: string }> (objs: T[], updateId: boolean): T[] {
+		return objs.map(obj => {
+			if (obj.rundownId) {
+				obj.rundownId = rundownId
+			}
+
+			if (obj.partId) {
+				obj.partId = partIdMap[obj.partId]
+			}
+			if (obj.segmentId) {
+				obj.segmentId = segmentIdMap[obj.segmentId]
+			}
+
+			if (updateId) {
+				obj._id = Random.id()
+			}
+
+			return obj
+		})
+	}
+
 	saveIntoDb(Rundowns, { _id: rundownId }, [snapshot.rundown])
-	saveIntoDb(IngestDataCache, { rundownId: rundownId }, snapshot.ingestData)
+	saveIntoDb(IngestDataCache, { rundownId: rundownId }, updateItemIds(snapshot.ingestData, true))
 	// saveIntoDb(UserActionsLog, {}, snapshot.userActions)
-	saveIntoDb(RundownBaselineObjs, { rundownId: rundownId }, snapshot.baselineObjs)
-	saveIntoDb(RundownBaselineAdLibPieces, { rundownId: rundownId }, snapshot.baselineAdlibs)
-	saveIntoDb(Segments, { rundownId: rundownId }, snapshot.segments)
-	saveIntoDb(Parts, { rundownId: rundownId }, snapshot.parts)
-	saveIntoDb(Pieces, { rundownId: rundownId }, snapshot.pieces)
-	saveIntoDb(AdLibPieces, { rundownId: rundownId }, snapshot.adLibPieces)
+	saveIntoDb(RundownBaselineObjs, { rundownId: rundownId }, updateItemIds(snapshot.baselineObjs, true))
+	saveIntoDb(RundownBaselineAdLibPieces, { rundownId: rundownId }, updateItemIds(snapshot.baselineAdlibs, true))
+	saveIntoDb(Segments, { rundownId: rundownId }, updateItemIds(snapshot.segments, false))
+	saveIntoDb(Parts, { rundownId: rundownId }, updateItemIds(snapshot.parts, false))
+	saveIntoDb(Pieces, { rundownId: rundownId }, updateItemIds(snapshot.pieces, true))
+	saveIntoDb(AdLibPieces, { rundownId: rundownId }, updateItemIds(snapshot.adLibPieces, true))
+	saveIntoDb(ExpectedMediaItems, { partId: { $in: snapshot.parts.map(i => i._id) } }, updateItemIds(snapshot.expectedMediaItems, true))
+
 	saveIntoDb(MediaObjects, { _id: { $in: _.map(snapshot.mediaObjects, mediaObject => mediaObject._id) } }, snapshot.mediaObjects)
-	saveIntoDb(ExpectedMediaItems, { partId: { $in: snapshot.parts.map(i => i._id) } }, snapshot.expectedMediaItems)
 
 	logger.info(`Restore done`)
 }


### PR DESCRIPTION
This PR fixes some issues with how Snapshots are handled.
The most prominent change is: When restoring a rundown from a snapshot, always restore into a new rundown-id.