### PR TITLE
feat: keyboard preview

### DIFF
--- a/meteor/client/lib/downloadBlob.ts
+++ b/meteor/client/lib/downloadBlob.ts
@@ -1,0 +1,18 @@
+/**
+ * Make the browser download a blob with a given filename
+ *
+ * @export
+ * @param {Blob} blob the Blob object to be saved by the browser
+ * @param {string} fileName the default file name to be given to the Blob
+ */
+export function downloadBlob(blob: Blob, fileName: string) {
+	const aDownload = window.document.createElement("a");
+
+	aDownload.href = window.URL.createObjectURL(blob);
+
+	aDownload.download = fileName;
+
+	document.body.appendChild(aDownload);
+	aDownload.click();
+	document.body.removeChild(aDownload);
+}

--- a/meteor/client/lib/hotkeyRegistry.ts
+++ b/meteor/client/lib/hotkeyRegistry.ts
@@ -1,0 +1,54 @@
+import { Mongo } from 'meteor/mongo'
+import { ISourceLayer } from 'tv-automation-sofie-blueprints-integration'
+import { literal } from '../../lib/lib'
+
+export enum HotkeyAssignmentType {
+	SYSTEM = 'system',
+	GLOBAL_ADLIB = 'global_adlib',
+	ADLIB = 'adlib',
+	CUSTOM_LABEL = 'custom_label'
+}
+
+export interface IHotkeyAssignment {
+	combo: string
+	label: string
+	type: HotkeyAssignmentType
+	sourceLayer: ISourceLayer | undefined
+	eventHandler: (e: any, ...args: any[]) => void
+	eventHandlerArguments?: any[]
+	willQueue?: boolean
+}
+
+interface IHotkeyAssignmentDB extends IHotkeyAssignment {
+	_id: string
+	tag: string | undefined
+}
+
+export const RegisteredHotkeys = new Mongo.Collection<IHotkeyAssignmentDB>(null as any)
+
+export function registerHotkey(
+	combo: string,
+	label: string,
+	type: HotkeyAssignmentType,
+	sourceLayer: ISourceLayer | undefined,
+	willQueue: boolean,
+	eventHandler: (e: any, ...args: any[]) => void,
+	eventHandlerArguments?: any[],
+	tag?: string
+) {
+	const id = combo + (tag ? '_' + tag : '')
+
+	RegisteredHotkeys.upsert(id, literal<IHotkeyAssignmentDB>({
+		_id: id,
+		tag,
+		combo,
+		label,
+		type,
+		sourceLayer,
+		willQueue,
+		eventHandler,
+		eventHandlerArguments
+	}))
+}
+
+window['RegisteredHotkeys'] = RegisteredHotkeys

--- a/meteor/client/lib/hotkeyRegistry.ts
+++ b/meteor/client/lib/hotkeyRegistry.ts
@@ -6,7 +6,8 @@ export enum HotkeyAssignmentType {
 	SYSTEM = 'system',
 	GLOBAL_ADLIB = 'global_adlib',
 	ADLIB = 'adlib',
-	CUSTOM_LABEL = 'custom_label'
+	CUSTOM_LABEL = 'custom_label',
+	RUNTIME_ARGUMENT = 'runtime_argument'
 }
 
 export interface IHotkeyAssignment {

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -129,9 +129,9 @@ export namespace mousetrapHelper {
 
 // Add mousetrap keycodes for special keys
 mousetrap.addKeycodes({
-	220: '§', // on US-based (ANSI) keyboards (single-row, Enter key), this is the key above Enter, usually with a backslash and the vertical pipe character
-	222: '\\', // on ANSI-based keyboards, this is the key with single quote
-	223: '|', // this key is not present on ANSI-based keyboards
+	220: '§', // on US-based (101-key) keyboards (single-row, Enter key), this is the key above Enter, usually with a backslash and the vertical pipe character
+	222: '\\', // on 101 keyboards, this is the key with single quote
+	223: '|', // this key is not present on 101 keyboards
 
 	96: 'num0',
 	97: 'num1',

--- a/meteor/client/styles/keyboardPreview.scss
+++ b/meteor/client/styles/keyboardPreview.scss
@@ -1,3 +1,5 @@
+@import "_itemTypeColors";
+
 .keyboard-preview {
 	position: relative;
 	display: flex;
@@ -48,12 +50,14 @@
 
 			color: #fff;
 
+			@include item-type-colors();
+
 			&.keyboard-preview__key--fill {
 				max-width: none;
 				flex-grow: 1;
 			}
 
-			&.keyboard-preview__key--down {
+			&.keyboard-preview__key--down, &:active {
 				&::after {
 					content: ' ';
 					display: block;
@@ -74,12 +78,13 @@
 				color: #999;
 
 				text-transform: capitalize;
+				mix-blend-mode: screen;
 			}
 
 			> .keyboard-preview__key__function-label {
 				font-size: 16px;
 				font-weight: bold;
-				text-align: right;
+				text-align: left;
 				padding: 3px;
 				color: #fff;
 				position: absolute;

--- a/meteor/client/styles/keyboardPreview.scss
+++ b/meteor/client/styles/keyboardPreview.scss
@@ -1,0 +1,87 @@
+.keyboard-preview {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+
+	user-select: none;
+	cursor: default;
+
+	--keyboard-preview-height: calc(100vw / 23);
+	--keyboard-preview-key-margin: 5px;
+	--keyboard-preview-section-margin: 10px;
+
+	font-size: calc(var(--keyboard-preview-height) / 3);
+
+	.keyboard-preview__key-row {
+		display: flex;
+		margin-bottom: var(--keyboard-preview-key-margin);
+
+		.keyboard-preview__blank-space {
+			min-width: 1em;
+			max-width: 1em;
+			height: var(--keyboard-preview-height);
+
+			font-size: 3em;
+			margin-right: var(--keyboard-preview-key-margin);
+
+			&.keyboard-preview__blank-space--spring {
+				flex: 1 1;
+				min-width: auto;
+				max-width: none;
+			}
+		}
+
+		.keyboard-preview__key {
+			position: relative;
+			min-width: 1em;
+			max-width: 1em;
+			
+			height: var(--keyboard-preview-height);
+
+			font-size: 3em;
+			margin-right: var(--keyboard-preview-key-margin);
+
+			background: #333;
+			border-radius: 3px;
+
+			color: #fff;
+
+			&.keyboard-preview__key--fill {
+				max-width: none;
+				flex-grow: 1;
+			}
+
+			> .keyboard-preview__key__label {
+				font-size: 16px;
+				font-weight: bold;
+				text-align: right;
+				padding: 3px;
+				color: #999;
+
+				text-transform: capitalize;
+			}
+		}
+	}
+
+	.keyboard-preview__alphanumeric {
+		max-width: 50em;
+	}
+
+	.keyboard-preview__function {
+		max-width: 50em;
+		margin-bottom: var(--keyboard-preview-section-margin);
+	}
+
+	.keyboard-preview__control-pad {
+		position: absolute;
+		top: calc(var(--keyboard-preview-height) + var(--keyboard-preview-key-margin) + var(--keyboard-preview-section-margin));
+		left: 52em;
+	}
+
+	.keyboard-preview__arrow-pad {
+		position: absolute;
+		top: calc(var(--keyboard-preview-height) + var(--keyboard-preview-key-margin) + var(--keyboard-preview-section-margin) + (3 * (var(--keyboard-preview-height) + var(--keyboard-preview-key-margin))));
+		left: 52em;
+	}
+}

--- a/meteor/client/styles/keyboardPreview.scss
+++ b/meteor/client/styles/keyboardPreview.scss
@@ -44,12 +44,26 @@
 
 			background: #333;
 			border-radius: 3px;
+			overflow: hidden;
 
 			color: #fff;
 
 			&.keyboard-preview__key--fill {
 				max-width: none;
 				flex-grow: 1;
+			}
+
+			&.keyboard-preview__key--down {
+				&::after {
+					content: ' ';
+					display: block;
+					position: absolute;
+					top: 0;
+					left: 0;
+					right: 0;
+					bottom: 0;
+					background-color: rgba(255, 255, 255, 0.3);
+				}
 			}
 
 			> .keyboard-preview__key__label {
@@ -60,6 +74,19 @@
 				color: #999;
 
 				text-transform: capitalize;
+			}
+
+			> .keyboard-preview__key__function-label {
+				font-size: 16px;
+				font-weight: bold;
+				text-align: right;
+				padding: 3px;
+				color: #fff;
+				position: absolute;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				top: auto;
 			}
 		}
 	}

--- a/meteor/client/styles/shelf/adLibPanel.scss
+++ b/meteor/client/styles/shelf/adLibPanel.scss
@@ -333,4 +333,9 @@ $adlib-item-selected-color: #009DFF;
 			}
 		}
 	}
+
+	&.adlib-panel--keyboard-preview {
+		display: block;
+		padding: 20px;
+	}
 }

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -522,10 +522,6 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 					getAllowDeveloper() ?
 						<>
 							<ManualPlayout></ManualPlayout>
-							<KeyboardPreview 
-								hotkeys={[]}
-								physicalLayout={KeyboardLayouts.STANDARD_102}
-							/>
 						</> :
 						null
 				}

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -28,6 +28,7 @@ import { PubSub } from '../../lib/api/pubsub'
 import { ReactNotification } from '../lib/notifications/ReactNotification'
 import { Spinner } from '../lib/Spinner'
 import { MeteorCall } from '../../lib/api/methods'
+import { KeyboardPreview, KeyboardLayouts } from './Shelf/KeyboardPreview'
 
 const PackageInfo = require('../../package.json')
 
@@ -519,7 +520,14 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 				</div>
 				{
 					getAllowDeveloper() ?
-					<ManualPlayout></ManualPlayout> : null
+						<>
+							<ManualPlayout></ManualPlayout>
+							<KeyboardPreview 
+								hotkeys={[]}
+								physicalLayout={KeyboardLayouts.STANDARD_102}
+							/>
+						</> :
+						null
 				}
 			</div>
 		</React.Fragment>

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -28,7 +28,6 @@ import { PubSub } from '../../lib/api/pubsub'
 import { ReactNotification } from '../lib/notifications/ReactNotification'
 import { Spinner } from '../lib/Spinner'
 import { MeteorCall } from '../../lib/api/methods'
-import { KeyboardPreview, KeyboardLayouts } from './Shelf/KeyboardPreview'
 
 const PackageInfo = require('../../package.json')
 

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1435,16 +1435,23 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 			preventDefault(e)
 		}
 
+		const HOTKEY_GROUP = 'RuntimeArguments'
+
 		this.usedArgumentKeys.forEach((k) => {
 			if (k.up) {
-				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keyup')
-				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, HOTKEY_GROUP, 'keyup')
+				mousetrapHelper.unbind(k.key, HOTKEY_GROUP, 'keydown')
 			}
 			if (k.down) {
-				mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
+				mousetrapHelper.unbind(k.key, HOTKEY_GROUP, 'keydown')
 			}
 		})
+
 		this.usedArgumentKeys = []
+
+		RegisteredHotkeys.remove({
+			tag: HOTKEY_GROUP
+		})
 
 		if (this.props.showStyleBase) {
 			_.each(this.props.showStyleBase.runtimeArguments, (i) => {
@@ -1467,13 +1474,24 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 					}
 				}
 				_.each(combos, (combo: string) => {
-					mousetrapHelper.bind(combo, handler, 'keyup', 'RuntimeArguments')
-					mousetrapHelper.bind(combo, noOp, 'keydown', 'RuntimeArguments')
+					mousetrapHelper.bind(combo, handler, 'keyup', HOTKEY_GROUP)
+					mousetrapHelper.bind(combo, noOp, 'keydown', HOTKEY_GROUP)
 					this.usedArgumentKeys.push({
 						up: handler,
 						key: combo,
 						label: i.label || ''
 					})
+
+					registerHotkey(
+						combo,
+						i.label || '',
+						HotkeyAssignmentType.RUNTIME_ARGUMENT,
+						undefined,
+						false,
+						handler,
+						undefined,
+						HOTKEY_GROUP
+					)
 				})
 			})
 		}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -118,6 +118,7 @@ class KeyboardFocusMarker extends React.Component<IKeyboardFocusMarkerProps, IKe
 				MeteorCall.userAction.guiFocused('checkFocus', viewInfo).catch(console.error)
 			} else {
 				MeteorCall.userAction.guiBlurred('checkFocus', viewInfo).catch(console.error)
+				window.dispatchEvent(new Event('blur'))
 			}
 		}
 	}
@@ -488,8 +489,6 @@ const RundownHeader = translate()(class extends React.Component<Translated<IRund
 
 		let preventDefault = (e: Event) => {
 			e.preventDefault()
-			e.stopImmediatePropagation()
-			e.stopPropagation()
 		}
 		_.each(this.bindKeys, (k) => {
 			const method = k.global ? mousetrapHelper.bindGlobal : mousetrapHelper.bind
@@ -1349,8 +1348,6 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 
 		let preventDefault = (e) => {
 			e.preventDefault()
-			e.stopImmediatePropagation()
-			e.stopPropagation()
 		}
 		_.each(this.bindKeys, (k) => {
 			const method = k.global ? mousetrap.bindGlobal : mousetrap.bind
@@ -1430,8 +1427,6 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 		const { t } = this.props
 		let preventDefault = (e) => {
 			e.preventDefault()
-			e.stopImmediatePropagation()
-			e.stopPropagation()
 		}
 		const noOp = (e) => {
 			preventDefault(e)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -65,6 +65,7 @@ import { NoraPreviewRenderer } from './SegmentTimeline/Renderers/NoraPreviewRend
 import { OffsetPosition } from '../utils/positions'
 import { Settings } from '../../lib/Settings'
 import { MeteorCall } from '../../lib/api/methods'
+import { RegisteredHotkeys, registerHotkey, HotkeyAssignmentType } from '../lib/hotkeyRegistry'
 
 type WrappedShelf = ShelfBase & { getWrappedInstance (): ShelfBase }
 
@@ -349,6 +350,8 @@ class extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 interface HotkeyDefinition {
 	key: string
 	label: string
+	up?: (e: any) => void
+	down?: (e: any) => void
 }
 
 interface IRundownHeaderProps {
@@ -1757,6 +1760,27 @@ class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps
 		this.state.usedHotkeys = this.state.usedHotkeys.concat(hotkeys) // we concat directly to the state object member, because we need to
 		this.setState({
 			usedHotkeys: this.state.usedHotkeys
+		})
+
+		const HOTKEY_TAG = 'RundownView'
+
+		RegisteredHotkeys.remove({
+			tag: HOTKEY_TAG
+		})
+
+		function noop() { }
+
+		this.state.usedHotkeys.forEach((hotkey) => {
+			registerHotkey(
+				hotkey.key,
+				hotkey.label,
+				HotkeyAssignmentType.SYSTEM,
+				undefined,
+				false,
+				hotkey.up || hotkey.down || noop,
+				undefined,
+				HOTKEY_TAG
+			)
 		})
 	}
 

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -63,7 +63,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		compatibleStudios: compatibleStudios
 	}
 })(class ShowStyleBaseSettings extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
-	constructor (props: Translated<IProps & ITrackedProps>) {
+	constructor(props: Translated<IProps & ITrackedProps>) {
 		super(props)
 		this.state = {
 			uploadFileKey: Date.now(),
@@ -71,7 +71,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		}
 	}
 
-	onUploadFile (e) {
+	onUploadFile(e) {
 		const file = e.target.files[0]
 		if (!file) {
 			return
@@ -90,7 +90,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		reader.readAsText(file)
 	}
 
-	getOptionBlueprints () {
+	getOptionBlueprints() {
 		return _.map(Blueprints.find({ blueprintType: BlueprintManifestType.SHOWSTYLE }).fetch(), (blueprint) => {
 			return {
 				name: blueprint.name ? blueprint.name + ` (${blueprint._id})` : blueprint._id,
@@ -99,7 +99,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		})
 	}
 
-	renderEditForm (showStyleBase: ShowStyleBase) {
+	renderEditForm(showStyleBase: ShowStyleBase) {
 		const { t } = this.props
 
 		return (
@@ -109,10 +109,10 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 						{t('Show Style Base Name')}
 						{
 							!(this.props.showStyleBase && this.props.showStyleBase.name) ?
-							<div className='error-notice inline'>
-								<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No name set')}
-							</div> :
-							null
+								<div className='error-notice inline'>
+									<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No name set')}
+								</div> :
+								null
 						}
 						<div className='mdi'>
 							<EditAttribute
@@ -129,10 +129,10 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 						{t('Blueprint')}
 						{
 							!(this.props.showStyleBase && this.props.showStyleBase.blueprintId) ?
-							<div className='error-notice inline'>
-								{t('Blueprint not set')} <FontAwesomeIcon icon={faExclamationTriangle} />
-							</div> :
-							null
+								<div className='error-notice inline'>
+									{t('Blueprint not set')} <FontAwesomeIcon icon={faExclamationTriangle} />
+								</div> :
+								null
 						}
 						<div className='mdi'>
 							<EditAttribute
@@ -172,7 +172,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 				</div>
 				<div className='row'>
 					<div className='col c12 r1-c12'>
-						<HotkeyLegendSettings showStyleBase={showStyleBase}/>
+						<HotkeyLegendSettings showStyleBase={showStyleBase} />
 					</div>
 				</div>
 				<div className='row'>
@@ -193,7 +193,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 							object={showStyleBase}
 							collection={ShowStyleBases}
 							configPath={'config'}
-							/>
+						/>
 					</div>
 				</div>
 				<div className='row'>
@@ -208,7 +208,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 		)
 	}
 
-	render () {
+	render() {
 
 		if (this.props.showStyleBase) {
 			return this.renderEditForm(this.props.showStyleBase)
@@ -226,7 +226,7 @@ interface IStudioRuntimeArgumentsSettingsState {
 }
 
 const StudioRuntimeArgumentsSettings = translate()(class StudioRuntimeArgumentsSettings extends React.Component<Translated<IStudioRuntimeArgumentsSettingsProps>, IStudioRuntimeArgumentsSettingsState> {
-	constructor (props: Translated<IStudioRuntimeArgumentsSettingsProps>) {
+	constructor(props: Translated<IStudioRuntimeArgumentsSettingsProps>) {
 		super(props)
 
 		this.state = {
@@ -298,7 +298,7 @@ const StudioRuntimeArgumentsSettings = translate()(class StudioRuntimeArgumentsS
 			</React.Fragment>
 		})
 	}
-	renderItems () {
+	renderItems() {
 		const { t } = this.props
 		return (
 			(this.props.showStyleBase.runtimeArguments || []).map((item, index) => {
@@ -378,7 +378,7 @@ const StudioRuntimeArgumentsSettings = translate()(class StudioRuntimeArgumentsS
 		)
 	}
 
-	render () {
+	render() {
 		const { t } = this.props
 		return (
 			<div>
@@ -406,7 +406,7 @@ interface IStudioSourcesSettingsState {
 }
 
 const SourceLayerSettings = translate()(class SourceLayerSettings extends React.Component<Translated<IStudioSourcesSettingsProps>, IStudioSourcesSettingsState> {
-	constructor (props: Translated<IStudioSourcesSettingsProps>) {
+	constructor(props: Translated<IStudioSourcesSettingsProps>) {
 		super(props)
 
 		this.state = {
@@ -439,7 +439,7 @@ const SourceLayerSettings = translate()(class SourceLayerSettings extends React.
 		}
 	}
 
-	sourceLayerString (type: SourceLayerType) {
+	sourceLayerString(type: SourceLayerType) {
 		const { t } = this.props
 		switch (type) {
 			case SourceLayerType.CAMERA:
@@ -514,17 +514,17 @@ const SourceLayerSettings = translate()(class SourceLayerSettings extends React.
 				this.onDeleteSource(item)
 			},
 			message: <React.Fragment>
-				<p>{t('Are you sure you want to delete source layer "{{sourceLayerId}}"?',{ sourceLayerId: item && item.name })}</p>
+				<p>{t('Are you sure you want to delete source layer "{{sourceLayerId}}"?', { sourceLayerId: item && item.name })}</p>
 				<p>{t('Please note: This action is irreversible!')}</p>
 			</React.Fragment>
 		})
 	}
-	renderInputSources () {
+	renderInputSources() {
 		const { t } = this.props
 
 		return (
 			_.map(this.props.showStyleBase.sourceLayers, (item, index) => {
-				let newItem = _.clone(item) as (ISourceLayer & {index: number})
+				let newItem = _.clone(item) as (ISourceLayer & { index: number })
 				newItem.index = index
 				return newItem
 			}).sort((a, b) => {
@@ -779,7 +779,7 @@ const SourceLayerSettings = translate()(class SourceLayerSettings extends React.
 		)
 	}
 
-	render () {
+	render() {
 		const { t } = this.props
 		return (
 			<div>
@@ -793,10 +793,10 @@ const SourceLayerSettings = translate()(class SourceLayerSettings extends React.
 				</h2>
 				{
 					(!this.props.showStyleBase || !this.props.showStyleBase.sourceLayers || !this.props.showStyleBase.sourceLayers.length) ?
-					<div className='error-notice'>
-						<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No source layers set')}
-					</div> :
-					null
+						<div className='error-notice'>
+							<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No source layers set')}
+						</div> :
+						null
 				}
 				<table className='expando settings-studio-source-table'>
 					<tbody>
@@ -821,7 +821,7 @@ interface IOutputSettingsState {
 }
 
 const OutputSettings = translate()(class OutputSettings extends React.Component<Translated<IOutputSettingsProps>, IOutputSettingsState> {
-	constructor (props: Translated<IOutputSettingsProps>) {
+	constructor(props: Translated<IOutputSettingsProps>) {
 		super(props)
 
 		this.state = {
@@ -829,7 +829,7 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 		}
 	}
 
-	isPGMChannelSet () {
+	isPGMChannelSet() {
 		if (!this.props.showStyleBase.outputLayers) return false
 		return this.props.showStyleBase.outputLayers.filter(layer => layer.isPGM).length > 0
 	}
@@ -869,7 +869,7 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 				this.onDeleteOutput(output)
 			},
 			message: <React.Fragment>
-				<p>{t('Are you sure you want to delete source layer "{{outputId}}"?',{ outputId: output && output.name })}</p>
+				<p>{t('Are you sure you want to delete source layer "{{outputId}}"?', { outputId: output && output.name })}</p>
 				<p>{t('Please note: This action is irreversible!')}</p>
 			</React.Fragment>
 		})
@@ -903,7 +903,7 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 		}
 	}
 
-	renderOutputs () {
+	renderOutputs() {
 		const { t } = this.props
 		return (
 			_.map(this.props.showStyleBase.outputLayers, (item, index) => {
@@ -944,13 +944,13 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 									<div className='mod mvs mhs'>
 										<label className='field'>
 											{t('Channel Name')}
-												<EditAttribute
-													modifiedClassName='bghl'
-													attribute={'outputLayers.' + item.index + '.name'}
-													obj={this.props.showStyleBase}
-													type='text'
-													collection={ShowStyleBases}
-													className='input text-input input-l'></EditAttribute>
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'outputLayers.' + item.index + '.name'}
+												obj={this.props.showStyleBase}
+												type='text'
+												collection={ShowStyleBases}
+												className='input text-input input-l'></EditAttribute>
 										</label>
 									</div>
 									<div className='mod mvs mhs'>
@@ -997,14 +997,14 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 								</div>
 							</td>
 						</tr>
-					:
+						:
 						null
 				]
 			})
 		)
 	}
 
-	render () {
+	render() {
 		const { t } = this.props
 		return (
 			<div>
@@ -1018,17 +1018,17 @@ const OutputSettings = translate()(class OutputSettings extends React.Component<
 				</h2>
 				{
 					(!this.props.showStyleBase || !this.props.showStyleBase.outputLayers || !this.props.showStyleBase.outputLayers.length) ?
-					<div className='error-notice'>
-						<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No output channels set')}
-					</div> :
-					null
+						<div className='error-notice'>
+							<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No output channels set')}
+						</div> :
+						null
 				}
 				{
 					!this.isPGMChannelSet() ?
-					<div className='error-notice'>
-						<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No PGM output')}
-					</div> :
-					null
+						<div className='error-notice'>
+							<FontAwesomeIcon icon={faExclamationTriangle} /> {t('No PGM output')}
+						</div> :
+						null
 				}
 				<table className='expando settings-studio-output-table'>
 					<tbody>
@@ -1053,7 +1053,7 @@ interface IHotkeyLegendSettingsState {
 }
 
 const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends React.Component<Translated<IHotkeyLegendSettingsProps>, IHotkeyLegendSettingsState> {
-	constructor (props: Translated<IHotkeyLegendSettingsProps>) {
+	constructor(props: Translated<IHotkeyLegendSettingsProps>) {
 		super(props)
 
 		this.state = {
@@ -1111,7 +1111,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 		})
 	}
 
-	renderItems () {
+	renderItems() {
 		const { t } = this.props
 		return (
 			(this.props.showStyleBase.hotkeyLegend || []).map((item, index) => {
@@ -1142,7 +1142,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 					</tr>
 					{this.isItemEdited(item) &&
 						<tr className='expando-details hl'>
-							<td colSpan={4}>
+							<td colSpan={5}>
 								<div>
 									<div className='mod mvs mhs'>
 										<label className='field'>
@@ -1219,7 +1219,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 		)
 	}
 
-	render () {
+	render() {
 		const { t } = this.props
 		return (
 			<div>
@@ -1246,7 +1246,7 @@ interface IShowStyleVariantsSettingsState {
 	editedMappings: ProtectedString<any>[]
 }
 const ShowStyleVariantsSettings = translate()(class ShowStyleVariantsSettings extends React.Component<Translated<IShowStyleVariantsProps>, IShowStyleVariantsSettingsState> {
-	constructor (props: Translated<IShowStyleVariantsProps>) {
+	constructor(props: Translated<IShowStyleVariantsProps>) {
 		super(props)
 
 		this.state = {
@@ -1293,7 +1293,7 @@ const ShowStyleVariantsSettings = translate()(class ShowStyleVariantsSettings ex
 		})
 	}
 
-	renderShowStyleVariants () {
+	renderShowStyleVariants() {
 		const { t } = this.props
 
 		return (
@@ -1355,7 +1355,7 @@ const ShowStyleVariantsSettings = translate()(class ShowStyleVariantsSettings ex
 		)
 	}
 
-	render () {
+	render() {
 		const { t } = this.props
 		return (
 			<div>

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -1188,6 +1188,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 											type='checkbox'
 											options={SourceLayerType}
 											className='mod mas'
+											collection={ShowStyleBases}
 											mutateDisplayValue={v => v === undefined ? false : true}
 											mutateUpdateValue={v => undefined} />
 										<EditAttribute
@@ -1199,7 +1200,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 											optionsAreNumbers
 											collection={ShowStyleBases}
 											className='input text-input input-l dropdown'
-											></EditAttribute>
+											mutateUpdateValue={v => v ? v : undefined} />
 									</div>
 								</div>
 								<div className='mod alright'>

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -1128,6 +1128,9 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 						<td className='settings-studio-custom-config-table__value c2'>
 							{item.platformKey ? mousetrapHelper.shortcutLabel(item.platformKey) : ''}
 						</td>
+						<td className='settings-studio-custom-config-table__value c2'>
+							{item.sourceLayerType !== undefined ? SourceLayerType[item.sourceLayerType] : ''}
+						</td>
 						<td className='settings-studio-custom-config-table__actions table-item-actions c3'>
 							<button className='action-btn' onClick={() => this.editItem(item)}>
 								<FontAwesomeIcon icon={faPencilAlt} />

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -1125,6 +1125,9 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 						<td className='settings-studio-custom-config-table__value c3'>
 							{item.label}
 						</td>
+						<td className='settings-studio-custom-config-table__value c2'>
+							{item.platformKey ? mousetrapHelper.shortcutLabel(item.platformKey) : ''}
+						</td>
 						<td className='settings-studio-custom-config-table__actions table-item-actions c3'>
 							<button className='action-btn' onClick={() => this.editItem(item)}>
 								<FontAwesomeIcon icon={faPencilAlt} />
@@ -1152,7 +1155,7 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 									</div>
 									<div className='mod mvs mhs'>
 										<label className='field'>
-											{t('Value')}
+											{t('Label')}
 											<EditAttribute
 												modifiedClassName='bghl'
 												attribute={'hotkeyLegend.' + index + '.label'}
@@ -1161,6 +1164,42 @@ const HotkeyLegendSettings = translate()(class HotkeyLegendSettings extends Reac
 												collection={ShowStyleBases}
 												className='input text-input input-l'></EditAttribute>
 										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Host key')}
+											<EditAttribute
+												modifiedClassName='bghl'
+												attribute={'hotkeyLegend.' + index + '.platformKey'}
+												obj={this.props.showStyleBase}
+												type='text'
+												collection={ShowStyleBases}
+												className='input text-input input-l'></EditAttribute>
+										</label>
+									</div>
+									<div className='mod mvs mhs'>
+										<label className='field'>
+											{t('Source Layer type')}
+										</label>
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'hotkeyLegend.' + index + '.sourceLayerType'}
+											obj={this.props.showStyleBase}
+											type='checkbox'
+											options={SourceLayerType}
+											className='mod mas'
+											mutateDisplayValue={v => v === undefined ? false : true}
+											mutateUpdateValue={v => undefined} />
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'hotkeyLegend.' + index + '.sourceLayerType'}
+											obj={this.props.showStyleBase}
+											type='dropdown'
+											options={SourceLayerType}
+											optionsAreNumbers
+											collection={ShowStyleBases}
+											className='input text-input input-l dropdown'
+											></EditAttribute>
 									</div>
 								</div>
 								<div className='mod alright'>

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -110,7 +110,7 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 				>
 				<td className={ClassNames(
 					'adlib-panel__list-view__list__table__cell--icon',
-					RundownUtils.getSourceLayerClassName(this.props.layer.type),
+					this.props.layer ? RundownUtils.getSourceLayerClassName(this.props.layer.type) : undefined,
 					{
 						'source-missing': this.props.status === RundownAPI.PieceStatusCode.SOURCE_MISSING,
 						'source-broken': this.props.status === RundownAPI.PieceStatusCode.SOURCE_BROKEN,

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -34,7 +34,7 @@ interface IListViewItemProps {
 	layer: ISourceLayer
 	outputLayer?: IOutputLayer
 	onSelectAdLib: (aSLine: IAdLibListItem) => void
-	onToggleAdLib: (aSLine: IAdLibListItem, queue: boolean, context: any) => void
+	onToggleAdLib: (context: any, aSLine: IAdLibListItem, queue: boolean) => void
 	playlist: RundownPlaylist
 }
 
@@ -105,7 +105,7 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 				'floated': this.props.adLibListItem.floated
 			})} key={unprotectString(this.props.adLibListItem._id)}
 				onClick={(e) => this.props.onSelectAdLib(this.props.adLibListItem)}
-				onDoubleClick={(e) => this.props.onToggleAdLib(this.props.adLibListItem, e.shiftKey, e)}
+				onDoubleClick={(e) => this.props.onToggleAdLib(e, this.props.adLibListItem, e.shiftKey)}
 				data-obj-id={this.props.adLibListItem._id}
 				>
 				<td className={ClassNames(

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -32,6 +32,7 @@ import { RundownAPI } from '../../../lib/api/rundown'
 import { memoizedIsolatedAutorun } from '../../lib/reactiveData/reactiveDataHelper'
 import { PartInstance, PartInstances } from '../../../lib/collections/PartInstances'
 import { MeteorCall } from '../../../lib/api/methods'
+import { RegisteredHotkeys, registerHotkey, HotkeyAssignmentType } from '../../lib/hotkeyRegistry'
 
 interface IListViewPropsHeader {
 	uiSegments: Array<AdlibSegmentUi>
@@ -760,6 +761,10 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 			e.preventDefault()
 		}
 
+		RegisteredHotkeys.remove({
+			tag: HOTKEY_GROUP
+		})
+
 		if (this.props.liveSegment && this.props.liveSegment.pieces) {
 			this.props.liveSegment.pieces.forEach((item) => {
 				if (item.hotkey) {
@@ -770,6 +775,19 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 					}, 'keyup', HOTKEY_GROUP)
 					this.usedHotkeys.push(item.hotkey)
 
+					if (this.props.sourceLayerLookup[item.sourceLayerId]) {
+						registerHotkey(
+							item.hotkey,
+							item.name,
+							HotkeyAssignmentType.ADLIB,
+							this.props.sourceLayerLookup[item.sourceLayerId],
+							item.toBeQueued || false,
+							this.onToggleAdLib,
+							[item, false, { type: 'simulatedhotkey' }],
+							HOTKEY_GROUP
+						)
+					}
+
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {
 						const queueHotkey = [RundownViewKbdShortcuts.ADLIB_QUEUE_MODIFIER, item.hotkey].join('+')
@@ -779,6 +797,19 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 							this.onToggleAdLib(item, true, e)
 						}, 'keyup', HOTKEY_GROUP)
 						this.usedHotkeys.push(queueHotkey)
+
+						if (this.props.sourceLayerLookup[item.sourceLayerId]) {
+							registerHotkey(
+								item.hotkey,
+								item.name,
+								HotkeyAssignmentType.ADLIB,
+								this.props.sourceLayerLookup[item.sourceLayerId],
+								true,
+								this.onToggleAdLib,
+								[item, true, { type: 'simulatedhotkey' }],
+								HOTKEY_GROUP
+							)
+						}
 					}
 				}
 			})

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -731,18 +731,20 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 		this.refreshKeyboardHotkeys()
 	}
 
-	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', HOTKEY_GROUP)
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', HOTKEY_GROUP)
-		this.usedHotkeys.length = 0
-
-		if (this.props.liveSegment && this.props.liveSegment !== prevProps.liveSegment && this.state.followLive) {
-			this.setState({
-				selectedSegment: this.props.liveSegment
-			})
+	componentDidUpdate (prevProps: IAdLibPanelProps & IAdLibPanelTrackedProps, prevState: IState) {
+		if (!_.isEqual(prevProps, this.props) || !_.isEqual(prevState, this.state)) {
+			mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', HOTKEY_GROUP)
+			mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', HOTKEY_GROUP)
+			this.usedHotkeys.length = 0
+	
+			if (this.props.liveSegment && this.props.liveSegment !== prevProps.liveSegment && this.state.followLive) {
+				this.setState({
+					selectedSegment: this.props.liveSegment
+				})
+			}
+	
+			this.refreshKeyboardHotkeys()
 		}
-
-		this.refreshKeyboardHotkeys()
 	}
 
 	componentWillUnmount () {

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -37,7 +37,7 @@ import { RegisteredHotkeys, registerHotkey, HotkeyAssignmentType } from '../../l
 interface IListViewPropsHeader {
 	uiSegments: Array<AdlibSegmentUi>
 	onSelectAdLib: (piece: AdLibPieceUi) => void
-	onToggleAdLib: (piece: AdLibPieceUi, queue: boolean, e: ExtendedKeyboardEvent) => void
+	onToggleAdLib: (e: ExtendedKeyboardEvent, piece: AdLibPieceUi, queue: boolean) => void
 	selectedPart: AdLibPieceUi | undefined
 	selectedSegment: AdlibSegmentUi | undefined
 	searchFilter: string | undefined
@@ -771,7 +771,7 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 					mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', HOTKEY_GROUP)
 					mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 						preventDefault(e)
-						this.onToggleAdLib(item, false, e)
+						this.onToggleAdLib(e, item, false)
 					}, 'keyup', HOTKEY_GROUP)
 					this.usedHotkeys.push(item.hotkey)
 
@@ -783,7 +783,7 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 							this.props.sourceLayerLookup[item.sourceLayerId],
 							item.toBeQueued || false,
 							this.onToggleAdLib,
-							[item, false, { type: 'simulatedhotkey' }],
+							[item, false],
 							HOTKEY_GROUP
 						)
 					}
@@ -794,7 +794,7 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 						mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', HOTKEY_GROUP)
 						mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
-							this.onToggleAdLib(item, true, e)
+							this.onToggleAdLib(e, item, true)
 						}, 'keyup', HOTKEY_GROUP)
 						this.usedHotkeys.push(queueHotkey)
 
@@ -806,7 +806,7 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 								this.props.sourceLayerLookup[item.sourceLayerId],
 								true,
 								this.onToggleAdLib,
-								[item, true, { type: 'simulatedhotkey' }],
+								[item, true],
 								HOTKEY_GROUP
 							)
 						}
@@ -829,7 +829,7 @@ export const AdLibPanel = translateWithTracker<IAdLibPanelProps, IState, IAdLibP
 		})
 	}
 
-	onToggleAdLib = (adlibPiece: AdLibPieceUi, queue: boolean, e: any) => {
+	onToggleAdLib = (e: any, adlibPiece: AdLibPieceUi, queue: boolean) => {
 		const { t } = this.props
 
 		if (adlibPiece.invalid) {

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -35,8 +35,8 @@ import { RegisteredHotkeys, registerHotkey, HotkeyAssignmentType } from '../../l
 
 interface IListViewPropsHeader {
 	onSelectAdLib: (piece: AdLibPieceUi) => void
-	onToggleSticky: (item: IAdLibListItem, e: any) => void
-	onToggleAdLib: (piece: AdLibPieceUi, queue: boolean, e: any) => void
+	onToggleSticky: (e: any, item: IAdLibListItem) => void
+	onToggleAdLib: (e: any, piece: AdLibPieceUi, queue: boolean) => void
 	selectedPiece: AdLibPieceUi | undefined
 	searchFilter: string | undefined
 	showStyleBase: ShowStyleBase
@@ -381,7 +381,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 						mousetrapHelper.bind(item.hotkey, preventDefault, 'keydown', HOTKEY_GROUP)
 						mousetrapHelper.bind(item.hotkey, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
-							this.onToggleAdLib(item, false, e)
+							this.onToggleAdLib(e, item, false)
 						}, 'keyup', HOTKEY_GROUP)
 						this.usedHotkeys.push(item.hotkey)
 
@@ -393,7 +393,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 								this.props.sourceLayerLookup[item.sourceLayerId],
 								item.toBeQueued || false,
 								this.onToggleAdLib,
-								[item, false, { type: 'simulatedhotkey' }],
+								[item, false],
 								HOTKEY_GROUP
 							)
 						}
@@ -404,7 +404,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 							mousetrapHelper.bind(queueHotkey, preventDefault, 'keydown', HOTKEY_GROUP)
 							mousetrapHelper.bind(queueHotkey, (e: ExtendedKeyboardEvent) => {
 								preventDefault(e)
-								this.onToggleAdLib(item, true, e)
+								this.onToggleAdLib(e, item, true)
 							}, 'keyup', HOTKEY_GROUP)
 							this.usedHotkeys.push(queueHotkey)
 
@@ -416,7 +416,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 									this.props.sourceLayerLookup[item.sourceLayerId],
 									true,
 									this.onToggleAdLib,
-									[item, true, { type: 'simulatedhotkey' }],
+									[item, true],
 									HOTKEY_GROUP
 								)
 							}
@@ -431,7 +431,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 						mousetrapHelper.bind(element, preventDefault, 'keydown', HOTKEY_GROUP)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
-							this.onClearAllSourceLayer(item, e)
+							this.onClearAllSourceLayer(e, item)
 						}, 'keyup', HOTKEY_GROUP)
 						this.usedHotkeys.push(element)
 
@@ -442,7 +442,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 							undefined,
 							false,
 							this.onClearAllSourceLayer,
-							[item, { type: 'simulatedhotkey' }],
+							[item],
 							HOTKEY_GROUP
 						)
 					})
@@ -454,7 +454,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 						mousetrapHelper.bind(element, preventDefault, 'keydown', HOTKEY_GROUP)
 						mousetrapHelper.bind(element, (e: ExtendedKeyboardEvent) => {
 							preventDefault(e)
-							this.onToggleSticky(item._id, e)
+							this.onToggleSticky(e, item._id)
 						}, 'keyup', HOTKEY_GROUP)
 						this.usedHotkeys.push(element)
 
@@ -465,7 +465,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 							item,
 							false,
 							this.onToggleSticky,
-							[item._id, { type: 'simulatedhotkey' }],
+							[item._id],
 							HOTKEY_GROUP
 						)
 					})
@@ -480,11 +480,11 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		})
 	}
 
-	onToggleStickyItem = (item: IAdLibListItem, e: any) => {
-		this.onToggleSticky(unprotectString(item._id), e)
+	onToggleStickyItem = (e: any, item: IAdLibListItem) => {
+		this.onToggleSticky(e, unprotectString(item._id))
 	}
 
-	onToggleSticky = (sourceLayerId: string, e: any) => {
+	onToggleSticky = (e: any, sourceLayerId: string) => {
 		if (this.props.currentRundown && this.props.playlist.currentPartInstanceId && this.props.playlist.active) {
 			const { t } = this.props
 			doUserAction(t, e, 'Start playing Sticky Piece', (e) => MeteorCall.userAction.sourceLayerStickyPieceStart(e, this.props.playlist._id, sourceLayerId))
@@ -498,7 +498,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		})
 	}
 
-	onToggleAdLib = (adlibPiece: AdLibPieceUi, queue: boolean, e: any) => {
+	onToggleAdLib = (e: any, adlibPiece: AdLibPieceUi, queue: boolean) => {
 		const { t } = this.props
 
 		if (adlibPiece.invalid) {
@@ -522,7 +522,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		}
 	}
 
-	onClearAllSourceLayer = (sourceLayer: ISourceLayer, e: any) => {
+	onClearAllSourceLayer = (e: any, sourceLayer: ISourceLayer) => {
 		// console.log(sourceLayer)
 
 		if (this.props.playlist && this.props.playlist.currentPartInstanceId) {

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -342,11 +342,13 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 	}
 
 	componentDidUpdate (prevProps: IProps & ITrackedProps) {
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', HOTKEY_GROUP)
-		mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', HOTKEY_GROUP)
-		this.usedHotkeys.length = 0
-
-		this.refreshKeyboardHotkeys()
+		if (!_.isEqual(this.props, prevProps)) {
+			mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', HOTKEY_GROUP)
+			mousetrapHelper.unbindAll(this.usedHotkeys, 'keydown', HOTKEY_GROUP)
+			this.usedHotkeys.length = 0
+	
+			this.refreshKeyboardHotkeys()
+		}
 	}
 
 	componentWillUnmount () {

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -7,6 +7,7 @@ import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
 import { ShowStyleBase, HotkeyDefinition } from '../../../lib/collections/ShowStyleBases'
+import { PhysicalLayout, KeyPositon } from '../../../lib/keyboardLayout';
 
 const _isMacLike = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false
 
@@ -41,18 +42,6 @@ export enum SpecialKeyPositions {
 	BLANK_SPACE = '$space'
 }
 
-export interface KeyPositon {
-	code: string
-	width: number
-	space?: true
-}
-
-/**
- * Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
- * Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A. Not all rows need to be specified.
- */
-export type PhysicalLayout = KeyPositon[][]
-
 export interface IProps {
 	physicalLayout: PhysicalLayout
 	showStyleBase: ShowStyleBase
@@ -66,30 +55,6 @@ interface ITrackedProps {
 interface IState {
 	layout: KeyboardLayoutMap | undefined
 	keyDown: { [key: string]: boolean }
-}
-
-/**
- * Convert an array of strings into a PhysicalLayout.
- * See https://w3c.github.io/uievents-code/#keyboard-sections for rows and sections
- *
- * @param {string[]} shortForm Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
- * 							   Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A.
- * @returns {PhysicalLayout}
- */
-function createPhysicalLayout(shortForm: string[]): PhysicalLayout {
-	return shortForm.map((row) => {
-		return _.compact(row.split(',').map((keyPosition) => {
-			const args = keyPosition.split(':')
-			return args[0] ? {
-				code: args[1] ? args[1] : args[0],
-				width: args[1] ?
-					args[0] === 'X' ?
-						-1 :
-						parseFloat(args[0]) :
-					3
-			} : undefined
-		}))
-	})
 }
 
 export enum GenericFuncionalKeyLabels {
@@ -121,47 +86,6 @@ export enum GenericFuncionalKeyLabels {
 	ArrowDown = '⯆',
 	ArrowLeft = '⯇',
 	ArrowRight = '⯈'
-}
-
-export namespace KeyboardLayouts {
-	// This is a small keyboard layout: 102-Standard keybord, without the Numpad
-	export const STANDARD_102_TKL: PhysicalLayout = createPhysicalLayout([
-		// Row E
-		'Backquote,Digit1,Digit2,Digit3,Digit4,Digit5,Digit6,Digit7,Digit8,Digit9,Digit0,Minus,Equal,X:Backspace',
-		// Row D
-		'4:Tab,KeyQ,KeyW,KeyE,KeyR,KeyT,KeyY,KeyU,KeyI,KeyO,KeyP,BracketLeft,BracketRight',
-		// Row C
-		'5:CapsLock,KeyA,KeyS,KeyD,KeyF,KeyG,KeyH,KeyJ,KeyK,KeyL,Semicolon,Quote,Backslash,X:Enter',
-		// Row B
-		'3.5:ShiftLeft,IntlBackslash,KeyZ,KeyX,KeyC,KeyV,KeyB,KeyN,KeyM,Comma,Period,Slash,X:ShiftRight',
-		// Row A
-		'4:ControlLeft,MetaLeft,AltLeft,21:Space,AltRight,MetaRight,ContextMenu,X:ControlRight',
-
-		// Row K
-		'Escape,-1:$space,F1,F2,F3,F4,-1:$space,F5,F6,F7,F8,-1:$space,F9,F10,F11,F12',
-
-		// Control Pad E
-		'Insert,Home,PageUp',
-		// Control Pad D
-		'Delete,End,PageDown',
-
-		// Arrow Pad B
-		'$space,ArrowUp,$space',
-		// Arrow Pad A
-		'ArrowLeft,ArrowDown,ArrowRight',
-	])
-
-	export function nameToPhysicalLayout(name: Names) {
-		switch (name) {
-			case Names.STANDARD_102_TKL:
-			default:
-				return STANDARD_102_TKL
-		}
-	}
-
-	export enum Names {
-		STANDARD_102_TKL = 'STANDARD_102_TKL'
-	}
 }
 
 const COMBINATOR_RE = /\s*\+\s*/

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -198,7 +198,7 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 		customLabels: _.object(
 			_.map(
 				customLabels,
-				(value, key) => [ value.platformKey || value.key, value ]
+				(value, key) => [ value.platformKey ? value.platformKey.toUpperCase() : value.key.toUpperCase(), value ]
 			)
 		)
 	}
@@ -330,10 +330,7 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 					let customLabel: string | undefined = undefined
 					let customSourceLayer: SourceLayerType | undefined = undefined
 
-					if (this.props.customLabels[thisCombo.toLowerCase()]) {
-						customLabel = this.props.customLabels[thisCombo.toLowerCase()].label
-						customSourceLayer = this.props.customLabels[thisCombo.toLowerCase()].sourceLayerType
-					} else if (this.props.customLabels[thisCombo.toUpperCase()]) {
+					if (this.props.customLabels[thisCombo.toUpperCase()]) {
 						customLabel = this.props.customLabels[thisCombo.toUpperCase()].label
 						customSourceLayer = this.props.customLabels[thisCombo.toUpperCase()].sourceLayerType
 					}

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -1,0 +1,223 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import * as classNames from 'classnames'
+import { ISourceLayer } from 'tv-automation-sofie-blueprints-integration'
+import { IHotkeyAssignment, RegisteredHotkeys } from '../../lib/hotkeyRegistry'
+import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData';
+import { MeteorReactComponent } from '../../lib/MeteorReactComponent';
+
+declare global {
+	type KeyboardLayoutMap = Map<string, string>
+
+	type KeyboardLayoutEvents = 'layoutchange'
+
+	interface Keyboard {
+		getLayoutMap (): Promise<KeyboardLayoutMap>
+		addEventListener (type: KeyboardLayoutEvents, listener: EventListener): void
+		removeEventListener (type: KeyboardLayoutEvents, listener: EventListener): void
+	}
+
+	interface Navigator {
+		keyboard: Keyboard
+	}
+}
+
+export interface IParsedHotkeyAssignment extends IHotkeyAssignment {
+	keys: Set<string>
+}
+
+export enum SpecialKeyPositions {
+	BLANK_SPACE = '$space'
+}
+
+export interface KeyPositon {
+	code: string
+	width: number
+	space?: true
+}
+
+/**
+ * Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
+ * Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A. Not all rows need to be specified.
+ */
+export type PhysicalLayout = KeyPositon[][]
+
+export interface IProps {
+	physicalLayout: PhysicalLayout
+}
+
+interface ITrackedProps {
+	hotkeys: IHotkeyAssignment[]
+}
+
+interface IState {
+	layout: KeyboardLayoutMap | undefined
+}
+
+/**
+ * Convert an array of strings into a PhysicalLayout.
+ * See https://w3c.github.io/uievents-code/#keyboard-sections for rows and sections
+ *
+ * @param {string[]} shortForm Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
+ * 							   Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A.
+ * @returns {PhysicalLayout}
+ */
+function createPhysicalLayout(shortForm: string[]): PhysicalLayout {
+	return shortForm.map((row) => {
+		return _.compact(row.split(',').map((keyPosition) => {
+			const args = keyPosition.split(':')
+			return args[0] ? {
+				code: args[1] ? args[1] : args[0],
+				width: args[1] ?
+					args[0] === 'X' ?
+						-1 :
+						parseFloat(args[0]) :
+					3
+			} : undefined
+		}))
+	})
+}
+
+export enum GenericFuncionalKeyLabels {
+	Backspace = '⌫',
+	Tab = 'Tab ⭾',
+	CapsLock = 'CapsLock',
+	Enter = 'Enter',
+	ShiftLeft = 'Shift',
+	ShiftRight = 'Shift',
+	ControlLeft = 'Ctrl',
+	MetaLeft = '❖',
+	AltLeft = 'Alt',
+	Space = ' ',
+	AltRight = 'Alt',
+	MetaRight = '❖',
+	ContextMenu = '☰',
+	ControlRight = 'Ctrl',
+
+	Escape = 'Esc',
+
+	Insert = 'Insert',
+	Delete = 'Delete',
+	Home = 'Home',
+	End = 'End',
+	PageUp = 'PgUp',
+	PageDown = 'PgDn',
+
+	ArrowUp = '⯅',
+	ArrowDown = '⯆',
+	ArrowLeft = '⯇',
+	ArrowRight = '⯈'
+}
+
+export namespace KeyboardLayouts {
+	export const STANDARD_102: PhysicalLayout = createPhysicalLayout([
+		// Row E
+		'Backquote,Digit1,Digit2,Digit3,Digit4,Digit5,Digit6,Digit7,Digit8,Digit9,Digit0,Minus,Equal,X:Backspace',
+		// Row D
+		'4:Tab,KeyQ,KeyW,KeyE,KeyR,KeyT,KeyY,KeyU,KeyI,KeyO,KeyP,BracketLeft,BracketRight',
+		// Row C
+		'5:CapsLock,KeyA,KeyS,KeyD,KeyF,KeyG,KeyH,KeyJ,KeyK,KeyL,Semicolon,Quote,Backslash,X:Enter',
+		// Row B
+		'3.5:ShiftLeft,IntlBackslash,KeyZ,KeyX,KeyC,KeyV,KeyB,KeyN,KeyM,Comma,Period,Slash,X:ShiftRight',
+		// Row A
+		'4:ControlLeft,MetaLeft,AltLeft,21:Space,AltRight,MetaRight,ContextMenu,X:ControlRight',
+
+		// Row K
+		'Escape,-1:$space,F1,F2,F3,F4,-1:$space,F5,F6,F7,F8,-1:$space,F9,F10,F11,F12',
+
+		// Control Pad E
+		'Insert,Home,PageUp',
+		// Control Pad D
+		'Delete,End,PageDown',
+
+		// Arrow Pad B
+		'$space,ArrowUp,$space',
+		// Arrow Pad A
+		'ArrowLeft,ArrowDown,ArrowRight',
+	])
+}
+
+export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props: IProps) => {
+	return {
+		hotkeys: RegisteredHotkeys.find().fetch()
+	}
+})(class KeyboardPreview extends MeteorReactComponent<IProps & ITrackedProps, IState> {
+	constructor(props: IProps) {
+		super(props)
+
+		this.state = {
+			layout: undefined
+		}
+	}
+
+	onLayoutChange = () => {
+		if (navigator.keyboard) {
+			navigator.keyboard.getLayoutMap().then(layout => this.setState({ layout }))
+		}
+	}
+
+	componentDidMount() {
+		if (navigator.keyboard) {
+			navigator.keyboard.getLayoutMap().then(layout => this.setState({ layout }))
+			if (navigator.keyboard.addEventListener) {
+				navigator.keyboard.addEventListener('layoutchange', this.onLayoutChange)
+			}
+		}
+	}
+
+	componentWillUnmount() {
+		if (navigator.keyboard && navigator.keyboard.removeEventListener) {
+			navigator.keyboard.removeEventListener('layoutchange', this.onLayoutChange)
+		}
+	}
+
+	private renderBlock(block) {
+		return block.map((row) => <div className='keyboard-preview__key-row'>
+			{ row.map((key, index) => {
+				if (key.code === SpecialKeyPositions.BLANK_SPACE) {
+					return <div key={'idx' + index} className={classNames('keyboard-preview__blank-space', {
+						'keyboard-preview__blank-space--spring': (key.width < 0)
+					})} style={{fontSize: key.width >= 0 ? (key.width || 1) + 'em' : undefined }}></div>
+				} else {
+					return <div key={key.code} className={classNames('keyboard-preview__key', {
+						'keyboard-preview__key--fill': (key.width < 0)
+					})} style={{fontSize: key.width >= 0 ? (key.width || 1) + 'em' : undefined }}>
+							<div className='keyboard-preview__key__label'>
+								{this.state.layout ?
+									this.state.layout.get(key.code) || GenericFuncionalKeyLabels[key.code] || key.code :
+									GenericFuncionalKeyLabels[key.code] || key.code
+								}
+							</div>
+						</div>
+				}
+			}) }
+		</div>)
+	}
+
+	render() {
+		const { physicalLayout: keys } = this.props
+		const alphanumericBlock = keys.slice(0, 5)
+		const functionBlock = keys.slice(5, 6)
+		const controlPad = keys.slice(6, 8)
+		const arrowPad = keys.slice(8, 10)
+		const numPad = keys.slice(11, 15)
+
+		return <div className='keyboard-preview'>
+			{functionBlock.length > 0 && <div className='keyboard-preview__function'>
+				{this.renderBlock(functionBlock)}
+			</div>}
+			{alphanumericBlock.length > 0 && <div className='keyboard-preview__alphanumeric'>
+				{this.renderBlock(alphanumericBlock)}
+			</div>}
+			{controlPad.length > 0 && <div className='keyboard-preview__control-pad'>
+				{this.renderBlock(controlPad)}
+			</div>}
+			{arrowPad.length > 0 && <div className='keyboard-preview__arrow-pad'>
+				{this.renderBlock(arrowPad)}
+			</div>}
+			{numPad.length > 0 && <div className='keyboard-preview__num-pad'>
+				{this.renderBlock(numPad)}
+			</div>}
+		</div>
+	}
+})

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -330,9 +330,12 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 					let customLabel: string | undefined = undefined
 					let customSourceLayer: SourceLayerType | undefined = undefined
 
-					if (this.props.customLabels[thisCombo]) {
-						customLabel = this.props.customLabels[thisCombo].label
-						customSourceLayer = this.props.customLabels[thisCombo].sourceLayerType
+					if (this.props.customLabels[thisCombo.toLowerCase()]) {
+						customLabel = this.props.customLabels[thisCombo.toLowerCase()].label
+						customSourceLayer = this.props.customLabels[thisCombo.toLowerCase()].sourceLayerType
+					} else if (this.props.customLabels[thisCombo.toUpperCase()]) {
+						customLabel = this.props.customLabels[thisCombo.toUpperCase()].label
+						customSourceLayer = this.props.customLabels[thisCombo.toUpperCase()].sourceLayerType
 					}
 
 					return <div

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -304,9 +304,9 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 					let modifierKey: string | undefined
 
 					let allFuncs: IBaseHotkeyAssignment[] | undefined = this.props.hotkeys[modifiers] && this.props.hotkeys[modifiers].filter(hotkey =>
-						hotkey.finalKey === key.code.toLowerCase() ||
+						hotkey.finalKey.toLowerCase() === key.code.toLowerCase() ||
 							(this.state.layout ?
-								hotkey.finalKey === (this.state.layout.get(key.code) || '').toLowerCase() :
+								hotkey.finalKey.toLowerCase() === (this.state.layout.get(key.code) || '').toLowerCase() :
 								false)
 					)
 					let func: IBaseHotkeyAssignment | undefined = allFuncs && allFuncs[0]
@@ -352,7 +352,7 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 							<div className='keyboard-preview__key__label'>
 								{ thisKeyLabel }
 							</div>
-							{func && <div className='keyboard-preview__key__function-label'>
+							{(func || customLabel) && <div className='keyboard-preview__key__function-label'>
 								{ customLabel || allFuncs.map(func => func.label).join(', ') }
 							</div>}
 						</div>

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -150,6 +150,18 @@ export namespace KeyboardLayouts {
 		// Arrow Pad A
 		'ArrowLeft,ArrowDown,ArrowRight',
 	])
+
+	export function nameToPhysicalLayout(name: Names) {
+		switch (name) {
+			case Names.STANDARD_102_TKL:
+			default:
+				return STANDARD_102_TKL
+		}
+	}
+
+	export enum Names {
+		STANDARD_102_TKL = 'STANDARD_102_TKL'
+	}
 }
 
 const COMBINATOR_RE = /\s*\+\s*/

--- a/meteor/client/ui/Shelf/KeyboardPreview.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreview.tsx
@@ -88,6 +88,8 @@ export enum GenericFuncionalKeyLabels {
 	ArrowRight = '⯈'
 }
 
+const _modifierKeys = ['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'AltLeft', 'AltRight', 'MetaLeft', 'MetaRight']
+
 const COMBINATOR_RE = /\s*\+\s*/
 
 function normalizeModifier (key: string) {
@@ -254,6 +256,15 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 		})
 	}
 
+	toggleModifierOnTouch = (modifier: string) => {
+		const keyDown = {}
+		keyDown[modifier] = !this.state.keyDown[modifier]
+
+		this.setState({
+			keyDown: Object.assign({}, this.state.keyDown, keyDown)
+		})
+	}
+
 	componentDidMount() {
 		if (navigator.keyboard) {
 			navigator.keyboard.getLayoutMap().then(layout => this.setState({ layout }))
@@ -290,6 +301,8 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 						'keyboard-preview__blank-space--spring': (key.width < 0)
 					})} style={{fontSize: key.width >= 0 ? (key.width || 1) + 'em' : undefined }}></div>
 				} else {
+					let modifierKey: string | undefined
+
 					let allFuncs: IBaseHotkeyAssignment[] | undefined = this.props.hotkeys[modifiers] && this.props.hotkeys[modifiers].filter(hotkey =>
 						hotkey.finalKey === key.code.toLowerCase() ||
 							(this.state.layout ?
@@ -304,6 +317,10 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 
 					if (_isMacLike && thisKeyLabel === '❖') {
 						thisKeyLabel = '\u2318'
+					}
+
+					if (_modifierKeys.includes(key.code)) {
+						modifierKey = key.code
 					}
 
 					const thisCombo = (modifiers ?
@@ -329,8 +346,8 @@ export const KeyboardPreview = withTracker<IProps, IState, ITrackedProps>((props
 								'keyboard-preview__key--down': this.state.keyDown[key.code] === true
 							}
 						)}
-						style={{fontSize: key.width >= 0 ? (key.width || 1) + 'em' : undefined }}
-						onClick={(e) => func && this.onKeyClick(e, allFuncs || [])}
+						style={{ fontSize: key.width >= 0 ? (key.width || 1) + 'em' : undefined }}
+						onClick={(e) => func ? this.onKeyClick(e, allFuncs || []) : modifierKey && this.toggleModifierOnTouch(modifierKey) }
 					>
 							<div className='keyboard-preview__key__label'>
 								{ thisKeyLabel }

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -21,7 +21,7 @@ export const KeyboardPreviewPanel = translate()(class KeyboardPreviewPanel exten
 			return (
 				<div className='adlib-panel super-dark adlib-panel--keyboard-preview'>
 					<KeyboardPreview
-						physicalLayout={KeyboardLayouts.STANDARD_102}
+						physicalLayout={KeyboardLayouts.STANDARD_102_TKL}
 					/>
 				</div>
 			)

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -1,0 +1,32 @@
+import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { translate } from 'react-i18next'
+import * as React from 'react'
+import { mousetrapHelper } from '../../lib/mousetrapHelper'
+import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
+import { KeyboardPreview, KeyboardLayouts } from './KeyboardPreview'
+
+interface IProps {
+	visible?: boolean
+}
+
+const _isMacLike = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false
+
+export const KeyboardPreviewPanel = translate()(class KeyboardPreviewPanel extends React.Component<Translated<IProps>> {
+	constructor (props: Translated<IProps>) {
+		super(props)
+	}
+
+	render () {
+		if (this.props.visible) {
+			return (
+				<div className='adlib-panel super-dark adlib-panel--keyboard-preview'>
+					<KeyboardPreview
+						physicalLayout={KeyboardLayouts.STANDARD_102}
+					/>
+				</div>
+			)
+		} else {
+			return null
+		}
+	}
+})

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -7,6 +7,7 @@ import { KeyboardPreview, KeyboardLayouts } from './KeyboardPreview'
 
 interface IProps {
 	visible?: boolean
+	showStyleBase: ShowStyleBase
 }
 
 const _isMacLike = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? true : false
@@ -22,6 +23,7 @@ export const KeyboardPreviewPanel = translate()(class KeyboardPreviewPanel exten
 				<div className='adlib-panel super-dark adlib-panel--keyboard-preview'>
 					<KeyboardPreview
 						physicalLayout={KeyboardLayouts.STANDARD_102_TKL}
+						showStyleBase={this.props.showStyleBase}
 					/>
 				</div>
 			)

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { mousetrapHelper } from '../../lib/mousetrapHelper'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { KeyboardPreview, KeyboardLayouts } from './KeyboardPreview'
+import { Settings } from '../../../lib/Settings';
 
 interface IProps {
 	visible?: boolean
@@ -22,7 +23,7 @@ export const KeyboardPreviewPanel = translate()(class KeyboardPreviewPanel exten
 			return (
 				<div className='adlib-panel super-dark adlib-panel--keyboard-preview'>
 					<KeyboardPreview
-						physicalLayout={KeyboardLayouts.STANDARD_102_TKL}
+						physicalLayout={KeyboardLayouts.nameToPhysicalLayout(Settings.keyboardMapLayout)}
 						showStyleBase={this.props.showStyleBase}
 					/>
 				</div>

--- a/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
+++ b/meteor/client/ui/Shelf/KeyboardPreviewPanel.tsx
@@ -3,8 +3,9 @@ import { translate } from 'react-i18next'
 import * as React from 'react'
 import { mousetrapHelper } from '../../lib/mousetrapHelper'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-import { KeyboardPreview, KeyboardLayouts } from './KeyboardPreview'
-import { Settings } from '../../../lib/Settings';
+import { KeyboardPreview } from './KeyboardPreview'
+import { Settings } from '../../../lib/Settings'
+import { KeyboardLayouts } from '../../../lib/keyboardLayout'
 
 interface IProps {
 	visible?: boolean

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -28,6 +28,7 @@ import { ErrorBoundary } from '../../lib/ErrorBoundary'
 import { DashboardActionButton } from './DashboardActionButton'
 import { DashboardActionButtonGroup } from './DashboardActionButtonGroup'
 import { KeyboardPreviewPanel } from './KeyboardPreviewPanel'
+import { Settings } from '../../../lib/Settings'
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
@@ -368,9 +369,9 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 				<div className={ClassNames('rundown-view__shelf__tabs__tab', {
 					'selected': (this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS
 				})} onClick={(e) => this.switchTab(ShelfTabs.SYSTEM_HOTKEYS)} tabIndex={0}>{t('Shortcuts')}</div>
-				<div className={ClassNames('rundown-view__shelf__tabs__tab', {
+				{ Settings.showKeyboardMap ? <div className={ClassNames('rundown-view__shelf__tabs__tab', {
 					'selected': (this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD
-				})} onClick={(e) => this.switchTab(ShelfTabs.KEYBOARD)} tabIndex={0}>{t('Keyboard')}</div>
+				})} onClick={(e) => this.switchTab(ShelfTabs.KEYBOARD)} tabIndex={0}>{t('Keyboard')}</div> : null }
 			</div>
 			<div className='rundown-view__shelf__panel super-dark'>
 				<ErrorBoundary>
@@ -410,12 +411,12 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 						hotkeys={this.props.hotkeys}
 						/>
 				</ErrorBoundary>
-				<ErrorBoundary>
+				{ Settings.showKeyboardMap ? <ErrorBoundary>
 					<KeyboardPreviewPanel
 						visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD}
 						showStyleBase={this.props.showStyleBase}
 						/>
-				</ErrorBoundary>
+				</ErrorBoundary> : null }
 			</div>
 		</React.Fragment>
 	}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -25,14 +25,16 @@ import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { DashboardPanel } from './DashboardPanel'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
-import { DashboardActionButton } from './DashboardActionButton';
-import { DashboardActionButtonGroup } from './DashboardActionButtonGroup';
+import { DashboardActionButton } from './DashboardActionButton'
+import { DashboardActionButtonGroup } from './DashboardActionButtonGroup'
+import { KeyboardPreviewPanel } from './KeyboardPreviewPanel'
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
 	ADLIB_LAYOUT_FILTER = 'adlib_layout_filter',
 	GLOBAL_ADLIB = 'global_adlib',
-	SYSTEM_HOTKEYS = 'system_hotkeys'
+	SYSTEM_HOTKEYS = 'system_hotkeys',
+	KEYBOARD = 'keyboard_preview'
 }
 export interface ShelfProps {
 	isExpanded: boolean
@@ -123,8 +125,6 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 	componentDidMount () {
 		let preventDefault = (e) => {
 			e.preventDefault()
-			e.stopImmediatePropagation()
-			e.stopPropagation()
 		}
 		_.each(this.bindKeys, (k) => {
 			const method = k.global ? mousetrap.bindGlobal : mousetrap.bind
@@ -368,6 +368,9 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 				<div className={ClassNames('rundown-view__shelf__tabs__tab', {
 					'selected': (this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS
 				})} onClick={(e) => this.switchTab(ShelfTabs.SYSTEM_HOTKEYS)} tabIndex={0}>{t('Shortcuts')}</div>
+				<div className={ClassNames('rundown-view__shelf__tabs__tab', {
+					'selected': (this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD
+				})} onClick={(e) => this.switchTab(ShelfTabs.KEYBOARD)} tabIndex={0}>{t('Keyboard')}</div>
 			</div>
 			<div className='rundown-view__shelf__panel super-dark'>
 				<ErrorBoundary>
@@ -392,6 +395,9 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 				</ErrorBoundary>
 				<ErrorBoundary>
 					<HotkeyHelpPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS} {...this.props}></HotkeyHelpPanel>
+				</ErrorBoundary>
+				<ErrorBoundary>
+					<KeyboardPreviewPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD} {...this.props}></KeyboardPreviewPanel>
 				</ErrorBoundary>
 			</div>
 		</React.Fragment>

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -377,7 +377,10 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 					<AdLibPanel
 						visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.ADLIB}
 						registerHotkeys={true}
-						{...this.props}></AdLibPanel>
+						playlist={this.props.playlist}
+						showStyleBase={this.props.showStyleBase}
+						studioMode={this.props.studioMode}
+						></AdLibPanel>
 				</ErrorBoundary>
 				<ErrorBoundary>
 					{rundownLayout && rundownLayout.filters.map(panel =>
@@ -386,18 +389,32 @@ export class ShelfBase extends React.Component<Translated<ShelfProps>, IState> {
 							visible={(this.state.selectedTab || DEFAULT_TAB) === `${ShelfTabs.ADLIB_LAYOUT_FILTER}_${panel._id}`}
 							includeGlobalAdLibs={true}
 							filter={panel}
-							{...this.props}
+							playlist={this.props.playlist}
+							showStyleBase={this.props.showStyleBase}
+							studioMode={this.props.studioMode}
 							/>
 					)}
 				</ErrorBoundary>
 				<ErrorBoundary>
-					<GlobalAdLibPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.GLOBAL_ADLIB} {...this.props}></GlobalAdLibPanel>
+					<GlobalAdLibPanel
+						visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.GLOBAL_ADLIB}
+						playlist={this.props.playlist}
+						showStyleBase={this.props.showStyleBase}
+						studioMode={this.props.studioMode}
+						/>
 				</ErrorBoundary>
 				<ErrorBoundary>
-					<HotkeyHelpPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS} {...this.props}></HotkeyHelpPanel>
+					<HotkeyHelpPanel
+						visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.SYSTEM_HOTKEYS}
+						showStyleBase={this.props.showStyleBase}
+						hotkeys={this.props.hotkeys}
+						/>
 				</ErrorBoundary>
 				<ErrorBoundary>
-					<KeyboardPreviewPanel visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD} {...this.props}></KeyboardPreviewPanel>
+					<KeyboardPreviewPanel
+						visible={(this.state.selectedTab || DEFAULT_TAB) === ShelfTabs.KEYBOARD}
+						showStyleBase={this.props.showStyleBase}
+						/>
 				</ErrorBoundary>
 			</div>
 		</React.Fragment>

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
+import { KeyboardLayouts } from '../client/ui/Shelf/KeyboardPreview'
 
 /**
  * This is an object specifying installation-wide, User Interface settings.
@@ -25,6 +26,10 @@ export interface ISettings {
 	autoExpandCurrentNextSegment: boolean
 	// Disable blur border in RundownView
 	disableBlurBorder: boolean
+	// Show keyboard map in AdLib Shelf
+	showKeyboardMap: boolean
+	// Keyboard map layout (what physical layout to use for the keyboard)
+	keyboardMapLayout: KeyboardLayouts.Names
 }
 
 export let Settings: ISettings
@@ -37,7 +42,9 @@ const DEFAULT_SETTINGS: ISettings = {
 	'defaultToCollapsedSegments': false,
 	'autoExpandCurrentNextSegment': false,
 	'autoRewindLeavingSegment': false,
-	'disableBlurBorder': false
+	'disableBlurBorder': false,
+	'showKeyboardMap': true,
+	'keyboardMapLayout': KeyboardLayouts.Names.STANDARD_102_TKL
 }
 
 Settings = _.clone(DEFAULT_SETTINGS)

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -43,7 +43,7 @@ const DEFAULT_SETTINGS: ISettings = {
 	'autoExpandCurrentNextSegment': false,
 	'autoRewindLeavingSegment': false,
 	'disableBlurBorder': false,
-	'showKeyboardMap': true,
+	'showKeyboardMap': false,
 	'keyboardMapLayout': KeyboardLayouts.Names.STANDARD_102_TKL
 }
 

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
-import { KeyboardLayouts } from '../client/ui/Shelf/KeyboardPreview'
+import { KeyboardLayouts } from './keyboardLayout'
 
 /**
  * This is an object specifying installation-wide, User Interface settings.

--- a/meteor/lib/collections/ShowStyleBases.ts
+++ b/meteor/lib/collections/ShowStyleBases.ts
@@ -7,7 +7,8 @@ import {
 	IBlueprintShowStyleBase,
 	IOutputLayer,
 	ISourceLayer,
-	IBlueprintRuntimeArgumentsItem
+	IBlueprintRuntimeArgumentsItem,
+	SourceLayerType
 } from 'tv-automation-sofie-blueprints-integration'
 import { ObserveChangesForHash, createMongoCollection } from './lib'
 import { BlueprintId } from './Blueprints'
@@ -16,6 +17,8 @@ export interface HotkeyDefinition {
 	_id: string
 	key: string
 	label: string
+	platformKey?: string
+	sourceLayerType?: SourceLayerType
 }
 /** A string, identifying a ShowStyleBase */
 export type ShowStyleBaseId = ProtectedString<'ShowStyleBaseId'>

--- a/meteor/lib/keyboardLayout.ts
+++ b/meteor/lib/keyboardLayout.ts
@@ -1,0 +1,78 @@
+import * as _ from 'underscore'
+
+/**
+ * Convert an array of strings into a PhysicalLayout.
+ * See https://w3c.github.io/uievents-code/#keyboard-sections for rows and sections
+ *
+ * @param {string[]} shortForm Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
+ * 							   Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A.
+ * @returns {PhysicalLayout}
+ */
+function createPhysicalLayout(shortForm: string[]): PhysicalLayout {
+	return shortForm.map((row) => {
+		return _.compact(row.split(',').map((keyPosition) => {
+			const args = keyPosition.split(':')
+			return args[0] ? {
+				code: args[1] ? args[1] : args[0],
+				width: args[1] ?
+					args[0] === 'X' ?
+						-1 :
+						parseFloat(args[0]) :
+					3
+			} : undefined
+		}))
+	})
+}
+
+export interface KeyPositon {
+	code: string
+	width: number
+	space?: true
+}
+
+/**
+ * Order of keys is: Alphanum Row E...A, Function Section Row K, Control Pad E,
+ * Control Pad D, Arrow Pad B, Arrow Pad A, Numpad Row E...A. Not all rows need to be specified.
+ */
+export type PhysicalLayout = KeyPositon[][]
+
+export namespace KeyboardLayouts {
+	// This is a small keyboard layout: 102-Standard keybord, without the Numpad
+	export const STANDARD_102_TKL: PhysicalLayout = createPhysicalLayout([
+		// Row E
+		'Backquote,Digit1,Digit2,Digit3,Digit4,Digit5,Digit6,Digit7,Digit8,Digit9,Digit0,Minus,Equal,X:Backspace',
+		// Row D
+		'4:Tab,KeyQ,KeyW,KeyE,KeyR,KeyT,KeyY,KeyU,KeyI,KeyO,KeyP,BracketLeft,BracketRight',
+		// Row C
+		'5:CapsLock,KeyA,KeyS,KeyD,KeyF,KeyG,KeyH,KeyJ,KeyK,KeyL,Semicolon,Quote,Backslash,X:Enter',
+		// Row B
+		'3.5:ShiftLeft,IntlBackslash,KeyZ,KeyX,KeyC,KeyV,KeyB,KeyN,KeyM,Comma,Period,Slash,X:ShiftRight',
+		// Row A
+		'4:ControlLeft,MetaLeft,AltLeft,21:Space,AltRight,MetaRight,ContextMenu,X:ControlRight',
+
+		// Row K
+		'Escape,-1:$space,F1,F2,F3,F4,-1:$space,F5,F6,F7,F8,-1:$space,F9,F10,F11,F12',
+
+		// Control Pad E
+		'Insert,Home,PageUp',
+		// Control Pad D
+		'Delete,End,PageDown',
+
+		// Arrow Pad B
+		'$space,ArrowUp,$space',
+		// Arrow Pad A
+		'ArrowLeft,ArrowDown,ArrowRight',
+	])
+
+	export function nameToPhysicalLayout(name: Names) {
+		switch (name) {
+			case Names.STANDARD_102_TKL:
+			default:
+				return STANDARD_102_TKL
+		}
+	}
+
+	export enum Names {
+		STANDARD_102_TKL = 'STANDARD_102_TKL'
+	}
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduces the Keyboard shortcuts preview feature

![ezgif-2-f7142014576f](https://user-images.githubusercontent.com/3635991/77558454-3d068a80-6ebb-11ea-9df2-d0bd24bfb99b.gif)

* **What is the current behavior?** (You can also link to an open issue here)

The hotkeys assigned to various system functions and adlibs can be figured out through various elements of the user interface. Some aren't shown anywhere.

* **What is the new behavior (if this is a feature change)?**

This feature combines all of those various sources of hotkeys and shows them on a simulation of a keyboard. The customLabels feature in a ShowStyle now also allows overriding the "type" of the adlib as well as the auto-generated label. The physical key labels are detected automatically, based on user agent settings using Keyboard Map API. The keyboard preview feature is disabled by default, can be enabled through Meteor settings (`settings.json`). The keyboard layout can be also selected there. Right now, only a ten-key-less 102-key euro-style keyboard physical layout is supported.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
