### PR TITLE
fix: cut icon logic for marking trimmed clips

### DIFF
--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -116,7 +116,12 @@ export class CustomLayerItemRenderer<IProps extends ICustomLayerItemProps, IStat
 		const vtContent = this.props.piece.content as VTContent
 		const duration = this.props.partDuration
 
-		return (vtContent && vtContent.editable && duration !== vtContent.editable.editorialDuration && vtContent.editable.editorialDuration !== 0) ?
+		return (
+			vtContent &&
+			vtContent.editable &&
+			vtContent.editable.editorialDuration !== undefined &&
+			vtContent.editable.editorialDuration !== vtContent.sourceDuration
+		) ?
 			<div className='segment-timeline__piece__label label-icon'>
 				<FontAwesomeIcon icon={faCut} />
 			</div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

The "scissors" icon visibility logic is broken. It shows in situations where it shouldn't and then doesn't show when a clip is cut using IN/OUT points.

* **What is the new behavior (if this is a feature change)?**

The "scissor" icon will show when `editorialDuration` is not undefined and `editorialDuration` is not equal `sourceDuration`.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
