### PR TITLE
chore: refactor connection status notification strings

### DIFF
--- a/meteor/client/ui/ConnectionStatusNotification.tsx
+++ b/meteor/client/ui/ConnectionStatusNotification.tsx
@@ -108,7 +108,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 	}
 
 	private getStatusText (
-		status: string,
+		status: DDP.Status,
 		reason: string | undefined,
 		retryTime: number | undefined
 	): string | React.ReactElement<HTMLElement> | null {

--- a/meteor/client/ui/ConnectionStatusNotification.tsx
+++ b/meteor/client/ui/ConnectionStatusNotification.tsx
@@ -113,17 +113,18 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 		retryTime: number | undefined
 	): string | React.ReactElement<HTMLElement> | null {
 		const t = this._translator
+		const platformName = t('Sofie Automation Server')
 		switch (status) {
 			case 'connecting':
-				return <span>{t('Connecting to the')} {t('Sofie Automation Server')}.</span>
+				return <span>{t('Connecting to the {{platformName}}', { platformName })}.</span>
 			case 'failed':
-				return <span>{t('Cannot connect to the')} {t('Sofie Automation Server:')} + reason}</span>
+				return <span>{t('Cannot connect to the {{platformName}}:', { platformName })} { reason }</span>
 			case 'waiting':
-				return <span>{t('Reconnecting to the')} {t('Sofie Automation Server')} <MomentFromNow unit='seconds'>{retryTime}</MomentFromNow></span>
+				return <span>{t('Reconnecting to the {{platformName}}', { platformName })} <MomentFromNow unit='seconds'>{retryTime}</MomentFromNow></span>
 			case 'offline':
-				return <span>{t('Your machine is offline and cannot connect to the')} {t('Sofie Automation Server')}.</span>
+				return <span>{t('Your machine is offline and cannot connect to the {{platformName}}.', { platformName })}</span>
 			case 'connected':
-				return <span>{t('Connected to the')} {t('Sofie Automation Server')}.</span>
+				return <span>{t('Connected to the {{platformName}}.', { platformName })}</span>
 		}
 		return null
 	}

--- a/meteor/client/ui/ConnectionStatusNotification.tsx
+++ b/meteor/client/ui/ConnectionStatusNotification.tsx
@@ -118,7 +118,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 			case 'connecting':
 				return <span>{t('Connecting to the {{platformName}}', { platformName })}.</span>
 			case 'failed':
-				return <span>{t('Cannot connect to the {{platformName}}:', { platformName })} { reason }</span>
+				return <span>{t('Cannot connect to the {{platformName}}: {{reason}}', { platformName, reason })}</span>
 			case 'waiting':
 				return <span>{t('Reconnecting to the {{platformName}}', { platformName })} <MomentFromNow unit='seconds'>{retryTime}</MomentFromNow></span>
 			case 'offline':


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Make connection status text generation more organized and easier to localize

* **What is the current behavior?** (You can also link to an open issue here)

There is some code-based concatenation of strings in `getStatusText` that could make translations impossible into some languages (non-VSO or -SVO word-order).

* **What is the new behavior (if this is a feature change)?**

The Sofie Automation Server string is translated and then used as an input to the connection status strings, allowing full localization.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
