### PR TITLE
feat: reset in-out-duration in ClipTrimPanel

### DIFF
--- a/meteor/client/styles/tooltips.scss
+++ b/meteor/client/styles/tooltips.scss
@@ -60,7 +60,7 @@
 
 .rc-tooltip {
 	position: absolute;
-	z-index: 1070;
+	z-index: 10007;
 	display: block;
 	visibility: visible;
 	font-size: 16px;

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -28,7 +28,7 @@ export const ClipTrimDialog = translate()(class ClipTrimDialog extends React.Com
 
 		this.state = {
 			inPoint: ((this.props.selectedPiece.content as VTContent).editable as VTEditableParameters).editorialStart,
-			duration: ((this.props.selectedPiece.content as VTContent).editable as VTEditableParameters).editorialDuration
+			duration: ((this.props.selectedPiece.content as VTContent).editable as VTEditableParameters).editorialDuration,
 		}
 	}
 	handleChange = (inPoint: number, duration: number) => {

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.scss
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.scss
@@ -19,6 +19,13 @@
 		margin: 15px 15px;
 
 		.clip-trim-panel__timecode-encoders__input {
+			position: relative;
+
+			> .clip-trim-panel__timecode-encoders__input__reset {
+				position: absolute;
+				right: 0;
+				font-size: 0.8em;
+			}
 			> label {
 				text-transform: uppercase;
 				font-weight: 600;

--- a/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimPanel.tsx
@@ -12,6 +12,9 @@ import { TimecodeEncoder } from './TimecodeEncoder'
 import { Settings } from '../../../lib/Settings'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { PartId } from '../../../lib/collections/Parts'
+import { faUndo } from '@fortawesome/fontawesome-free-solid'
+import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
+const Tooltip = require('rc-tooltip')
 
 export interface IProps {
 	pieceId: PieceId
@@ -21,6 +24,8 @@ export interface IProps {
 
 	inPoint: number
 	duration: number
+	originalInPoint?: number
+	originalDuration?: number
 	onChange: (inPoint: number, duration: number) => void
 
 	invalidDuration?: boolean
@@ -180,6 +185,33 @@ export const ClipTrimPanel = translateWithTracker<IProps, IState, ITrackedProps>
 		}
 	}
 
+	onResetIn = () => {
+		const ns = this.checkInOutPoints({
+			inPoint: 0,
+			duration: this.state.duration + this.state.inPoint
+		})
+		this.setState(ns)
+		this.props.onChange(ns.inPoint / this.fps * 1000, ns.duration / this.fps * 1000)
+	}
+
+	onResetOut = () => {
+		const ns = this.checkInOutPoints({
+			inPoint: this.state.inPoint,
+			duration: this.state.maxDuration - this.state.inPoint
+		})
+		this.setState(ns)
+		this.props.onChange(ns.inPoint / this.fps * 1000, ns.duration / this.fps * 1000)
+	}
+
+	onResetAll = () => {
+		const ns = this.checkInOutPoints({
+			inPoint: 0,
+			duration: this.state.maxDuration
+		})
+		this.setState(ns)
+		this.props.onChange(ns.inPoint / this.fps * 1000, ns.duration / this.fps * 1000)
+	}
+
 	render () {
 		const { t } = this.props
 		let previewUrl: string | undefined = undefined
@@ -212,6 +244,12 @@ export const ClipTrimPanel = translateWithTracker<IProps, IState, ITrackedProps>
 				</div>
 				<div className='clip-trim-panel__timecode-encoders'>
 					<div className='clip-trim-panel__timecode-encoders__input'>
+						<Tooltip overlay={t('Remove in-trimming')} placement='top'>
+							<button className='action-btn clip-trim-panel__timecode-encoders__input__reset'
+								onClick={this.onResetIn}>
+								<FontAwesomeIcon icon={faUndo} />
+							</button>
+						</Tooltip>
 						<label>{t('In')}</label>
 						<TimecodeEncoder
 							fps={this.fps}
@@ -220,6 +258,12 @@ export const ClipTrimPanel = translateWithTracker<IProps, IState, ITrackedProps>
 						/>
 					</div>
 					<div className='clip-trim-panel__timecode-encoders__input'>
+						<Tooltip overlay={t('Remove all trimming')} placement='top'>
+							<button className='action-btn clip-trim-panel__timecode-encoders__input__reset'
+								onClick={this.onResetAll}>
+								<FontAwesomeIcon icon={faUndo} />
+							</button>
+						</Tooltip>
 						<label>{t('Duration')}</label>
 						<TimecodeEncoder
 							fps={this.fps}
@@ -229,6 +273,12 @@ export const ClipTrimPanel = translateWithTracker<IProps, IState, ITrackedProps>
 						/>
 					</div>
 					<div className='clip-trim-panel__timecode-encoders__input'>
+						<Tooltip overlay={t('Remove out-trimming')} placement='top'>
+							<button className='action-btn clip-trim-panel__timecode-encoders__input__reset'
+								onClick={this.onResetOut}>
+								<FontAwesomeIcon icon={faUndo} />
+							</button>
+						</Tooltip>
 						<label>{t('Out')}</label>
 						<TimecodeEncoder
 							fps={this.fps}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This feature adds a "reset" button feature to the Trim Clip dialog.

* **What is the current behavior?** (You can also link to an open issue here)

Removing a trim requires multiple clicks.

* **What is the new behavior (if this is a feature change)?**

There is a "reset" button next to the "In", "Out" and "Duration" inputs. Resetting "in" causes the in point to be set to 0. Resetting "out" causes the out point to be cleared. Resetting "duration" causes both to be reset.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
