### PR TITLE
feat: option for sticky items to only make 'original' pieces sticky

### DIFF
--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -723,6 +723,18 @@ const SourceLayerSettings = translate()(class SourceLayerSettings extends React.
 									</div>
 									<div className='mod mvs mhs'>
 										<label className='field'>
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'sourceLayers.' + item.index + '.stickyOriginalOnly'}
+												obj={this.props.showStyleBase}
+												type='checkbox'
+												collection={ShowStyleBases}
+												className=''></EditAttribute>
+											{t('Sticky: Only use original pieces')}
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
 											{t('Activate Sticky Item Shortcut')}
 											<EditAttribute
 												modifiedClassName='bghl'


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature
* **What is the current behavior?** (You can also link to an open issue here)
All pieces on sticky layers are sticky.
* **What is the new behavior (if this is a feature change)?**
Adds an optional setting to showstyle such that adlibs are not sticky.