### PR TITLE
fix: make the userActions.take method be a syncFunction on a rundownPlaylist

### DIFF
--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -1171,7 +1171,7 @@ export function isStringOrProtectedString<T extends ProtectedString<any>> (val: 
 	return _.isString(val)
 }
 
-export function isPromise<T extends object> (val: any): val is Promise<T> {
+export function isPromise<T extends any> (val: any): val is Promise<T> {
 	return (_.isObject(val)) && (typeof val.then === 'function') && (typeof val.catch === 'function')
 }
 // const aaa: ProtectedString<'aaaa'> = protectString('asdf')

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -1170,6 +1170,10 @@ export function unprotectObjectArray<T extends object> (obj: T[]): UnprotectedSt
 export function isStringOrProtectedString<T extends ProtectedString<any>> (val: any): val is string | T {
 	return _.isString(val)
 }
+
+export function isPromise<T extends object> (val: any): val is Promise<T> {
+	return (_.isObject(val)) && (typeof val.then === 'function') && (typeof val.catch === 'function')
+}
 // const aaa: ProtectedString<'aaaa'> = protectString('asdf')
 
 // interface Test {

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -645,7 +645,7 @@ class ServerUserActionAPI implements NewUserActionAPI {
 }
 registerClassToMeteorMethods(UserActionAPIMethods, ServerUserActionAPI, false, (methodContext: MethodContext, methodName: string, args: any[], fcn: Function) => {
 	const eventContext = args[0]
-	return ServerClientAPI.runInUserLog(methodContext, eventContext, methodName, args, () => {
+	return ServerClientAPI.runInUserLog(methodContext, eventContext, methodName, args.slice(1), () => {
 		return fcn.apply(methodContext, args)
 	})
 })

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -55,7 +55,7 @@ export function setMinimumTakeSpan (span: number) {
 */
 
 // TODO - these use the rundownSyncFunction earlier, to ensure there arent differences when we get to the syncFunction?
-export const take = syncFunction((rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientResponse<void> => {
+export const take = syncFunction(function take (rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientResponse<void> {
 	// Called by the user. Wont throw as nasty errors
 	let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -57,6 +57,8 @@ export function setMinimumTakeSpan (span: number) {
 // TODO - these use the rundownSyncFunction earlier, to ensure there arent differences when we get to the syncFunction?
 export const take = syncFunction(function take (rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientResponse<void> {
 	// Called by the user. Wont throw as nasty errors
+	const now = getCurrentTime()
+
 	let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
 	if (!playlist.active) {
@@ -71,7 +73,7 @@ export const take = syncFunction(function take (rundownPlaylistId: RundownPlayli
 			const lastStartedPlayback = _.last(currentPartInstance.part.timings.startedPlayback || []) || 0
 			const lastTake = _.last(currentPartInstance.part.timings.take || []) || 0
 			const lastChange = Math.max(lastTake, lastStartedPlayback)
-			if (getCurrentTime() - lastChange < MINIMUM_TAKE_SPAN) {
+			if (now - lastChange < MINIMUM_TAKE_SPAN) {
 				logger.debug(`Time since last take is shorter than ${MINIMUM_TAKE_SPAN} for ${currentPartInstance._id}: ${getCurrentTime() - lastStartedPlayback}`)
 				logger.debug(`lastStartedPlayback: ${lastStartedPlayback}, getCurrentTime(): ${getCurrentTime()}`)
 				return ClientAPI.responseError(`Ignoring TAKES that are too quick after eachother (${MINIMUM_TAKE_SPAN} ms)`)

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -37,6 +37,7 @@ import { PieceInstances, PieceInstanceId } from '../../lib/collections/PieceInst
 import { MediaWorkFlowId } from '../../lib/collections/MediaWorkFlows'
 import { MethodContext } from '../../lib/api/methods'
 import { ServerClientAPI } from './client'
+import { syncFunctionIgnore, syncFunction } from '../codeControl'
 
 let MINIMUM_TAKE_SPAN = 1000
 export function setMinimumTakeSpan (span: number) {
@@ -54,9 +55,8 @@ export function setMinimumTakeSpan (span: number) {
 */
 
 // TODO - these use the rundownSyncFunction earlier, to ensure there arent differences when we get to the syncFunction?
-export function take (rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientResponse<void> {
+export const take = syncFunction((rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientResponse<void> => {
 	// Called by the user. Wont throw as nasty errors
-
 	let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
 	if (!playlist.active) {
@@ -82,7 +82,7 @@ export function take (rundownPlaylistId: RundownPlaylistId): ClientAPI.ClientRes
 		}
 	}
 	return ServerPlayoutAPI.takeNextPart(playlist._id)
-}
+}, 'userActionsTake$0')
 export function setNext (rundownPlaylistId: RundownPlaylistId, nextPartId: PartId | null, setManually?: boolean, timeOffset?: number | undefined): ClientAPI.ClientResponse<void> {
 	check(rundownPlaylistId, String)
 	if (nextPartId) check(nextPartId, String)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes a bug with the `MINIMUM_TAKE_SPAN` protection.

* **What is the current behavior?** (You can also link to an open issue here)

There is a short window of opportunity where a slow response from the DB at the right moment, when switching between two non-autonext parts, can cause a double-take to happen.

* **What is the new behavior (if this is a feature change)?**

The userActions take method is now a `syncFunction`, so that only a single `take` userAction can be executed at any time for a rundownPlaylist. This should ensure that the already existing `MINIMUM_TAKE_SPAN` check can work correctly.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
