### PR TITLE
feat: Add field for CasparCG mappings previewWhenNotOnAir property

### DIFF
--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -289,6 +289,19 @@ const StudioMappings = translate()(class StudioMappings extends React.Component<
 						<i>{t('The layer in a channel to use')}</i>
 					</label>
 				</div>
+				<div className='mod mvs mhs'>
+					<label className='field'>
+						{t('Preview when not on air')}
+						<EditAttribute
+							modifiedClassName='bghl'
+							attribute={'mappings.' + layerId + '.previewWhenNotOnAir'}
+							obj={this.props.studio}
+							type='checkbox'
+							collection={Studios}
+							className='input'></EditAttribute>
+						<i>{t('Whether to load to first frame')}</i>
+					</label>
+				</div>
 			</React.Fragment>
 		)
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the new behavior (if this is a feature change)?**
Adds the option "preview when not on air" to CasparCG layer mappings, allowing for the first frame of a video to be loaded on a caspar player that is about
to be taken on air (set as next).
* **Other information**:
This can be used with A/B playback to show a preview of the next clip to be played while a clip is still on-air.