### PR TITLE
dontUseQueryPort 

### DIFF
--- a/meteor/client/ui/Settings/components/MosDeviceSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/MosDeviceSettingsComponent.tsx
@@ -195,6 +195,12 @@ export const MosDeviceSettingsComponent = translate()(class MosDeviceSettingsCom
 									</div>
 									<div className='mod mvs mhs'>
 										<label className='field'>
+											{t('Primary: dont use MOS query-port')}
+											<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.primary.dontUseQueryPort'} obj={this.props.device} type='checkbox' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
 											{t('Secondary ID (Newsroom System MOS ID)')}
 											<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.secondary.id'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
 										</label>
@@ -203,6 +209,12 @@ export const MosDeviceSettingsComponent = translate()(class MosDeviceSettingsCom
 										<label className='field'>
 											{t('Secondary Host (IP Address or Hostname)')}
 											<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.secondary.host'} obj={this.props.device} type='text' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Secondary: dont use MOS query-port')}
+											<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.secondary.dontUseQueryPort'} obj={this.props.device} type='checkbox' collection={PeripheralDevices} className='input text-input input-l'></EditAttribute>
 										</label>
 									</div>
 								</div>


### PR DESCRIPTION
Add option for the dontUseQueryPort property on MOS-devices, used to suppress errors when the query port is not open on the MOS server.

(I'm also adding this to the config manifest of MOS gateway)

Feel free to merge this right away after review. :)

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
