### PR TITLE
Fix: DeviceConfigManifest: creating default table rows

### DIFF
--- a/meteor/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/GenericDeviceSettingsComponent.tsx
@@ -117,7 +117,7 @@ export const GenericDeviceSettingsComponent = translate()(class GenericDeviceSet
 		}
 		if (itemConfig.defaultType === undefined) throw new Error('defaultType not set: ' + itemConfig.id)
 		for (const prop of itemConfig.config[itemConfig.defaultType]) {
-			if ((prop as SubDeviceConfigManifestEntry).defaultVal) {
+			if ((prop as SubDeviceConfigManifestEntry).defaultVal !== undefined) {
 				createDefault(prop.id.split('.'), (prop as SubDeviceConfigManifestEntry).defaultVal, defaults)
 			}
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

When creating "default" rows in tables, a truthy check is done on the `defaultVal` for each field before creating. This causes a problem if the default value is an empty string, 0 or false.

* **What is the new behavior (if this is a feature change)?**

It uses a `!== undefined` to verify that the `defaultVal` is defined.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
