### PR TITLE
feat: animated unfocused border in rundown

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -198,7 +198,11 @@ body.no-overflow {
 	bottom: 0;
 	right: 0;
 
-	background: linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%);
+	background:
+		linear-gradient(-45deg, $color-status-fatal 33%, transparent 33%, transparent 66%, $color-status-fatal 66%),
+		linear-gradient(-45deg, $color-status-fatal 33%, transparent 33%, transparent 66%, $color-status-fatal 66%),
+		linear-gradient(-45deg, $color-status-fatal 33%, transparent 33%, transparent 66%, $color-status-fatal 66%),
+		linear-gradient(-45deg, $color-status-fatal 33%, transparent 33%, transparent 66%, $color-status-fatal 66%);
 	background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
 	background-size: 30px 8px, 30px 8px, 8px 30px, 8px 30px;
 	background-position: 0 0, 100% 100%, 0 100%, 100% 0;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -182,6 +182,15 @@ body.no-overflow {
     overflow-y: hidden;
 }
 
+@keyframes border-dance {
+  0% {
+    background-position: 0 0, 300px 100%, 0 150px, 100% 0;
+  }
+  100% {
+    background-position: 300px 0, 0 100%, 0 0, 100% 150px;
+  }
+}
+
 .rundown-view__focus-lost-frame {
 	position: fixed;
 	top: 0;
@@ -189,21 +198,12 @@ body.no-overflow {
 	bottom: 0;
 	right: 0;
 
-	border: 8px dashed $color-status-fatal;
-	border-image: repeating-linear-gradient(
-		315deg,
-		transparent,
-		transparent 10px,
-		$color-status-fatal 11px,
-		$color-status-fatal 31px,
-		transparent 32px) 8; 
-/* 	border-image: repeating-linear-gradient(
-		315deg,
-		#ffff00,
-		#ffff00 10px,
-		$color-status-fatal 11px,
-		$color-status-fatal 31px,
-		#ffff00 32px) 8;  */
+	background: linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%), linear-gradient(-45deg, red 33%, transparent 33%, transparent 66%, red 66%);
+	background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+	background-size: 30px 8px, 30px 8px, 8px 30px, 8px 30px;
+	background-position: 0 0, 100% 100%, 0 100%, 100% 0;
+	animation: border-dance 3s infinite linear;
+
 	z-index: 10000;
 	pointer-events: none;
 }

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -61,6 +61,7 @@ import { RundownLayout, RundownLayouts, RundownLayoutType, RundownLayoutBase } f
 import { VirtualElement } from '../lib/VirtualElement'
 import { SEGMENT_TIMELINE_ELEMENT_ID } from './SegmentTimeline/SegmentTimeline'
 import { NoraPreviewRenderer } from './SegmentTimeline/Renderers/NoraPreviewRenderer'
+import { Settings } from '../../lib/Settings';
 
 type WrappedShelf = ShelfBase & { getWrappedInstance (): ShelfBase }
 
@@ -1794,7 +1795,7 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 							'rundown-view--studio-mode': this.state.studioMode
 						})} style={this.getStyle()} onWheelCapture={this.onWheel} onContextMenu={this.onContextMenuTop}>
 							<ErrorBoundary>
-								{ this.state.studioMode && <KeyboardFocusMarker /> }
+								{ this.state.studioMode && !Settings.disableBlurBorder && <KeyboardFocusMarker /> }
 							</ErrorBoundary>
 							<ErrorBoundary>
 								<RundownFullscreenControls

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -17,12 +17,14 @@ export interface ISettings {
 	// Should the Rundown view User Interface default all segments to "collapsed" state?
 	// Default: false
 	defaultToCollapsedSegments: boolean,
-  // Should the segment in the Rundown view automatically rewind after it stops being live?
-  // Default: false
+	// Should the segment in the Rundown view automatically rewind after it stops being live?
+	// Default: false
 	autoRewindLeavingSegment: boolean,
 	// Should the Current and Next segments be automatically made expanded (uncollapsed)?
 	// Default: false
 	autoExpandCurrentNextSegment: boolean
+	// Disable blur border in RundownView
+	disableBlurBorder: boolean
 }
 
 export let Settings: ISettings
@@ -34,7 +36,8 @@ const DEFAULT_SETTINGS: ISettings = {
 	'frameRate': 25,
 	'defaultToCollapsedSegments': false,
 	'autoExpandCurrentNextSegment': false,
-	'autoRewindLeavingSegment': false
+	'autoRewindLeavingSegment': false,
+	'disableBlurBorder': false
 }
 
 Settings = _.clone(DEFAULT_SETTINGS)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The blur border (notification that the Rundown view is unfocused) is now animated for better peripheral vision functionality.

* **What is the current behavior?** (You can also link to an open issue here)

The blur border is static.

* **What is the new behavior (if this is a feature change)?**

The unfocused border is now animated.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
