### PR TITLE
fix: infinites spanning an autonext should take the end from the next part

### DIFF
--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -502,6 +502,15 @@ function buildTimelineObjsForRundown (playoutData: RundownPlaylistPlayoutData, b
 		}
 		currentPartGroup = createPartGroup(currentPartInstance, currentPartEnable)
 
+		const nextPartInfinites: { [infiniteId: string]: PieceInstance | undefined } = {}
+		if (currentPartInstance.part.autoNext && nextPartInstance) {
+			nextPartInstance.getAllPieceInstances().forEach(piece => {
+				if (piece.piece.infiniteId) {
+					nextPartInfinites[unprotectString(piece.piece.infiniteId)] = piece
+				}
+			})
+		}
+
 		// any continued infinite lines need to skip the group, as they need a different start trigger
 		for (let piece of currentInfinitePieces) {
 			const infiniteGroup = createPartGroup(currentPartInstance, { duration: piece.piece.enable.duration || undefined })
@@ -532,6 +541,14 @@ function buildTimelineObjsForRundown (playoutData: RundownPlaylistPlayoutData, b
 							infiniteGroup.enable.duration = offsetTimelineEnableExpression(piece.piece.userDuration.duration, previousPartsDuration)
 						}
 					}
+				}
+
+				// If this infinite piece continues to the next part, and has a duration then we should respect that in case it is really close to the take
+				const hasDurationOrEnd = (enable: TSR.Timeline.TimelineEnable) => enable.duration !== undefined || enable.end !== undefined
+				const infiniteInNextPart = nextPartInfinites[unprotectString(piece.piece.infiniteId)]
+				if (infiniteInNextPart && !hasDurationOrEnd(infiniteGroup.enable) && hasDurationOrEnd(infiniteInNextPart.piece.enable)) {
+					infiniteGroup.enable.end = infiniteInNextPart.piece.enable.end
+					infiniteGroup.enable.duration = infiniteInNextPart.piece.enable.duration
 				}
 			}
 


### PR DESCRIPTION
This fixes the case where an infinite is running in part A, part B overrides it briefly at the start.
During an autonext, the layer would go to the override, then back to the original infinite until the new timeline had been resolved and applied.

To fix this, we look ahead at the next part to see if the infinite is there and with and end time. If so and we are going to autonext, then we use that end time for the current part.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
