### PR TITLE
fix: Part Instances contentMetaData broken

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -460,7 +460,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 						firstPartInSegment={this.props.parts[0]}
 						isLastSegment={this.props.isLastSegment}
 						isLastInSegment={index === (this.props.parts.length - 1)}
-						isAfterLastValidInSegmentAndItsLive={(index === (this.props.lastValidPartIndex || 0) + 1) && previousPartIsLive && !!this.props.rundown.nextPartId}
+						isAfterLastValidInSegmentAndItsLive={(index === (this.props.lastValidPartIndex || 0) + 1) && previousPartIsLive && !!this.props.playlist.nextPartInstanceId}
 						part={part} />
 				)
 			})}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -136,7 +136,7 @@ export const SegmentTimelineContainer = withTracker<IProps, IState, ITrackedProp
 	let lastValidPartIndex = o.parts.length - 1
 
 	for (let i = lastValidPartIndex; i > 0; i--) {
-		if (o.parts[i].invalid) {
+		if (o.parts[i].instance.part.invalid) {
 			lastValidPartIndex = i - 1
 		} else {
 			break

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -51,7 +51,7 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 	private mediaObjectSub: Meteor.SubscriptionHandle
 	private statusComp: Tracker.Computation
 	private objId: string
-	private overrides: any
+	private overrides: Partial<IPropsHeader>
 	private destroyed: boolean
 
 	updateMediaObjectSubscription () {
@@ -149,12 +149,15 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 				if (status !== props.piece.instance.piece.status || metadata) {
 					// Deep clone the required bits
 					const origPiece = (overrides.piece || props.piece) as PieceUi
-					const pieceCopy = {
+					const pieceCopy: PieceUi = {
 						...(overrides.piece || props.piece),
 						instance: {
 							...origPiece.instance,
+							piece: {
+								...origPiece.instance.piece,
+								status: status
+							}
 						},
-						status: status,
 						contentMetaData: metadata
 					}
 

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItemContainer.tsx
@@ -153,12 +153,9 @@ export const SourceLayerItemContainer = class extends MeteorReactComponent<IProp
 						...(overrides.piece || props.piece),
 						instance: {
 							...origPiece.instance,
-							piece: {
-								...origPiece.instance.piece,
-								status: status,
-								contentMetaData: metadata
-							}
-						}
+						},
+						status: status,
+						contentMetaData: metadata
 					}
 
 					overrides.piece = _.extend(overrides.piece || {}, pieceCopy)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR resolves an issue with `contentMetaData` not being attached to the correct object within `SourceLayerItemContainer`

* **What is the current behavior?** (You can also link to an open issue here)

Hoverscrub box doesn't show up, even if it should (mediaPreviewsUrl is set up and the MediaObject is found)

* **What is the new behavior (if this is a feature change)?**

The `contentMetaData` is now placed in the correct position, where `VTRenderer` and other Piece renderers can pick it up.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
