### PR TITLE
feat: use ResizeObserver instead of element-resize-event

### DIFF
--- a/meteor/client/lib/resizeObserver.ts
+++ b/meteor/client/lib/resizeObserver.ts
@@ -1,0 +1,31 @@
+declare global {
+	interface IObserveOptions {
+		box: 'content-box' | 'border-box'
+	}
+
+	interface ResizeObserverEntry {
+		contentBoxSize?: DOMRectReadOnly
+		borderBoxSize?: DOMRectReadOnly
+		target?: HTMLElement
+	}
+
+	class ResizeObserver {
+		constructor(clb: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void)
+		/** Make the observer observe changes to the size of the element */
+		observe(target: HTMLElement, options?: IObserveOptions): void
+		/** Remove all observed elements */
+		disconnect(): void
+		/** Remove a single element from the observed collection */
+		unobserve(target: HTMLElement): void
+	}
+}
+
+export function onElementResize(el: HTMLElement, clb: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void) {
+	const resizeObserver = new ResizeObserver(clb)
+	resizeObserver.observe(el)
+	return resizeObserver
+}
+
+export function offElementResize(resizeObserver: ResizeObserver, el: HTMLElement) {
+	resizeObserver.unobserve(el)
+}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineZoomControls.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineZoomControls.tsx
@@ -1,8 +1,8 @@
-import * as elementResizeEvent from 'element-resize-event'
 import * as React from 'react'
 import * as ClassNames from 'classnames'
 import { getElementWidth } from '../../utils/dimensions'
 import { getElementDocumentOffset } from '../../utils/positions'
+import { onElementResize, offElementResize } from '../../lib/resizeObserver';
 
 interface IPropsHeader {
 	scrollLeft: number
@@ -30,7 +30,8 @@ export const SegmentTimelineZoomControls = class extends React.Component<IPropsH
 	clickOffsetX: number
 	clickOffsetY: number
 
-	_isTouch: boolean = false
+	private _isTouch: boolean = false
+	private resizeObserver: ResizeObserver
 
 	SMALL_WIDTH_BREAKPOINT = 25
 
@@ -77,9 +78,16 @@ export const SegmentTimelineZoomControls = class extends React.Component<IPropsH
 		}
 	}
 
-	onElementResize = () => {
+	onElementResize = (entries: ResizeObserverEntry[]) => {
+		let width: number
+		if (entries && entries[0] && entries[0].contentBoxSize) {
+			width = entries[0].contentBoxSize!.width
+		} else {
+			width = getElementWidth(this.parentElement)
+		}
+
 		this.setState({
-			width: getElementWidth(this.parentElement) || 1
+			width: width || 1
 		})
 		this.checkSmallMode()
 	}
@@ -244,14 +252,14 @@ export const SegmentTimelineZoomControls = class extends React.Component<IPropsH
 	}
 
 	componentDidMount () {
-		elementResizeEvent(this.parentElement, this.onElementResize)
+		this.resizeObserver = onElementResize(this.parentElement, this.onElementResize)
 		this.setState({
 			width: getElementWidth(this.parentElement) || 1
 		})
 	}
 
 	componentWillUnmount () {
-		elementResizeEvent.unbind(this.parentElement, this.onElementResize)
+		offElementResize(this.resizeObserver, this.parentElement)
 	}
 
 	render () {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineZoomControls.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineZoomControls.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as ClassNames from 'classnames'
 import { getElementWidth } from '../../utils/dimensions'
 import { getElementDocumentOffset } from '../../utils/positions'
-import { onElementResize, offElementResize } from '../../lib/resizeObserver';
+import { onElementResize, offElementResize } from '../../lib/resizeObserver'
 
 interface IPropsHeader {
 	scrollLeft: number

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4256,11 +4256,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.70.tgz",
       "integrity": "sha512-WYMjqCnPVS5JA+XvwEnpwucJpVi2+q9cdCFpbhxgWGsCtforFBEkuP9+nCyy/wnU/0SyLcLRIeZct9ayMGcXoQ=="
     },
-    "element-resize-event": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-3.0.3.tgz",
-      "integrity": "sha512-vhGNxT87PdZA6Ak4E0QhArwGzNcSPUwSN7n9wCFLeBlY2NNuuiwguQuQIp7P5oB65PLJ892yKcHiqz1xLWeiug=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -49,7 +49,6 @@
     "caller-module": "^1.0.1",
     "classnames": "^2.2.5",
     "core-js": "^2.5.4",
-    "element-resize-event": "^3.0.3",
     "fast-clone": "^1.5.3",
     "html-entities": "^1.2.1",
     "i18next": "^11.2.3",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Removes a dependency on `element-resize-event` and uses ResizeObserver instead.

* **What is the current behavior?** (You can also link to an open issue here)

Sofie uses an external dependency called `element-resize-event` that emulates a resize event by using an empty `iframe` and listening to it's resize events.

* **What is the new behavior (if this is a feature change)?**

Instead of using the external dependency, the `ResizeObserver` browser API is used to monitor changing display sizes of various elements. The added benefit is that `ResizeObserver` is supposed to measure the sizes of elements at a convenient time for the browser engine, so less element measurements need to be taken, thus the resize handler should execute more quickly. Also, the resize event is executed at a time where it's easier to resize other elements, so we don't have a "jank" effect on the Timeline Grid. Also, the memory load seems to be reduced, based on some quick profiling done on R19 vs this PR.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
