### PR TITLE
hotfix: prompter

### DIFF
--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -385,16 +385,23 @@ interface IPrompterProps {
 	config: PrompterConfig
 }
 interface IPrompterTrackedProps {
-	prompterData: PrompterData
+	prompterData: PrompterData | undefined
 }
 
 type ScrollAnchor = [number, string] | null
 
 export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTrackedProps>((props: IPrompterProps) => {
-	const prompterData = PrompterAPI.getPrompterData(props.rundownPlaylistId)
+	const playlist = RundownPlaylists.findOne(props.rundownPlaylistId)
 
-	return {
-		prompterData
+	if (!playlist) {
+		const prompterData = PrompterAPI.getPrompterData(props.rundownPlaylistId)
+		return {
+			prompterData
+		}
+	} else {
+		return {
+			prompterData: undefined
+		}
 	}
 })(class Prompter extends MeteorReactComponent<Translated<IPrompterProps & IPrompterTrackedProps>, {}> {
 	private _debounceUpdate: NodeJS.Timer

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -393,7 +393,7 @@ type ScrollAnchor = [number, string] | null
 export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTrackedProps>((props: IPrompterProps) => {
 	const playlist = RundownPlaylists.findOne(props.rundownPlaylistId)
 
-	if (!playlist) {
+	if (playlist) {
 		const prompterData = PrompterAPI.getPrompterData(props.rundownPlaylistId)
 		return {
 			prompterData


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix for a crash in the Prompter component that sometimes would happen since R19.

* **What is the current behavior?** (You can also link to an open issue here)

Certain conditions can cause the Prompter to crash, because an underlying method would throw an exception if a rundown playlist could not be found. Specific, reproduceable sequence of events was not determined, but a static code analysis was enough to pinpoint the issue.

* **What is the new behavior (if this is a feature change)?**

The component doesn't crash if a Rundown Playlist cannot be found.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
