### PR TITLE
fix: splits constructor initial state to avoid warnings

### DIFF
--- a/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
@@ -49,6 +49,13 @@ export class SplitsSourceRenderer extends CustomLayerItemRenderer<IProps, IState
 	leftLabel: HTMLSpanElement
 	rightLabel: HTMLSpanElement
 
+	constructor (props) {
+		super(props)
+		this.state = {
+			subItems: []
+		}
+	}
+
 	static getDerivedStateFromProps (props: IProps): IState {
 		let subItems: Array<SplitSubItem> = []
 		const splitContent = props.piece.instance.piece.content as SplitsContent | undefined


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes a warning about `SplitsSourceRenderer` that shows up in RundownView

* **What is the current behavior?** (You can also link to an open issue here)

A warning is produced when showing a rundown with splits:

```
Warning: `%s` uses `getDerivedStateFromProps` but its initial state is %s. This is not recommended. Instead, define the initial state by assigning an object to `this.state` in the constructor of `%s`. This ensures that `getDerivedStateFromProps` arguments have a consistent shape.
```

* **What is the new behavior (if this is a feature change)?**

Proper shape of the state object is ensured by the constructor of `SplitsSourceRenderer`.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
