### PR TITLE
feat: validate in- & out-point change in MOS

### DIFF
--- a/meteor/client/lib/ModalDialog.tsx
+++ b/meteor/client/lib/ModalDialog.tsx
@@ -25,6 +25,7 @@ interface IModalDialogAttributes {
 	inputs?: {[attribute: string]: ModalInput}
 	warning?: boolean
 	actions?: ModalAction[]
+	className?: string
 }
 interface ModalInput {
 	type: EditAttributeType
@@ -138,7 +139,7 @@ export class ModalDialog extends React.Component<IModalDialogAttributes> {
 										translateY: [0, 100],
 										opacity: [1, 0]
 									}, easing: 'spring', duration: 250 }} runOnMount={true}>
-										<dialog open={true} className='border-box overlay-m'>
+										<dialog open={true} className={'border-box overlay-m ' + this.props.className || ''}>
 											<div className={'flex-row ' + (this.props.warning ? 'warn' : 'info') + ' vertical-align-stretch tight-s'}>
 												<div className='flex-col c12'>
 													<h2>

--- a/meteor/client/styles/modalDialog.scss
+++ b/meteor/client/styles/modalDialog.scss
@@ -5,6 +5,11 @@
 		border: none;
 		pointer-events: auto;
 
+		.big {
+			max-width: 500px;
+			width: 100%;
+		}
+
 		p, center, .table {
 			font-weight: 300;
 		}

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -59,7 +59,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 					undefined,
 					NoticeLevel.CRITICAL,
 					<>
-						<strong>{selectedPiece.name}</strong>:
+						<strong>{selectedPiece.name}</strong>:&ensp;
 						{t('Trimming this clip has timed out. It\'s possible that the story is currently locked for writing in {{nrcsName}} and will eventually be updated. Make sure that the story is not being edited by other users.', { nrcsName: 'ENPS' })}
 					</>,
 					protectString('ClipTrimDialog')
@@ -69,7 +69,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 					undefined,
 					NoticeLevel.CRITICAL,
 					<>
-						<strong>{selectedPiece.name}</strong>:
+						<strong>{selectedPiece.name}</strong>:&ensp;
 						{t('Trimming this clip has failed due to an error: {{error}}.', { error: err.message || err.error || err })}
 					</>,
 					protectString('ClipTrimDialog')
@@ -79,7 +79,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 					undefined,
 					NoticeLevel.NOTIFICATION,
 					<>
-						<strong>{selectedPiece.name}</strong>:
+						<strong>{selectedPiece.name}</strong>:&ensp;
 						{t('Trimmed succesfully.')}
 					</>,
 					protectString('ClipTrimDialog')
@@ -93,7 +93,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 				undefined,
 				NoticeLevel.WARNING,
 				<>
-					<strong>{selectedPiece.name}</strong>: 
+					<strong>{selectedPiece.name}</strong>:&ensp;
 					{t('Trimming this clip is taking longer than expected. It\'s possible that the story is locked for writing in {{nrcsName}}.', { nrcsName: 'ENPS' })}
 				</>,
 				protectString('ClipTrimDialog')

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -10,6 +10,7 @@ import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
 import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications';
 import { protectString } from '../../../lib/lib';
+import { ClientAPI } from '../../../lib/api/client';
 
 export interface IProps {
 	playlistId: RundownPlaylistId
@@ -53,7 +54,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 		), (err, res) => {
 			clearTimeout(pendingInOutPoints)
 
-			if (typeof err === 'string' && err.match(/timed out/)) {
+			if (ClientAPI.isClientResponseError(err) && err.message && err.message.match(/timed out/)) {
 				NotificationCenter.push(new Notification(
 					undefined,
 					NoticeLevel.CRITICAL,
@@ -63,13 +64,13 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 					</>,
 					protectString('ClipTrimDialog')
 				))
-			} else if (err) {
+			} else if (ClientAPI.isClientResponseError(err) || err) {
 				NotificationCenter.push(new Notification(
 					undefined,
 					NoticeLevel.CRITICAL,
 					<>
 						<strong>{selectedPiece.name}</strong>:
-						{t('Trimming this clip has failed due to an error: {{error}}.', { error: err })}
+						{t('Trimming this clip has failed due to an error: {{error}}.', { error: err.message || err.error || err })}
 					</>,
 					protectString('ClipTrimDialog')
 				))

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -84,6 +84,8 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 					protectString('ClipTrimDialog')
 				))
 			}
+
+			return false // do not use default doUserAction failure handler
 		})
 		pendingInOutPoints = setTimeout(() => {
 			NotificationCenter.push(new Notification(

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -103,7 +103,8 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 		const { t } = this.props
 		return (
 			<ModalDialog title={t('Trim "{{name}}"', { name: this.props.selectedPiece.name })} show={true} acceptText={t('OK')} secondaryText={t('Cancel')}
-			onAccept={this.handleAccept} onDiscard={(e) => this.props.onClose && this.props.onClose()} onSecondary={(e) => this.props.onClose && this.props.onClose()}>
+			onAccept={this.handleAccept} onDiscard={(e) => this.props.onClose && this.props.onClose()} onSecondary={(e) => this.props.onClose && this.props.onClose()}
+			className='big'>
 				<ClipTrimPanel
 					studioId={this.props.studio._id}
 					playlistId={this.props.playlistId}

--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -293,7 +293,7 @@ export function executeFunctionWithCustomTimeout (deviceId: PeripheralDeviceId, 
 				// logger.debug('got reply ' + commandId)
 
 				// Cleanup before the callback to ensure it doesnt get a timeout during the callback
-				observer.stop()
+				if (observer) observer.stop()
 				PeripheralDeviceCommands.remove(cmd._id)
 				if (subscription) subscription.stop()
 				if (timeoutCheck) {
@@ -309,7 +309,7 @@ export function executeFunctionWithCustomTimeout (deviceId: PeripheralDeviceId, 
 				}
 			} else if (getCurrentTime() - (cmd.time || 0) >= timeoutTime) { // timeout
 				cb('Timeout when executing the function "' + cmd.functionName + '" on device "' + cmd.deviceId + '" ', null)
-				observer.stop()
+				if (observer) observer.stop()
 				PeripheralDeviceCommands.remove(cmd._id)
 				if (subscription) subscription.stop()
 			}

--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -261,9 +261,7 @@ export interface PiecePlaybackStartedResult {
 }
 export type PiecePlaybackStoppedResult = PiecePlaybackStartedResult
 
-
-
-export function executeFunction (deviceId: PeripheralDeviceId, cb: (err, result) => void, functionName: string, ...args: any[]) {
+export function executeFunctionWithCustomTimeout (deviceId: PeripheralDeviceId, cb: (err, result) => void, timeoutTime: number, functionName: string, ...args: any[]) {
 
 	let commandId: PeripheralDeviceCommandId = getRandomId()
 	PeripheralDeviceCommands.insert({
@@ -278,7 +276,6 @@ export function executeFunction (deviceId: PeripheralDeviceId, cb: (err, result)
 	if (Meteor.isClient) {
 		subscription = meteorSubscribe(PubSub.peripheralDeviceCommands, deviceId)
 	}
-	const timeoutTime = 3000
 	// logger.debug('command created: ' + functionName)
 	const cursor = PeripheralDeviceCommands.find({
 		_id: commandId
@@ -326,6 +323,11 @@ export function executeFunction (deviceId: PeripheralDeviceId, cb: (err, result)
 		changed: checkReply,
 	})
 	timeoutCheck = Meteor.setTimeout(checkReply, timeoutTime)
+}
+
+export function executeFunction (deviceId: PeripheralDeviceId, cb: (err, result) => void, functionName: string, ...args: any[]) {
+	const timeoutTime = 3000
+	return executeFunctionWithCustomTimeout(deviceId, cb, timeoutTime, functionName, ...args)
 }
 
 }

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -86,11 +86,16 @@ export namespace MOSDeviceActions {
 			const story = mosPayload.Body.filter(item => item.Type === 'storyItem' && item.Content.ID === piece.externalId)[0].Content
 			const timeBase = story.TimeBase || 1
 			const modifiedFields = {
-				EditorialStart: inPoint * timeBase,
+				EditorialStart: inPoint * timeBase as number | undefined,
 				EditorialDuration: duration * timeBase,
 				TimeBase: timeBase
 			}
 			Object.assign(story, modifiedFields)
+
+			// ENPS will doesn't send a 0-length EditorialStart, instead it just ommits it from the object
+			if (modifiedFields.EditorialStart === 0) {
+				modifiedFields.EditorialStart = undefined
+			}
 
 			const peripheralDevice = PeripheralDevices.findOne(rundown.peripheralDeviceId)
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -92,8 +92,9 @@ export namespace MOSDeviceActions {
 			const peripheralDevice = PeripheralDevices.findOne(rundown.peripheralDeviceId)
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')
 
-			PeripheralDeviceAPI.executeFunction(peripheralDevice._id, (err?: any) => {
+			PeripheralDeviceAPI.executeFunction(peripheralDevice._id, (err: any, response: MOS.IMOSAck) => {
 				if (err) reject(err)
+				else if (response.Status !== MOS.IMOSAckStatus.ACK) reject(response)
 				else resolve()
 			}, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story)
 		})

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -85,18 +85,22 @@ export namespace MOSDeviceActions {
 
 			const story = mosPayload.Body.filter(item => item.Type === 'storyItem' && item.Content.ID === piece.externalId)[0].Content
 			const timeBase = story.TimeBase || 1
-			story.EditorialStart = inPoint * timeBase
-			story.EditorialDuration = duration * timeBase
-			story.TimeBase = timeBase
+			const modifiedFields = {
+				EditorialStart: inPoint * timeBase,
+				EditorialDuration: duration * timeBase,
+				TimeBase: timeBase
+			}
+			Object.assign(story, modifiedFields)
 
 			const peripheralDevice = PeripheralDevices.findOne(rundown.peripheralDeviceId)
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')
 
 			PeripheralDeviceAPI.executeFunction(peripheralDevice._id, (err: any, response: MOS.IMOSAck) => {
+				console.debug(`Received response from device: ${JSON.stringify(err)}, ${JSON.stringify(response)}`)
 				if (err) reject(err)
 				else if (response.Status !== MOS.IMOSAckStatus.ACK) reject(response)
 				else resolve()
-			}, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story)
+			}, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story, modifiedFields)
 		})
 	}
 }

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -101,7 +101,7 @@ export namespace MOSDeviceActions {
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')
 
 			PeripheralDeviceAPI.executeFunctionWithCustomTimeout(peripheralDevice._id, (err: any, response: any) => {
-				console.debug(`Received response from device: ${JSON.stringify(err)}, ${JSON.stringify(response)}`)
+				// console.debug(`Received response from device: ${JSON.stringify(err)}, ${JSON.stringify(response)}`)
 				if (err) reject(err)
 				else if (response && response.mos && response.mos.roAck && response.mos.roAck.roStatus !== "OK") reject(response)
 				else resolve()

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -95,12 +95,13 @@ export namespace MOSDeviceActions {
 			const peripheralDevice = PeripheralDevices.findOne(rundown.peripheralDeviceId)
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')
 
-			PeripheralDeviceAPI.executeFunction(peripheralDevice._id, (err: any, response: MOS.IMOSAck) => {
+			PeripheralDeviceAPI.executeFunctionWithCustomTimeout(peripheralDevice._id, (err: any, response: MOS.IMOSAck) => {
 				console.debug(`Received response from device: ${JSON.stringify(err)}, ${JSON.stringify(response)}`)
 				if (err) reject(err)
 				else if (response.Status !== MOS.IMOSAckStatus.ACK) reject(response)
 				else resolve()
-			}, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story, modifiedFields)
+			// we need a very long timeout to make sure we receive notification from the device
+			}, 120 * 1000, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story, modifiedFields)
 		})
 	}
 }

--- a/meteor/server/api/ingest/mosDevice/actions.ts
+++ b/meteor/server/api/ingest/mosDevice/actions.ts
@@ -100,10 +100,10 @@ export namespace MOSDeviceActions {
 			const peripheralDevice = PeripheralDevices.findOne(rundown.peripheralDeviceId)
 			if (!peripheralDevice) throw new Meteor.Error(404, 'PeripheralDevice "' + rundown.peripheralDeviceId + '" not found')
 
-			PeripheralDeviceAPI.executeFunctionWithCustomTimeout(peripheralDevice._id, (err: any, response: MOS.IMOSAck) => {
+			PeripheralDeviceAPI.executeFunctionWithCustomTimeout(peripheralDevice._id, (err: any, response: any) => {
 				console.debug(`Received response from device: ${JSON.stringify(err)}, ${JSON.stringify(response)}`)
 				if (err) reject(err)
-				else if (response.Status !== MOS.IMOSAckStatus.ACK) reject(response)
+				else if (response && response.mos && response.mos.roAck && response.mos.roAck.roStatus !== "OK") reject(response)
 				else resolve()
 			// we need a very long timeout to make sure we receive notification from the device
 			}, 120 * 1000, 'replaceStoryItem', mosPayload.RunningOrderId, mosPayload.ID, story, modifiedFields)

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -290,6 +290,7 @@ export function pieceSetInOutPoints (rundownPlaylistId: RundownPlaylistId, partI
 	// TODO: replace this with a general, non-MOS specific method
 	return MOSDeviceActions.setPieceInOutPoint(rundown, piece, partCache.data as IngestPart, inPoint / 1000, duration / 1000) // MOS data is in seconds
 	.then(() => ClientAPI.responseSuccess(undefined))
+	.catch((error) => ClientAPI.responseError(error))
 }
 export function segmentAdLibPieceStart (rundownPlaylistId: RundownPlaylistId, partInstanceId: PartInstanceId, adlibPieceId: PieceId, queue: boolean) {
 	check(rundownPlaylistId, String)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This implements validation of trimming operations through MOS by adding a using the new mos gateway feature where item changes can be validated in later roFullStory by sending a diff of the changes.

* **What is the current behavior?** (You can also link to an open issue here)

The promise for the change of parameters in an Item resolves as soon as an ACK is received from the NRCS. Some implementations will not change the Item immediately, before sending the ACK, but at a later time, due to an internal locking and queuing mechanism.

* **What is the new behavior (if this is a feature change)?**

The change request will be validated against incoming messages and the promise will only resolve once a MOS message with the changed item is received or will be rejected once a timeout occurs.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
