### PR TITLE
feat: segment and part identifier

### DIFF
--- a/meteor/client/lib/viewPort.ts
+++ b/meteor/client/lib/viewPort.ts
@@ -6,6 +6,7 @@ import { Parts, PartId } from '../../lib/collections/Parts'
 import { PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { SegmentId } from '../../lib/collections/Segments'
 import { isProtectedString } from '../../lib/lib'
+import { RundownViewEvents, IGoToPartEvent, IGoToPartInstanceEvent } from '../ui/RundownView'
 
 let focusInterval: NodeJS.Timer | undefined
 let _dontClearInterval: boolean = false
@@ -42,20 +43,34 @@ function quitFocusOnPart () {
 }
 
 export function scrollToPartInstance (partInstanceId: PartInstanceId, forceScroll?: boolean, noAnimation?: boolean): Promise<boolean> {
-	// TODO: do scrolling within segment as well?
 	quitFocusOnPart()
 	const partInstance = PartInstances.findOne(partInstanceId)
 	if (partInstance) {
+		window.dispatchEvent(
+			new CustomEvent<IGoToPartInstanceEvent>(
+				RundownViewEvents.goToPart, {
+					detail: {
+						segmentId: partInstance.segmentId,
+						partInstanceId: partInstanceId
+					}
+				}))
 		return scrollToSegment(partInstance.segmentId, forceScroll, noAnimation)
 	}
 	return Promise.reject('Could not find PartInstance')
 }
 
 export function scrollToPart (partId: PartId, forceScroll?: boolean, noAnimation?: boolean): Promise<boolean> {
-	// TODO: do scrolling within segment as well?
 	quitFocusOnPart()
 	let part = Parts.findOne(partId)
 	if (part) {
+		window.dispatchEvent(
+			new CustomEvent<IGoToPartEvent>(
+				RundownViewEvents.goToPart, {
+					detail: {
+						segmentId: part.segmentId,
+						partId: partId
+					}
+				}))
 		return scrollToSegment(part.segmentId, forceScroll, noAnimation)
 	}
 	return Promise.reject('Could not find part')

--- a/meteor/client/lib/viewPort.ts
+++ b/meteor/client/lib/viewPort.ts
@@ -59,10 +59,12 @@ export function scrollToPartInstance (partInstanceId: PartInstanceId, forceScrol
 	return Promise.reject('Could not find PartInstance')
 }
 
-export function scrollToPart (partId: PartId, forceScroll?: boolean, noAnimation?: boolean): Promise<boolean> {
+export async function scrollToPart (partId: PartId, forceScroll?: boolean, noAnimation?: boolean): Promise<boolean> {
 	quitFocusOnPart()
 	let part = Parts.findOne(partId)
 	if (part) {
+		await scrollToSegment(part.segmentId, forceScroll, noAnimation)
+
 		window.dispatchEvent(
 			new CustomEvent<IGoToPartEvent>(
 				RundownViewEvents.goToPart, {
@@ -71,7 +73,9 @@ export function scrollToPart (partId: PartId, forceScroll?: boolean, noAnimation
 						partId: partId
 					}
 				}))
-		return scrollToSegment(part.segmentId, forceScroll, noAnimation)
+
+		return true // rather meaningless as we don't know what happened
+		
 	}
 	return Promise.reject('Could not find part')
 }

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1697,6 +1697,14 @@ body.no-overflow {
 					box-shadow: 0px 0px 1px 1px rgba(0, 30, 0, 0.18);
 				}
 			}
+
+			.segment-timeline__identifier {
+				background-color: #095709;
+				width: min-content;
+				padding: 2px;
+				margin-left: 5px;
+				border-radius: 3px;
+			}
 		}
 	}
 

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1699,11 +1699,13 @@ body.no-overflow {
 			}
 
 			.segment-timeline__identifier {
-				background-color: #095709;
-				width: min-content;
-				padding: 2px;
-				margin-left: 5px;
-				border-radius: 3px;
+				position: absolute;
+				bottom: 0;
+				z-index: -1;
+				padding:  0 10px 0 10px;
+				box-sizing: border-box;
+				background-color: #7400d5;
+				border-radius: 0 10px 10px 0;
 			}
 		}
 	}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -19,7 +19,7 @@ import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/
 import { Rundown, Rundowns, RundownHoldState, RundownId } from '../../lib/collections/Rundowns'
 import { Segment, SegmentId } from '../../lib/collections/Segments'
 import { Studio, Studios } from '../../lib/collections/Studios'
-import { Part, Parts } from '../../lib/collections/Parts'
+import { Part, Parts, PartId } from '../../lib/collections/Parts'
 
 import { ContextMenu, MenuItem, ContextMenuTrigger } from 'react-contextmenu'
 
@@ -71,6 +71,7 @@ import { MeteorCall } from '../../lib/api/methods'
 import { PointerLockCursor } from '../lib/PointerLockCursor'
 import { AdLibPieceUi } from './Shelf/AdLibPanel'
 import { documentTitle } from '../lib/documentTitle'
+import { PartInstanceId } from '../../lib/collections/PartInstances'
 
 export const MAGIC_TIME_SCALE_FACTOR = 0.03
 
@@ -1053,6 +1054,17 @@ export enum RundownViewEvents {
 	'goToTop' = 'sofie:goToTop',
 	'segmentZoomOn' = 'sofie:segmentZoomOn',
 	'segmentZoomOff' = 'sofie:segmentZoomOff'
+	'goToPart'			=	'goToPart',
+	'goToPartInstance'			=	'goToPartInstance'
+}
+
+export interface IGoToPartEvent {
+	segmentId: SegmentId
+	partId: PartId
+}
+export interface IGoToPartInstanceEvent {
+	segmentId: SegmentId
+	partInstanceId: PartInstanceId
 }
 
 interface ITrackedProps {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1053,7 +1053,7 @@ export enum RundownViewEvents {
 	'goToLiveSegment' = 'sofie:goToLiveSegment',
 	'goToTop' = 'sofie:goToTop',
 	'segmentZoomOn' = 'sofie:segmentZoomOn',
-	'segmentZoomOff' = 'sofie:segmentZoomOff'
+	'segmentZoomOff' = 'sofie:segmentZoomOff',
 	'goToPart'			=	'goToPart',
 	'goToPartInstance'			=	'goToPartInstance'
 }

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
@@ -5,6 +5,14 @@ $timeline-layer-height: 1em;
     width: 100%;
     max-width: 100%;
 }
+.segment-timeline__title__label.identifier::before {
+	content: attr(data-identifier);
+	background-color: #095709;
+	margin-right: 10px;
+	padding: 3px;
+	white-space: nowrap;
+	border-radius: 3px;
+}
 .segment-timeline__liveline {
     position: absolute;
     top: 2.3em;

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
@@ -3,7 +3,11 @@ $timeline-layer-height: 1em;
 .segment-timeline {
     display: block;
     width: 100%;
-    max-width: 100%;
+	max-width: 100%;
+	
+	.segment-timeline__title {
+		position: relative;
+	}
 }
 .segment-timeline__title__label.identifier::before {
 	content: attr(data-identifier);
@@ -12,6 +16,22 @@ $timeline-layer-height: 1em;
 	padding: 3px;
 	white-space: nowrap;
 	border-radius: 3px;
+}
+.segment-timeline__part-identifiers {
+	display: flex;
+	position: absolute;
+	bottom: 2.5px;
+	flex-wrap: wrap;
+
+	.segment-timeline__part-identifiers__identifier {
+		float: left;
+		margin: 2.5px;
+		padding:  0 10px 0 10px;
+		box-sizing: border-box;
+		background-color: #7400d5;
+		border-radius: 10px;
+		cursor: pointer;
+	}
 }
 .segment-timeline__liveline {
     position: absolute;

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -688,7 +688,8 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 					}}
 					holdToDisplay={contextMenuHoldToDisplayTime()}
 					renderTag='div'>
-					<h2>
+					<h2 className={'segment-timeline__title__label' + (this.props.segment.identifier ? ' identifier' : '') }
+						data-identifier={this.props.segment.identifier}>
 						{this.props.segment.name}
 					</h2>
 					{(criticalNotes > 0 || warningNotes > 0) && <div className='segment-timeline__title__notes'>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -23,7 +23,7 @@ import {
 import { RundownUtils } from '../../lib/rundown'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
-import { scrollToSegment } from '../../lib/viewPort'
+import { scrollToSegment, scrollToPart } from '../../lib/viewPort'
 
 // @ts-ignore Not recognized by Typescript
 import * as Zoom_In_MouseOut from './Zoom_In_MouseOut.json'
@@ -492,6 +492,10 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 		}
 	}
 
+	onClickSegmentIdent = (partId: PartId) => {
+		scrollToPart(partId)
+	}
+
 	getSegmentContext = (props) => {
 		const ctx = literal<IContextMenuContext>({
 			segment: this.props.segment,
@@ -655,6 +659,10 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 			return prev
 		}, 0)
 
+		const identifiers: Array<{ partId: PartId, ident?: string }> = this.props.parts.map(p => {
+			return { partId: p.partId, ident: p.instance.part.identifier }
+		})
+
 		let countdownToPartId: PartId | undefined = undefined
 		if (!this.props.isLiveSegment) {
 			const nextPart = this.props.isNextSegment ?
@@ -714,6 +722,12 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							</div>
 						</div>}
 					</div>}
+					<div className='segment-timeline__part-identifiers'>
+						{ identifiers.map(ident => <div
+							className='segment-timeline__part-identifiers__identifier'
+							key={ident.partId + ''}
+							onClick={() => this.onClickSegmentIdent(ident.partId)}>{ident.ident}</div>) }
+					</div>
 				</ContextMenuTrigger>
 				<div className='segment-timeline__duration' tabIndex={0}
 					onClick={(e) => this.props.onCollapseSegmentToggle && this.props.onCollapseSegmentToggle(e)}>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -463,12 +463,11 @@ export const SegmentTimelineContainer = translate()(withTracker<IProps, IState, 
 
 	onGoToPart = (e: CustomEvent<IGoToPartEvent>) => {
 		if (this.props.segmentId === e.detail.segmentId) {
-			for (const part of this.props.parts) {
-				if (part.partId === e.detail.partId) {
-					this.setState({
-						scrollLeft: part.startsAt
-					})
-				}
+			const part = this.props.parts.find(part => part.partId === e.detail.partId)
+			if (part) {
+				this.setState({
+					scrollLeft: part.startsAt
+				})
 			}
 		}
 	}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -16,7 +16,7 @@ import {
 	PartExtended,
 	SegmentExtended
 } from '../../../lib/Rundown'
-import { RundownViewEvents, IContextMenuContext } from '../RundownView'
+import { RundownViewEvents, IContextMenuContext, IGoToPartEvent, IGoToPartInstanceEvent } from '../RundownView'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { NoteType, SegmentNote } from '../../../lib/api/notes'
@@ -312,6 +312,8 @@ export const SegmentTimelineContainer = translate()(withTracker<IProps, IState, 
 			}
 		}
 		window.addEventListener(RundownViewEvents.rewindsegments, this.onRewindSegment)
+		window.addEventListener(RundownViewEvents.goToPart, this.onGoToPart)
+		window.addEventListener(RundownViewEvents.goToPartInstance, this.onGoToPart)
 		window.requestAnimationFrame(() => {
 			this.mountedTime = Date.now()
 			if (this.isLiveSegment && this.props.followLiveSegments && !this.isVisible) {
@@ -456,6 +458,30 @@ export const SegmentTimelineContainer = translate()(withTracker<IProps, IState, 
 			this.setState({
 				scrollLeft: 0
 			})
+		}
+	}
+
+	onGoToPart = (e: CustomEvent<IGoToPartEvent>) => {
+		if (this.props.segmentId === e.detail.segmentId) {
+			for (const part of this.props.parts) {
+				if (part.partId === e.detail.partId) {
+					this.setState({
+						scrollLeft: part.startsAt
+					})
+				}
+			}
+		}
+	}
+
+	onGoToPartInstance = (e: CustomEvent<IGoToPartInstanceEvent>) => {
+		if (this.props.segmentId === e.detail.segmentId) {
+			for (const part of this.props.parts) {
+				if (part.instance._id === e.detail.partInstanceId) {
+					this.setState({
+						scrollLeft: part.startsAt
+					})
+				}
+			}
 		}
 	}
 

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -678,6 +678,7 @@ export const SegmentTimelinePart = translate()(withTiming<IProps, IState>((props
 						</div>
 					}
 					{this.renderTimelineOutputGroups(this.props.part)}
+					{!this.props.relative && this.props.part.identifier && <div className='segment-timeline__identifier'>{this.props.part.identifier}</div>}
 					{this.props.isLastInSegment && <div className={ClassNames('segment-timeline__part__nextline', 'segment-timeline__part__nextline--endline', {
 						'auto-next': innerPart.autoNext,
 						'is-next': this.state.isLive && (!this.props.isLastSegment && !this.props.isLastInSegment || !!this.props.playlist.nextPartInstanceId),

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -643,6 +643,7 @@ export const SegmentTimelinePart = translate()(withTiming<IProps, IState>((props
 							)}
 							{this.props.isAfterLastValidInSegmentAndItsLive && CARRIAGE_RETURN_ICON}
 						</div>
+							{!this.props.relative && this.props.part.instance.part.identifier && <div className='segment-timeline__identifier'>{this.props.part.instance.part.identifier}</div>}
 					</div>
 					{this.props.playlist.nextTimeOffset && this.state.isNext && // This is the off-set line
 						<div className={ClassNames('segment-timeline__part__nextline', {
@@ -678,7 +679,6 @@ export const SegmentTimelinePart = translate()(withTiming<IProps, IState>((props
 						</div>
 					}
 					{this.renderTimelineOutputGroups(this.props.part)}
-					{!this.props.relative && this.props.part.identifier && <div className='segment-timeline__identifier'>{this.props.part.identifier}</div>}
 					{this.props.isLastInSegment && <div className={ClassNames('segment-timeline__part__nextline', 'segment-timeline__part__nextline--endline', {
 						'auto-next': innerPart.autoNext,
 						'is-next': this.state.isLive && (!this.props.isLastSegment && !this.props.isLastInSegment || !!this.props.playlist.nextPartInstanceId),

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -68,6 +68,8 @@ export interface DBPart extends ProtectedStringProperties<IBlueprintPartDB, '_id
 	runtimeArguments?: BlueprintRuntimeArguments
 	/** An part should be marked as `dirty` if the part blueprint has been injected with runtimeArguments */
 	dirty?: boolean
+	/** Human readable unqiue identifier of the part */
+	identifier?: string
 }
 export interface PartTimings extends IBlueprintPartDBTimings {
 	/** The playback offset that was set for the last take */
@@ -124,6 +126,7 @@ export class Part implements DBPart {
 	public dynamicallyInserted?: boolean
 	public runtimeArguments?: BlueprintRuntimeArguments
 	public dirty?: boolean
+	public identifier?: string
 
 	constructor (document: DBPart) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/lib/collections/Segments.ts
+++ b/meteor/lib/collections/Segments.ts
@@ -47,6 +47,7 @@ export class Segment implements DBSegment {
 	public isHidden?: boolean
 	public unsynced?: boolean
 	public unsyncedTime?: Time
+	public identifier?: string
 
 	constructor (document: DBSegment) {
 		_.each(_.keys(document), (key) => {


### PR DESCRIPTION
This PR adds support for:

### Segment identifiers:
These are small human-readable unique strings that show the relation between a segment in Sofie and the data in the newsroom control system. The identifiers must be added through the blueprints and will then be rendered as a pseudo element such that the position and styling can be customised through custom CSS.

### Part identifiers:
These are similar to segment identifiers in that they are showing a relation between a part in Sofie and data in the NRCS. They achieve this on a more atomic level though. These identifiers are rendered in both the Timeline view as well as clickable items in the segment header. Where clicking on an identifier in the segment header moves the timeline to that part.

_Note: this PR modifies the **scrollToPart** and **scrollToPartInstance** to also scroll the timeline of the segment. This is done by triggering an event on the window that all the segments listen for._

![afbeelding](https://user-images.githubusercontent.com/9898648/78342692-f2130400-7599-11ea-8559-38ef12323ada.png)

