### PR TITLE
ExpectedPlayoutItems

### DIFF
--- a/meteor/lib/api/pubsub.ts
+++ b/meteor/lib/api/pubsub.ts
@@ -5,6 +5,7 @@ export enum PubSub {
 	blueprints = 'blueprints',
 	coreSystem = 'coreSystem',
 	evaluations = 'evaluations',
+	expectedPlayoutItems = 'expectedPlayoutItems',
 	expectedMediaItems = 'expectedMediaItems',
 	externalMessageQueue = 'externalMessageQueue',
 	mediaObjects = 'mediaObjects',

--- a/meteor/lib/collections/ExpectedPlayoutItems.ts
+++ b/meteor/lib/collections/ExpectedPlayoutItems.ts
@@ -1,0 +1,46 @@
+import { Meteor } from 'meteor/meteor'
+import { TransformedCollection } from '../typings/meteor'
+import { registerCollection } from '../lib'
+import { createMongoCollection } from './lib'
+import { DeviceType as TSR_DeviceType } from 'timeline-state-resolver-types'
+
+export interface ExpectedPlayoutItem {
+	_id: string
+
+	/** The studio installation this ExpectedPlayoutItem was generated in */
+	studioId: string
+	/** The rundown id that is the source of this PlayoutItem */
+	rundownId: string
+	/** The part id that is the source of this Playout Item */
+	partId: string
+	/** The piece id that is the source of this Playout Item */
+	pieceId: string
+
+	/** What type of playout device this item should be handled by */
+	deviceSubType: TSR_DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
+	/** Which playout device this item should be handled by */
+	// deviceId: string // Todo: implement deviceId support (later)
+
+	content: ExpectedPlayoutItemContent
+}
+export type ExpectedPlayoutItemContent = ExpectedPlayoutItemContentVizMSE
+
+export interface ExpectedPlayoutItemContentVizMSE { // TODO: This is a temporary implementation, and is a copy of the TSR typings
+	templateName: string
+	elementName: string | number // if number, it's a vizPilot element
+	dataFields: string[]
+}
+
+export const ExpectedPlayoutItems: TransformedCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>
+	= createMongoCollection<ExpectedPlayoutItem>('expectedPlayoutItems')
+registerCollection('ExpectedPlayoutItems', ExpectedPlayoutItems)
+Meteor.startup(() => {
+	if (Meteor.isServer) {
+		ExpectedPlayoutItems._ensureIndex({
+			studioId: 1
+		})
+		ExpectedPlayoutItems._ensureIndex({
+			rundownId: 1
+		})
+	}
+})

--- a/meteor/lib/collections/ExpectedPlayoutItems.ts
+++ b/meteor/lib/collections/ExpectedPlayoutItems.ts
@@ -4,17 +4,7 @@ import { registerCollection } from '../lib'
 import { createMongoCollection } from './lib'
 import { DeviceType as TSR_DeviceType } from 'timeline-state-resolver-types'
 
-export interface ExpectedPlayoutItem {
-	_id: string
-
-	/** The studio installation this ExpectedPlayoutItem was generated in */
-	studioId: string
-	/** The rundown id that is the source of this PlayoutItem */
-	rundownId: string
-	/** The part id that is the source of this Playout Item */
-	partId: string
-	/** The piece id that is the source of this Playout Item */
-	pieceId: string
+export interface ExpectedPlayoutItemGeneric { // TMP! This is to be moved into the blueprint definitions!
 
 	/** What type of playout device this item should be handled by */
 	deviceSubType: TSR_DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
@@ -30,6 +20,21 @@ export interface ExpectedPlayoutItemContentVizMSE { // TODO: This is a temporary
 	elementName: string | number // if number, it's a vizPilot element
 	dataFields: string[]
 }
+
+export interface ExpectedPlayoutItem extends ExpectedPlayoutItemGeneric {
+	/** Globally unique id of the item */
+	_id: string
+
+	/** The studio installation this ExpectedPlayoutItem was generated in */
+	studioId: string
+	/** The rundown id that is the source of this PlayoutItem */
+	rundownId: string
+	/** The part id that is the source of this Playout Item */
+	partId?: string
+	/** The piece id that is the source of this Playout Item */
+	pieceId: string
+}
+
 
 export const ExpectedPlayoutItems: TransformedCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>
 	= createMongoCollection<ExpectedPlayoutItem>('expectedPlayoutItems')

--- a/meteor/lib/collections/ExpectedPlayoutItems.ts
+++ b/meteor/lib/collections/ExpectedPlayoutItems.ts
@@ -2,24 +2,7 @@ import { Meteor } from 'meteor/meteor'
 import { TransformedCollection } from '../typings/meteor'
 import { registerCollection } from '../lib'
 import { createMongoCollection } from './lib'
-import { DeviceType as TSR_DeviceType } from 'timeline-state-resolver-types'
-
-export interface ExpectedPlayoutItemGeneric { // TMP! This is to be moved into the blueprint definitions!
-
-	/** What type of playout device this item should be handled by */
-	deviceSubType: TSR_DeviceType // subset of PeripheralDeviceAPI.DeviceSubType
-	/** Which playout device this item should be handled by */
-	// deviceId: string // Todo: implement deviceId support (later)
-
-	content: ExpectedPlayoutItemContent
-}
-export type ExpectedPlayoutItemContent = ExpectedPlayoutItemContentVizMSE
-
-export interface ExpectedPlayoutItemContentVizMSE { // TODO: This is a temporary implementation, and is a copy of the TSR typings
-	templateName: string
-	elementName: string | number // if number, it's a vizPilot element
-	dataFields: string[]
-}
+import { ExpectedPlayoutItemGeneric } from 'tv-automation-sofie-blueprints-integration'
 
 export interface ExpectedPlayoutItem extends ExpectedPlayoutItemGeneric {
 	/** Globally unique id of the item */

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -146,6 +146,9 @@ export class Part implements DBPart {
 			}, options)
 		).fetch()
 	}
+	getAllAdLibPieces () {
+		return this.getAdLibPieces()
+	}
 	getTimings () {
 		// return a chronological list of timing events
 		let events: Array<{time: Time, type: string, elapsed: Time}> = []

--- a/meteor/lib/collections/Pieces.ts
+++ b/meteor/lib/collections/Pieces.ts
@@ -11,9 +11,17 @@ import {
 	BaseContent,
 } from 'tv-automation-sofie-blueprints-integration'
 import { createMongoCollection } from './lib'
+import { ExpectedPlayoutItemGeneric } from './ExpectedPlayoutItems'
+
+// TMP!!!!!!!!!!!!!!!!!!!!
+// This is to be moved into IBlueprintPieceGeneric
+interface IBlueprintPieceGeneriTMPToBeInBlueprints {
+	expectedPlayoutItems?: Array<ExpectedPlayoutItemGeneric>
+}
+
 
 /** A Single item in a "line": script, VT, cameras */
-export interface PieceGeneric extends IBlueprintPieceGeneric {
+export interface PieceGeneric extends IBlueprintPieceGeneric, IBlueprintPieceGeneriTMPToBeInBlueprints {
 	// ------------------------------------------------------------------
 	_id: string
 	/** ID of the source object in MOS */

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -16,6 +16,7 @@ import { RundownNote } from '../api/notes'
 import { IngestDataCache } from './IngestDataCache'
 import { ExpectedMediaItems } from './ExpectedMediaItems'
 import { createMongoCollection } from './lib'
+import { ExpectedPlayoutItems } from './ExpectedPlayoutItems'
 
 export enum RundownHoldState {
 	NONE = 0,
@@ -188,6 +189,7 @@ export class Rundown implements DBRundown {
 		RundownBaselineAdLibPieces.remove({ rundownId: this._id })
 		IngestDataCache.remove({ rundownId: this._id })
 		ExpectedMediaItems.remove({ rundownId: this._id })
+		ExpectedPlayoutItems.remove({ rundownId: this._id })
 	}
 	touch () {
 		if (getCurrentTime() - this.modified > 3600 * 1000) {

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -42,6 +42,7 @@ export interface DBRundown extends IBlueprintRundownDB {
 	showStyleBaseId: string
 	/** The peripheral device the rundown originates from */
 	peripheralDeviceId: string
+	restoredFromSnapshotId?: string
 	created: Time
 	modified: Time
 
@@ -103,6 +104,7 @@ export class Rundown implements DBRundown {
 	public studioId: string
 	public showStyleBaseId: string
 	public peripheralDeviceId: string
+	public restoredFromSnapshotId?: string
 	public created: Time
 	public modified: Time
 	public importVersions: RundownImportVersions

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -1,3 +1,4 @@
+import { check } from 'meteor/check'
 import { PieceGeneric, Piece } from '../../../lib/collections/Pieces'
 import { ExpectedPlayoutItem, ExpectedPlayoutItemGeneric, ExpectedPlayoutItems } from '../../../lib/collections/ExpectedPlayoutItems'
 import * as _ from 'underscore'

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -1,0 +1,49 @@
+import { PieceGeneric, Piece } from '../../../lib/collections/Pieces'
+import { ExpectedPlayoutItem, ExpectedPlayoutItemGeneric } from '../../../lib/collections/ExpectedPlayoutItems'
+import * as _ from 'underscore'
+import { DBRundown } from '../../../lib/collections/Rundowns'
+import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
+
+interface ExpectedPlayoutItemGenericWithPiece extends ExpectedPlayoutItemGeneric {
+	partId?: string
+	pieceId: string
+}
+export function extractExpectedPlayoutItems (rundown: DBRundown, pieces: Array<Piece | AdLibPiece>): ExpectedPlayoutItem[] {
+
+	let expectedPlayoutItemsGeneric: ExpectedPlayoutItemGenericWithPiece[] = []
+
+	_.each(pieces, piece => {
+
+		if (piece.expectedPlayoutItems) {
+
+			_.each(piece.expectedPlayoutItems, pieceItem => {
+
+				expectedPlayoutItemsGeneric.push({
+					pieceId: piece._id,
+					partId: piece.partId,
+					...pieceItem
+				})
+			})
+		}
+	})
+	// TODO: Maybe make the expectedPlayoutItemsGeneric unique first?
+
+	// expectedPlayoutItemsGeneric.sort((a, b) => {
+	// })
+	// expectedPlayoutItemsGeneric = _.uniq(expectedPlayoutItemsGeneric, false, (a ,b) => {
+	// 	return _.isEqual(
+	// 		_.omit(a, ['pieceId']),
+	// 		_.omit(b, ['pieceId'])
+	// 	)
+	// })
+
+	let i: number = 0
+	return _.map<ExpectedPlayoutItemGenericWithPiece, ExpectedPlayoutItem>(expectedPlayoutItemsGeneric, item => {
+		return {
+			_id: item.pieceId + '_' + (i++),
+			studioId: rundown.studioId,
+			rundownId: rundown._id,
+			...item
+		}
+	})
+}

--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -110,14 +110,14 @@ function generateCacheForRundown (rundownId: string, ingestRundown: IngestRundow
 	return cacheEntries
 }
 function generateCacheForSegment (rundownId: string, ingestSegment: IngestSegment): IngestDataCacheObj[] {
-	const segmentExternalId = getSegmentId(rundownId, ingestSegment.externalId)
+	const segmentId = getSegmentId(rundownId, ingestSegment.externalId)
 	const cacheEntries: Array<IngestDataCacheObjSegment | IngestDataCacheObjPart> = []
 
 	const segment: IngestDataCacheObjSegment = {
-		_id: `${rundownId}_${segmentExternalId}`,
+		_id: `${rundownId}_${segmentId}`,
 		type: IngestCacheType.SEGMENT,
 		rundownId: rundownId,
-		segmentId: segmentExternalId,
+		segmentId: segmentId,
 		modified: getCurrentTime(),
 		data: {
 			...ingestSegment,
@@ -127,18 +127,18 @@ function generateCacheForSegment (rundownId: string, ingestSegment: IngestSegmen
 	cacheEntries.push(segment)
 
 	_.each(ingestSegment.parts, part => {
-		cacheEntries.push(generateCacheForPart(rundownId, segmentExternalId, part))
+		cacheEntries.push(generateCacheForPart(rundownId, segmentId, part))
 	})
 
 	return cacheEntries
 }
-function generateCacheForPart (rundownId: string, segmentExternalId: string, part: IngestPart): IngestDataCacheObjPart {
+function generateCacheForPart (rundownId: string, segmentId: string, part: IngestPart): IngestDataCacheObjPart {
 	const partId = getPartId(rundownId, part.externalId)
 	return {
 		_id: `${rundownId}_${partId}`,
 		type: IngestCacheType.PART,
 		rundownId: rundownId,
-		segmentId: segmentExternalId,
+		segmentId: segmentId,
 		partId: partId,
 		modified: getCurrentTime(),
 		data: part

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -47,7 +47,7 @@ import { PartNote, NoteType } from '../../../lib/api/notes'
 import { syncFunction } from '../../codeControl'
 import { updateSourceLayerInfinitesAfterPart } from '../playout/infinites'
 import { UpdateNext } from './updateNext'
-import { extractExpectedPlayoutItems } from './expectedPlayoutItems'
+import { extractExpectedPlayoutItems, updateExpectedPlayoutItemsOnRundown } from './expectedPlayoutItems'
 import { ExpectedPlayoutItem, ExpectedPlayoutItems } from '../../../lib/collections/ExpectedPlayoutItems'
 
 export enum RundownSyncFunctionPriority {
@@ -316,11 +316,6 @@ function updateRundownFromIngestData (
 		adlibPieces.push(...segmentContents.adlibPieces)
 	})
 
-	const expectedPlayoutItems: ExpectedPlayoutItem[] = extractExpectedPlayoutItems(dbRundown, [
-		...segmentPieces,
-		...adlibPieces
-	])
-
 	changes = sumChanges(
 		changes,
 		// Save the baseline
@@ -387,10 +382,7 @@ function updateRundownFromIngestData (
 			afterRemove (adLibPiece) {
 				logger.debug('deleted piece ' + adLibPiece._id)
 			}
-		}),
-		saveIntoDb<ExpectedPlayoutItem, ExpectedPlayoutItem>(ExpectedPlayoutItems, {
-			rundownId: rundownId,
-		}, expectedPlayoutItems)
+		})
 	)
 
 	const didChange = anythingChanged(changes)
@@ -533,6 +525,7 @@ function updateSegmentFromIngestData (
 export function afterIngestChangedData (rundown: Rundown, segmentIds: string[]) {
 	// To be called after rundown has been changed
 	updateExpectedMediaItemsOnRundown(rundown._id)
+	updateExpectedPlayoutItemsOnRundown(rundown._id)
 	updatePartRanks(rundown._id)
 	updateSourceLayerInfinitesAfterPart(rundown)
 	UpdateNext.ensureNextPartIsValid(rundown)

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -28,7 +28,7 @@ import { PeripheralDeviceSecurity } from '../../security/peripheralDevices'
 import { IngestRundown, IngestSegment, IngestPart, BlueprintResultSegment } from 'tv-automation-sofie-blueprints-integration'
 import { logger } from '../../../lib/logging'
 import { Studio } from '../../../lib/collections/Studios'
-import { selectShowStyleVariant, afterRemoveSegments, afterRemoveParts, ServerRundownAPI, removeSegments, updatePartRanks } from '../rundown'
+import { selectShowStyleVariant, afterRemoveSegments, afterRemoveParts, ServerRundownAPI, removeSegments, updatePartRanks, afterRemovePieces } from '../rundown'
 import { loadShowStyleBlueprints, getBlueprintOfRundown } from '../blueprints/cache'
 import { ShowStyleContext, RundownContext, SegmentContext } from '../blueprints/context'
 import { Blueprints, Blueprint } from '../../../lib/collections/Blueprints'
@@ -364,6 +364,9 @@ function updateRundownFromIngestData (
 			},
 			afterRemove (piece) {
 				logger.debug('deleted piece ' + piece._id)
+			},
+			afterRemoveAll (pieces) {
+				afterRemovePieces(rundownId, pieces)
 			}
 		}),
 
@@ -379,6 +382,9 @@ function updateRundownFromIngestData (
 			},
 			afterRemove (adLibPiece) {
 				logger.debug('deleted piece ' + adLibPiece._id)
+			},
+			afterRemoveAll (pieces) {
+				afterRemovePieces(rundownId, pieces)
 			}
 		})
 	)

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -108,7 +108,12 @@ export function deactivateRundownInner (rundown: Rundown) {
 
 	IngestActions.notifyCurrentPlayingPart(rundown, null)
 }
-export function prepareStudioForBroadcast (studio: Studio) {
+/**
+ * Prepares studio before a broadcast is about to start
+ * @param studio
+ * @param okToDestoryStuff true if we're not ON AIR, things might flicker on the output
+ */
+export function prepareStudioForBroadcast (studio: Studio, okToDestoryStuff: boolean, rundownToBeActivated: Rundown) {
 	logger.info('prepareStudioForBroadcast ' + studio._id)
 
 	const ssrcBgs: Array<IConfigItem> = _.compact([
@@ -131,7 +136,7 @@ export function prepareStudioForBroadcast (studio: Studio) {
 			} else {
 				logger.info('devicesMakeReady OK')
 			}
-		}, 'devicesMakeReady', okToDestoryStuff)
+		}, 'devicesMakeReady', okToDestoryStuff, rundownToBeActivated._id)
 
 		if (ssrcBgs.length > 0) {
 			PeripheralDeviceAPI.executeFunction(device._id, (err) => {

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -178,6 +178,10 @@ export function updateSourceLayerInfinitesAfterPartInner (rundown: Rundown, prev
 			   newPiece.startedPlayback = existingPiece.startedPlayback
 			   newPiece.stoppedPlayback = existingPiece.stoppedPlayback
 			   newPiece.timings = existingPiece.timings
+
+			   if (newPiece.expectedPlayoutItems) {
+				   newPiece.expectedPlayoutItems = []
+			   }
 		   }
 
 		   let pieceToInsert: Piece | null = (allowInsert ? newPiece : null)

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -268,7 +268,7 @@ export const stopInfinitesRunningOnLayer = syncFunction(function stopInfinitesRu
 			break
 		}
 
-		continuations.forEach(i => Pieces.remove(i))
+		continuations.forEach(i => Pieces.remove(i._id))
 	}
 
 	// ensure adlib is extended correctly if infinite

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -20,6 +20,7 @@ import { updateSegmentsFromIngestData } from '../ingest/rundownInput'
 import { updateSourceLayerInfinitesAfterPart } from './infinites'
 import { Studios } from '../../../lib/collections/Studios'
 import { DBSegment, Segments } from '../../../lib/collections/Segments'
+import { TimelineEnable } from 'superfly-timeline'
 
 /**
  * Reset the rundown:
@@ -304,6 +305,25 @@ export function onPartHasStoppedPlaying (part: Part, stoppedPlayingTime: Time) {
 		// logger.warn(`Part "${part._id}" has never started playback on rundown "${rundownId}".`)
 	}
 }
+
+export function substituteObjectIds (rawEnable: TimelineEnable, idMap: { [oldId: string]: string | undefined }) {
+	const replaceIds = (str: string) => {
+		return str.replace(/#([a-zA-Z0-9_]+)/g, (m) => {
+			const id = m.substr(1, m.length - 1)
+			return `#${idMap[id] || id}`
+		})
+	}
+
+	const enable = clone(rawEnable)
+
+	for (const key of _.keys(enable)) {
+		if (typeof enable[key] === 'string') {
+			enable[key] = replaceIds(enable[key])
+		}
+	}
+
+	return enable
+}
 export function prefixAllObjectIds<T extends TimelineObjGeneric> (objList: T[], prefix: string, ignoreOriginal?: boolean): T[] {
 	const getUpdatePrefixedId = (o: T) => {
 		let id = o.id
@@ -321,27 +341,16 @@ export function prefixAllObjectIds<T extends TimelineObjGeneric> (objList: T[], 
 		idMap[o.id] = getUpdatePrefixedId(o)
 	})
 
-	const replaceIds = (str: string) => {
-		return str.replace(/#([a-zA-Z0-9_]+)/g, (m) => {
-			const id = m.substr(1, m.length - 1)
-			return `#${idMap[id] || id}`
-		})
-	}
+	return objList.map(rawObj => {
+		const obj = clone(rawObj)
 
-	return objList.map(i => {
-		const o = clone(i)
-		o.id = getUpdatePrefixedId(o)
+		obj.id = getUpdatePrefixedId(obj)
+		obj.enable = substituteObjectIds(obj.enable, idMap)
 
-		for (const key of _.keys(o.enable)) {
-			if (typeof o.enable[key] === 'string') {
-				o.enable[key] = replaceIds(o.enable[key])
-			}
+		if (typeof obj.inGroup === 'string') {
+			obj.inGroup = idMap[obj.inGroup] || obj.inGroup
 		}
 
-		if (typeof o.inGroup === 'string') {
-			o.inGroup = idMap[o.inGroup] || o.inGroup
-		}
-
-		return o
+		return obj
 	})
 }

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -83,7 +83,7 @@ export namespace ServerPlayoutAPI {
 			}
 
 			libResetRundown(rundown)
-			prepareStudioForBroadcast(rundown.getStudio())
+			prepareStudioForBroadcast(rundown.getStudio(), true, rundown)
 
 			return libActivateRundown(rundown, true) // Activate rundown (rehearsal)
 		})
@@ -116,6 +116,7 @@ export namespace ServerPlayoutAPI {
 			if (rundown.active && !rundown.rehearsal) throw new Meteor.Error(402, `rundownResetAndActivate cannot be run when active!`)
 
 			libResetRundown(rundown)
+			prepareStudioForBroadcast(rundown.getStudio(), true, rundown)
 
 			return libActivateRundown(rundown, !!rehearsal) // Activate rundown
 		})
@@ -151,6 +152,7 @@ export namespace ServerPlayoutAPI {
 			}
 
 			libResetRundown(rundown)
+			prepareStudioForBroadcast(rundown.getStudio(), true, rundown)
 
 			return libActivateRundown(rundown, rehearsal)
 		})
@@ -163,6 +165,8 @@ export namespace ServerPlayoutAPI {
 		return rundownSyncFunction(rundownId, RundownSyncFunctionPriority.Playout, () => {
 			const rundown = Rundowns.findOne(rundownId)
 			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found!`)
+
+			prepareStudioForBroadcast(rundown.getStudio(), true, rundown)
 
 			return libActivateRundown(rundown, rehearsal)
 		})

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -33,6 +33,7 @@ import { UpdateNext } from './ingest/updateNext'
 import { UserActionAPI } from '../../lib/api/userActions'
 import { IngestActions } from './ingest/actions'
 import { ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
+import { updateExpectedPlayoutItemsOnPart } from './ingest/expectedPlayoutItems'
 
 export function selectShowStyleVariant (studio: Studio, ingestRundown: IngestRundown): { variant: ShowStyleVariant, base: ShowStyleBase } | null {
 	if (!studio.supportedShowStyleBase.length) {
@@ -164,6 +165,7 @@ export function afterRemoveParts (rundownId: string, removedParts: DBPart[]) {
 	_.each(removedParts, part => {
 		// TODO - batch?
 		updateExpectedMediaItemsOnPart(part.rundownId, part._id)
+		updateExpectedPlayoutItemsOnPart(part.rundownId, part._id)
 	})
 
 	const rundown = Rundowns.findOne(rundownId)

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -3,8 +3,8 @@ import * as _ from 'underscore'
 import { check } from 'meteor/check'
 import { Rundowns } from '../../lib/collections/Rundowns'
 import { Part, Parts, DBPart } from '../../lib/collections/Parts'
-import { Pieces } from '../../lib/collections/Pieces'
-import { AdLibPieces } from '../../lib/collections/AdLibPieces'
+import { Pieces, Piece } from '../../lib/collections/Pieces'
+import { AdLibPieces, AdLibPiece } from '../../lib/collections/AdLibPieces'
 import { Segments } from '../../lib/collections/Segments'
 import {
 	saveIntoDb,
@@ -32,6 +32,7 @@ import { PackageInfo } from '../coreSystem'
 import { UpdateNext } from './ingest/updateNext'
 import { UserActionAPI } from '../../lib/api/userActions'
 import { IngestActions } from './ingest/actions'
+import { ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
 
 export function selectShowStyleVariant (studio: Studio, ingestRundown: IngestRundown): { variant: ShowStyleVariant, base: ShowStyleBase } | null {
 	if (!studio.supportedShowStyleBase.length) {
@@ -138,13 +139,27 @@ export function afterRemoveParts (rundownId: string, removedParts: DBPart[]) {
 
 	// Clean up all the db parts that belong to the removed Parts
 	// TODO - is there anything else to remove?
-	Pieces.remove({
+
+	ExpectedPlayoutItems.remove({
 		rundownId: rundownId,
 		partId: { $in: _.map(removedParts, p => p._id) }
 	})
-	AdLibPieces.remove({
+
+	saveIntoDb<Piece, Piece>(Pieces, {
 		rundownId: rundownId,
 		partId: { $in: _.map(removedParts, p => p._id) }
+	}, [], {
+		afterRemoveAll (pieces) {
+			afterRemovePieces(rundownId, pieces)
+		}
+	})
+	saveIntoDb<AdLibPiece, AdLibPiece>(AdLibPieces, {
+		rundownId: rundownId,
+		partId: { $in: _.map(removedParts, p => p._id) }
+	}, [], {
+		afterRemoveAll (pieces) {
+			afterRemovePieces(rundownId, pieces)
+		}
 	})
 	_.each(removedParts, part => {
 		// TODO - batch?
@@ -156,6 +171,18 @@ export function afterRemoveParts (rundownId: string, removedParts: DBPart[]) {
 		// Ensure the next-part is still valid
 		UpdateNext.ensureNextPartIsValid(rundown)
 	}
+}
+/**
+ * After Pieces have been removed, handle the contents.
+ * This will NOT trigger an update of the timeline
+ * @param rundownId Id of the Rundown
+ * @param removedPieces The pieces that have been removed
+ */
+export function afterRemovePieces (rundownId: string, removedPieces: Array<Piece | AdLibPiece>) {
+	ExpectedPlayoutItems.remove({
+		rundownId: rundownId,
+		pieceId: { $in: _.map(removedPieces, p => p._id) }
+	})
 }
 /**
  * Update the ranks of all parts.

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -54,6 +54,7 @@ import { RundownBaselineObj, RundownBaselineObjs } from '../../lib/collections/R
 import { RundownBaselineAdLibItem, RundownBaselineAdLibPieces } from '../../lib/collections/RundownBaselineAdLibPieces'
 import { TimelineEnable } from 'timeline-state-resolver-types/dist/superfly-timeline'
 import { substituteObjectIds } from './playout/lib'
+import { ExpectedPlayoutItem, ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
 
 interface RundownSnapshot {
 	version: string
@@ -70,6 +71,7 @@ interface RundownSnapshot {
 	adLibPieces: Array<AdLibPiece>
 	mediaObjects: Array<MediaObject>
 	expectedMediaItems: Array<ExpectedMediaItem>
+	expectedPlayoutItems: Array<ExpectedPlayoutItem>
 }
 interface SystemSnapshot {
 	version: string
@@ -124,6 +126,7 @@ function createRundownSnapshot (rundownId: string): RundownSnapshot {
 	]
 	const mediaObjects = MediaObjects.find({ mediaId: { $in: mediaObjectIds } }).fetch()
 	const expectedMediaItems = ExpectedMediaItems.find({ partId: { $in: parts.map(i => i._id) } }).fetch()
+	const expectedPlayoutItems = ExpectedPlayoutItems.find({ rundownId: rundownId }).fetch()
 	const baselineObjs = RundownBaselineObjs.find({ rundownId: rundownId }).fetch()
 	const baselineAdlibs = RundownBaselineAdLibPieces.find({ rundownId: rundownId }).fetch()
 
@@ -150,7 +153,8 @@ function createRundownSnapshot (rundownId: string): RundownSnapshot {
 		pieces,
 		adLibPieces,
 		mediaObjects,
-		expectedMediaItems
+		expectedMediaItems,
+		expectedPlayoutItems,
 	}
 }
 
@@ -498,6 +502,7 @@ function restoreFromRundownSnapshot (snapshot: RundownSnapshot) {
 	saveIntoDb(Pieces, { rundownId: rundownId }, updateItemIds(snapshot.pieces, false))
 	saveIntoDb(AdLibPieces, { rundownId: rundownId }, updateItemIds(snapshot.adLibPieces, true))
 	saveIntoDb(ExpectedMediaItems, { partId: { $in: snapshot.parts.map(i => i._id) } }, updateItemIds(snapshot.expectedMediaItems, true))
+	saveIntoDb(ExpectedPlayoutItems, { rundownId: snapshot.rundownId }, updateItemIds(snapshot.expectedPlayoutItems, true))
 
 	saveIntoDb(MediaObjects, { _id: { $in: _.map(snapshot.mediaObjects, mediaObject => mediaObject._id) } }, snapshot.mediaObjects)
 

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -390,48 +390,82 @@ function restoreFromSnapshot (snapshot: AnySnapshot) {
 
 function restoreFromRundownSnapshot (snapshot: RundownSnapshot) {
 	logger.info(`Restoring from rundown snapshot "${snapshot.snapshot.name}"`)
-	let rundownId = snapshot.rundownId
+	const oldRundownId = snapshot.rundownId
 
 	if (!isVersionSupported(parseVersion(snapshot.version || '0.18.0'))) {
 		throw new Meteor.Error(400, `Cannot restore, the snapshot comes from an older, unsupported version of Sofie`)
 	}
 
-	if (rundownId !== snapshot.rundown._id) throw new Meteor.Error(500, `Restore snapshot: rundownIds don\'t match, "${rundownId}", "${snapshot.rundown._id}!"`)
-
-	let dbRundown = Rundowns.findOne(rundownId)
-
-	if (dbRundown && !dbRundown.unsynced) throw new Meteor.Error(500, `Not allowed to restore into synked Rundown!`)
+	if (oldRundownId !== snapshot.rundown._id) throw new Meteor.Error(500, `Restore snapshot: rundownIds don\'t match, "${oldRundownId}", "${snapshot.rundown._id}!"`)
 
 	if (!snapshot.rundown.unsynced) {
 		snapshot.rundown.unsynced = true
 		snapshot.rundown.unsyncedTime = getCurrentTime()
 	}
 
-	snapshot.rundown.active					= (dbRundown ? dbRundown.active : false)
-	snapshot.rundown.currentPartId		= (dbRundown ? dbRundown.currentPartId : null)
-	snapshot.rundown.nextPartId			= (dbRundown ? dbRundown.nextPartId : null)
-	snapshot.rundown.notifiedCurrentPlayingPartExternalId = (dbRundown ? dbRundown.notifiedCurrentPlayingPartExternalId : undefined)
+	const rundownId = snapshot.rundown._id = Random.id()
+	snapshot.rundown.restoredFromSnapshotId = snapshot.rundownId
+	snapshot.rundown.peripheralDeviceId = ''
+	snapshot.rundown.active = false
+	snapshot.rundown.currentPartId = null
+	snapshot.rundown.nextPartId = null
+	snapshot.rundown.notifiedCurrentPlayingPartExternalId = undefined
 
 	const studios = Studios.find().fetch()
-	if (studios.length === 1) snapshot.rundown.studioId = studios[0]._id
+	if (studios.length >= 1) snapshot.rundown.studioId = studios[0]._id
 
 	const showStyleVariants = ShowStyleVariants.find().fetch()
-	if (showStyleVariants.length === 1) {
+	if (showStyleVariants.length >= 1) {
 		snapshot.rundown.showStyleBaseId = showStyleVariants[0].showStyleBaseId
 		snapshot.rundown.showStyleVariantId = showStyleVariants[0]._id
 	}
 
+	// List any ids that need updating on other documents
+	const partIdMap: { [key: string]: string } = {}
+	_.each(snapshot.parts, part => {
+		const oldId = part._id
+		partIdMap[oldId] = part._id = Random.id()
+	})
+	const segmentIdMap: { [key: string]: string } = {}
+	_.each(snapshot.segments, segment => {
+		const oldId = segment._id
+		segmentIdMap[oldId] = segment._id = Random.id()
+	})
+
+	// Apply the updates of any properties to any document
+	function updateItemIds<T extends { _id: string, rundownId: string, partId?: string, segmentId?: string }> (objs: T[], updateId: boolean): T[] {
+		return objs.map(obj => {
+			if (obj.rundownId) {
+				obj.rundownId = rundownId
+			}
+
+			if (obj.partId) {
+				obj.partId = partIdMap[obj.partId]
+			}
+			if (obj.segmentId) {
+				obj.segmentId = segmentIdMap[obj.segmentId]
+			}
+
+			if (updateId) {
+				obj._id = Random.id()
+			}
+
+			return obj
+		})
+	}
+
 	saveIntoDb(Rundowns, { _id: rundownId }, [snapshot.rundown])
-	saveIntoDb(IngestDataCache, { rundownId: rundownId }, snapshot.ingestData)
+	saveIntoDb(IngestDataCache, { rundownId: rundownId }, updateItemIds(snapshot.ingestData, true))
 	// saveIntoDb(UserActionsLog, {}, snapshot.userActions)
-	saveIntoDb(RundownBaselineObjs, { rundownId: rundownId }, snapshot.baselineObjs)
-	saveIntoDb(RundownBaselineAdLibPieces, { rundownId: rundownId }, snapshot.baselineAdlibs)
-	saveIntoDb(Segments, { rundownId: rundownId }, snapshot.segments)
-	saveIntoDb(Parts, { rundownId: rundownId }, snapshot.parts)
-	saveIntoDb(Pieces, { rundownId: rundownId }, snapshot.pieces)
-	saveIntoDb(AdLibPieces, { rundownId: rundownId }, snapshot.adLibPieces)
+	saveIntoDb(RundownBaselineObjs, { rundownId: rundownId }, updateItemIds(snapshot.baselineObjs, true))
+	saveIntoDb(RundownBaselineAdLibPieces, { rundownId: rundownId }, updateItemIds(snapshot.baselineAdlibs, true))
+	saveIntoDb(Segments, { rundownId: rundownId }, updateItemIds(snapshot.segments, false))
+	saveIntoDb(Parts, { rundownId: rundownId }, updateItemIds(snapshot.parts, false))
+	saveIntoDb(Pieces, { rundownId: rundownId }, updateItemIds(snapshot.pieces, true))
+	saveIntoDb(AdLibPieces, { rundownId: rundownId }, updateItemIds(snapshot.adLibPieces, true))
+	saveIntoDb(ExpectedMediaItems, { partId: { $in: snapshot.parts.map(i => i._id) } }, updateItemIds(snapshot.expectedMediaItems, true))
+
 	saveIntoDb(MediaObjects, { _id: { $in: _.map(snapshot.mediaObjects, mediaObject => mediaObject._id) } }, snapshot.mediaObjects)
-	saveIntoDb(ExpectedMediaItems, { partId: { $in: snapshot.parts.map(i => i._id) } }, snapshot.expectedMediaItems)
 
 	logger.info(`Restore done`)
 }

--- a/meteor/server/publications/expectedPlayoutItems.ts
+++ b/meteor/server/publications/expectedPlayoutItems.ts
@@ -1,0 +1,17 @@
+import * as _ from 'underscore'
+import { ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
+import { ExpectedPlayoutItemsSecurity } from '../security/expectedPlayoutItems'
+import { meteorPublish } from './lib'
+import { PubSub } from '../../lib/api/pubsub'
+
+meteorPublish(PubSub.expectedPlayoutItems, (selector, token) => {
+	const allowed = ExpectedPlayoutItemsSecurity.allowReadAccess(selector, token, this)
+	if (allowed === true) {
+		return ExpectedPlayoutItems.find(selector)
+	} else if (typeof allowed === 'object') {
+		return ExpectedPlayoutItems.find(_.extend(selector, {
+			studioId: allowed.studioId
+		}))
+	}
+	return null
+})

--- a/meteor/server/security/expectedPlayoutItems.ts
+++ b/meteor/server/security/expectedPlayoutItems.ts
@@ -1,0 +1,48 @@
+import { check } from 'meteor/check'
+
+import { ExpectedPlayoutItem, ExpectedPlayoutItems } from '../../lib/collections/ExpectedPlayoutItems'
+import { PeripheralDeviceAPI } from '../../lib/api/peripheralDevice'
+import { PeripheralDevices, getStudioIdFromDevice } from '../../lib/collections/PeripheralDevices'
+
+import { Mongo } from 'meteor/mongo'
+
+export namespace ExpectedPlayoutItemsSecurity {
+	export function allowReadAccess (selector: Mongo.Query<ExpectedPlayoutItem> | any, token: string, context: any) {
+		check(selector, Object)
+		check(selector.studioId, String)
+
+		let playoutDevice = PeripheralDevices.findOne({
+			type: PeripheralDeviceAPI.DeviceType.PLAYOUT,
+			token: token
+		})
+		if (!playoutDevice) return false
+
+		playoutDevice.studioId = getStudioIdFromDevice(playoutDevice)
+
+		if (playoutDevice && token) {
+			return playoutDevice
+		} else {
+			// TODO: implement access logic here
+			// just returning true for now
+			return true
+		}
+	}
+	export function allowWriteAccess () {
+		// TODO
+	}
+}
+// Setup rules:
+
+ExpectedPlayoutItems.allow({
+	insert (userId: string, doc: ExpectedPlayoutItem): boolean {
+		return false
+	},
+
+	update (userId, doc, fields, modifier) {
+		return false
+	},
+
+	remove (userId, doc) {
+		return false
+	}
+})


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the new behavior (if this is a feature change)?**
Adds a new collection called expectedPlayoutItems which is used by the blueprints to report to the Playout-gateway that a list of items (e.g. graphics) is expected to be needed soon.
In the case of the VizMSE-integration, this is used to load all of the graphics when a rundown is activated so that all graphics are preloaded by the time they are taken on-air.