### PR TITLE
fix: dont call uploadFileToAtem as part of deviceMakeReady

### DIFF
--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -111,13 +111,6 @@ export function deactivateRundownInner (rundown: Rundown) {
 export function prepareStudioForBroadcast (studio: Studio) {
 	logger.info('prepareStudioForBroadcast ' + studio._id)
 
-	const ssrcBgs: Array<IConfigItem> = _.compact([
-		studio.config.find((o) => o._id === 'atemSSrcBackground'),
-		studio.config.find((o) => o._id === 'atemSSrcBackground2')
-	])
-	if (ssrcBgs.length > 1) logger.info(ssrcBgs[0].value + ' and ' + ssrcBgs[1].value + ' will be loaded to atems')
-	if (ssrcBgs.length > 0) logger.info(ssrcBgs[0].value + ' will be loaded to atems')
-
 	let playoutDevices = PeripheralDevices.find({
 		studioId: studio._id,
 		type: PeripheralDeviceAPI.DeviceType.PLAYOUT
@@ -132,15 +125,5 @@ export function prepareStudioForBroadcast (studio: Studio) {
 				logger.info('devicesMakeReady OK')
 			}
 		}, 'devicesMakeReady', okToDestoryStuff)
-
-		if (ssrcBgs.length > 0) {
-			PeripheralDeviceAPI.executeFunction(device._id, (err) => {
-				if (err) {
-					logger.error(err)
-				} else {
-					logger.info('Added Super Source BG to Atem')
-				}
-			}, 'uploadFileToAtem', ssrcBgs)
-		}
 	})
 }


### PR DESCRIPTION
Partner: https://github.com/nrkno/tv-automation-playout-gateway/pull/60

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove the calls of uploadFileToAtem to playout-gateway.
Playout-gateway should internally handle ensuring the media loaded to the device is correct.

* **What is the current behavior?** (You can also link to an open issue here)
This code will trigger an upload of media based on old and incorrect data, overriding correct media with outdated ones.

* **What is the new behavior (if this is a feature change)?**
The media upload process is left to playout-gateway

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
