### PR TITLE
MakeReady & StandDown

### DIFF
--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -108,7 +108,12 @@ export function deactivateRundownInner (rundown: Rundown) {
 
 	IngestActions.notifyCurrentPlayingPart(rundown, null)
 }
-export function prepareStudioForBroadcast (studio: Studio) {
+/**
+ * Prepares studio before a broadcast is about to start
+ * @param studio
+ * @param okToDestoryStuff true if we're not ON AIR, things might flicker on the output
+ */
+export function prepareStudioForBroadcast (studio: Studio, okToDestoryStuff: boolean) {
 	logger.info('prepareStudioForBroadcast ' + studio._id)
 
 	const ssrcBgs: Array<IConfigItem> = _.compact([
@@ -124,7 +129,6 @@ export function prepareStudioForBroadcast (studio: Studio) {
 	}).fetch()
 
 	_.each(playoutDevices, (device: PeripheralDevice) => {
-		let okToDestoryStuff = true
 		PeripheralDeviceAPI.executeFunction(device._id, (err) => {
 			if (err) {
 				logger.error(err)
@@ -133,14 +137,16 @@ export function prepareStudioForBroadcast (studio: Studio) {
 			}
 		}, 'devicesMakeReady', okToDestoryStuff)
 
-		if (ssrcBgs.length > 0) {
-			PeripheralDeviceAPI.executeFunction(device._id, (err) => {
-				if (err) {
-					logger.error(err)
-				} else {
-					logger.info('Added Super Source BG to Atem')
-				}
-			}, 'uploadFileToAtem', ssrcBgs)
+		if (okToDestoryStuff) {
+			if (ssrcBgs.length > 0) {
+				PeripheralDeviceAPI.executeFunction(device._id, (err) => {
+					if (err) {
+						logger.error(err)
+					} else {
+						logger.info('Added Super Source BG to Atem')
+					}
+				}, 'uploadFileToAtem', ssrcBgs)
+			}
 		}
 	})
 }

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -150,3 +150,26 @@ export function prepareStudioForBroadcast (studio: Studio, okToDestoryStuff: boo
 		}
 	})
 }
+/**
+ * Makes a studio "stand down" after a broadcast
+ * @param studio
+ * @param okToDestoryStuff true if we're not ON AIR, things might flicker on the output
+ */
+export function standDownStudio (studio: Studio, okToDestoryStuff: boolean) {
+	logger.info('standDownStudio ' + studio._id)
+
+	let playoutDevices = PeripheralDevices.find({
+		studioId: studio._id,
+		type: PeripheralDeviceAPI.DeviceType.PLAYOUT
+	}).fetch()
+
+	_.each(playoutDevices, (device: PeripheralDevice) => {
+		PeripheralDeviceAPI.executeFunction(device._id, (err) => {
+			if (err) {
+				logger.error(err)
+			} else {
+				logger.info('devicesStandDown OK')
+			}
+		}, 'devicesStandDown', okToDestoryStuff)
+	})
+}

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -180,6 +180,8 @@ export namespace ServerPlayoutAPI {
 			const rundown = Rundowns.findOne(rundownId)
 			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
 
+			standDownStudio(rundown.getStudio(), true)
+
 			return libDeactivateRundown(rundown)
 		})
 	}

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -54,7 +54,8 @@ import {
 	prepareStudioForBroadcast,
 	activateRundown as libActivateRundown,
 	deactivateRundown as libDeactivateRundown,
-	deactivateRundownInner
+	deactivateRundownInner,
+	standDownStudio
 } from './actions'
 import { PieceResolved, getOrderedPiece, getResolvedPieces, convertAdLibToPiece, convertPieceToAdLibPiece, resolveActivePieces } from './pieces'
 import { PackageInfo } from '../../coreSystem'
@@ -83,7 +84,7 @@ export namespace ServerPlayoutAPI {
 			}
 
 			libResetRundown(rundown)
-			prepareStudioForBroadcast(rundown.getStudio())
+			prepareStudioForBroadcast(rundown.getStudio(), true)
 
 			return libActivateRundown(rundown, true) // Activate rundown (rehearsal)
 		})
@@ -116,6 +117,7 @@ export namespace ServerPlayoutAPI {
 			if (rundown.active && !rundown.rehearsal) throw new Meteor.Error(402, `rundownResetAndActivate cannot be run when active!`)
 
 			libResetRundown(rundown)
+			prepareStudioForBroadcast(rundown.getStudio(), true)
 
 			return libActivateRundown(rundown, !!rehearsal) // Activate rundown
 		})
@@ -151,6 +153,7 @@ export namespace ServerPlayoutAPI {
 			}
 
 			libResetRundown(rundown)
+			prepareStudioForBroadcast(rundown.getStudio(), true)
 
 			return libActivateRundown(rundown, rehearsal)
 		})
@@ -163,6 +166,8 @@ export namespace ServerPlayoutAPI {
 		return rundownSyncFunction(rundownId, RundownSyncFunctionPriority.Playout, () => {
 			const rundown = Rundowns.findOne(rundownId)
 			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
+
+			prepareStudioForBroadcast(rundown.getStudio(), true)
 
 			return libActivateRundown(rundown, rehearsal)
 		})


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the new behavior (if this is a feature change)?**
Better handling of the makeReady & standDown signals, that is sent from Core to Playout-gateway before (and after) a show.

Now makeReady is also sent upon _activation of a rundown_, not only on "prepare rundown".

Note: This should be tested by NRK before merging, to ensure the system still works as intended.