### PR TITLE
feat: Queued adlibs

### DIFF
--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -15,7 +15,7 @@ import { prefixAllObjectIds } from './lib'
 import { convertAdLibToPiece, getResolvedPieces } from './pieces'
 import { cropInfinitesOnLayer, stopInfinitesRunningOnLayer } from './infinites'
 import { updateTimeline } from './timeline'
-import { updatePartRanks } from '../rundown'
+import { updatePartRanks, afterRemoveParts } from '../rundown'
 import { rundownSyncFunction, RundownSyncFunctionPriority } from '../ingest/rundownInput'
 
 import { ServerPlayoutAPI } from './playout' // TODO - this should not be calling back like this
@@ -176,6 +176,24 @@ export namespace ServerPlayoutAdLibAPI {
 
 		const part = Parts.findOne(partId)
 		if (!part) throw new Meteor.Error(404, `Part "${partId}" not found!`)
+
+		const afterPartId = part.afterPart || part._id
+
+		// check if there's already a queued part after this:
+		const alreadyQueuedPart = Parts.findOne({
+			rundownId: rundown._id,
+			segmentId: part.segmentId,
+			afterPart: afterPartId,
+			_rank: { $gt: part._rank }
+		}, {
+			sort: { _rank: -1, _id: -1 }
+		})
+		if (alreadyQueuedPart) {
+			if (rundown.currentPartId !== alreadyQueuedPart._id) {
+				Parts.remove(alreadyQueuedPart._id)
+				afterRemoveParts(rundown._id, [alreadyQueuedPart])
+			}
+		}
 
 		const newPartId = Random.id()
 		Parts.insert({

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -135,6 +135,11 @@ export namespace ServerPlayoutAdLibAPI {
 		})
 	}
 	function innerStartAdLibPiece (rundown: Rundown, queue: boolean, partId: string, adLibPiece: AdLibPiece) {
+		if (adLibPiece.toBeQueued) {
+			// Allow adlib to request to always be queued
+			queue = true
+		}
+
 		let orgPartId = partId
 		if (queue) {
 			// insert a NEW, adlibbed part after this part

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -12,7 +12,7 @@ import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBase
 import { Pieces, Piece } from '../../../lib/collections/Pieces'
 import { Parts } from '../../../lib/collections/Parts'
 import { prefixAllObjectIds } from './lib'
-import { convertAdLibToPiece, getResolvedPieces } from './pieces'
+import { convertAdLibToPiece, getResolvedPieces, convertPieceToAdLibPiece } from './pieces'
 import { cropInfinitesOnLayer, stopInfinitesRunningOnLayer } from './infinites'
 import { updateTimeline } from './timeline'
 import { updatePartRanks, afterRemoveParts } from '../rundown'
@@ -271,6 +271,41 @@ export namespace ServerPlayoutAdLibAPI {
 			})
 
 			updateTimeline(rundown.studioId)
+		})
+	}
+	export function sourceLayerStickyPieceStart (rundownId: string, sourceLayerId: string) {
+		return rundownSyncFunction(rundownId, RundownSyncFunctionPriority.Playout, () => {
+			const rundown = Rundowns.findOne(rundownId)
+			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
+			if (!rundown.active) throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
+			if (!rundown.currentPartId) throw new Meteor.Error(400, `A part needs to be active to place a sticky item`)
+
+			let showStyleBase = rundown.getShowStyleBase()
+
+			const sourceLayer = showStyleBase.sourceLayers.find(i => i._id === sourceLayerId)
+			if (!sourceLayer) throw new Meteor.Error(404, `Source layer "${sourceLayerId}" not found!`)
+			if (!sourceLayer.isSticky) throw new Meteor.Error(400, `Only sticky layers can be restarted. "${sourceLayerId}" is not sticky.`)
+
+			const lastPieces = Pieces.find({
+				rundownId: rundown._id,
+				sourceLayerId: sourceLayer._id,
+				startedPlayback: {
+					$exists: true
+				}
+			}, {
+				sort: {
+					startedPlayback: -1
+				},
+				limit: 1
+			}).fetch()
+
+			if (lastPieces.length > 0) {
+				const currentPart = Parts.findOne(rundown.currentPartId)
+				if (!currentPart) throw new Meteor.Error(501, `Current Part "${rundown.currentPartId}" could not be found.`)
+
+				const lastPiece = convertPieceToAdLibPiece(lastPieces[0])
+				innerStartAdLibPiece(rundown, false, rundown.currentPartId, lastPiece)
+			}
 		})
 	}
 }

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -17,7 +17,7 @@ import { getCurrentTime,
 	clone,
 	literal,
 	asyncCollectionRemove} from '../../../lib/lib'
-import { Timeline, getTimelineId, TimelineObjGeneric } from '../../../lib/collections/Timeline'
+import { Timeline, TimelineObjGeneric } from '../../../lib/collections/Timeline'
 import { Segments, Segment } from '../../../lib/collections/Segments'
 import { Random } from 'meteor/random'
 import * as _ from 'underscore'
@@ -40,7 +40,7 @@ import {
 } from '../asRunLog'
 import { Blueprints } from '../../../lib/collections/Blueprints'
 import { getBlueprintOfRundown } from '../blueprints/cache'
-import { PartEventContext, PartContext, RundownContext } from '../blueprints/context'
+import { PartEventContext, RundownContext } from '../blueprints/context'
 import { IngestActions } from '../ingest/actions'
 import { updateTimeline } from './timeline'
 import {
@@ -56,14 +56,12 @@ import {
 	deactivateRundown as libDeactivateRundown,
 	deactivateRundownInner
 } from './actions'
-import { PieceResolved, getOrderedPiece, getResolvedPieces, convertAdLibToPiece, convertPieceToAdLibPiece, resolveActivePieces } from './pieces'
+import { PieceResolved, getOrderedPiece, getResolvedPieces } from './pieces'
 import { PackageInfo } from '../../coreSystem'
 import { areThereActiveRundownsInStudio } from './studio'
-import { updateSourceLayerInfinitesAfterPart, cropInfinitesOnLayer, stopInfinitesRunningOnLayer } from './infinites'
+import { updateSourceLayerInfinitesAfterPart } from './infinites'
 import { rundownSyncFunction, RundownSyncFunctionPriority } from '../ingest/rundownInput'
 import { ServerPlayoutAdLibAPI } from './adlib'
-import { transformTimeline } from '../../../lib/timeline'
-import * as SuperTimeline from 'superfly-timeline'
 
 export namespace ServerPlayoutAPI {
 	/**
@@ -978,48 +976,7 @@ export namespace ServerPlayoutAPI {
 		check(rundownId, String)
 		check(sourceLayerId, String)
 
-		return rundownSyncFunction(rundownId, RundownSyncFunctionPriority.Playout, () => {
-			const rundown = Rundowns.findOne(rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
-			if (!rundown.active) throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
-			if (!rundown.currentPartId) throw new Meteor.Error(400, `A part needs to be active to place a sticky item`)
-
-			let showStyleBase = rundown.getShowStyleBase()
-
-			const sourceLayer = showStyleBase.sourceLayers.find(i => i._id === sourceLayerId)
-			if (!sourceLayer) throw new Meteor.Error(404, `Source layer "${sourceLayerId}" not found!`)
-			if (!sourceLayer.isSticky) throw new Meteor.Error(400, `Only sticky layers can be restarted. "${sourceLayerId}" is not sticky.`)
-
-			const lastPieces = Pieces.find({
-				rundownId: rundown._id,
-				sourceLayerId: sourceLayer._id,
-				startedPlayback: {
-					$exists: true
-				}
-			}, {
-				sort: {
-					startedPlayback: -1
-				},
-				limit: 1
-			}).fetch()
-
-			if (lastPieces.length > 0) {
-				const currentPart = Parts.findOne(rundown.currentPartId)
-				if (!currentPart) throw new Meteor.Error(501, `Current Part "${rundown.currentPartId}" could not be found.`)
-
-				const lastPiece = convertPieceToAdLibPiece(lastPieces[0])
-				const newAdLibPiece = convertAdLibToPiece(lastPiece, currentPart, false)
-
-				Pieces.insert(newAdLibPiece)
-
-				// logger.debug('adLibItemStart', newPiece)
-
-				cropInfinitesOnLayer(rundown, currentPart, newAdLibPiece)
-				stopInfinitesRunningOnLayer(rundown, currentPart, newAdLibPiece.sourceLayerId)
-
-				updateTimeline(rundown.studioId)
-			}
-		})
+		return ServerPlayoutAdLibAPI.sourceLayerStickyPieceStart(rundownId, sourceLayerId)
 	}
 	export function sourceLayerOnPartStop (rundownId: string, partId: string, sourceLayerId: string) {
 		check(rundownId, String)


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the new behavior (if this is a feature change)?**
Allows an adlib to indicate that it should always be queued when added to the timeline, rather than being immediately taken on air.
* **Other information**:
An example usecase is allowing the inserting of transitions as adlibs, where they may need to be created as their own part for timing calculations
to work.