### PR TITLE
fix: some pieces starting at non-zero time being forced to zero-time

### DIFF
--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -37,6 +37,7 @@ export function postProcessPieces (innerContext: RundownContext, pieces: IBluepr
 
 		if (!piece._id) piece._id = protectString(innerContext.getHashId(`${blueprintId}_${partId}_piece_${i++}`))
 		if (!piece.externalId && !piece.isTransition) throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" externalId not set for piece in ${partId}! ("${innerContext.unhashId(unprotectString(piece._id))}")`)
+		if (piece.enable.start === 'now')  throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" piece cannot have a start of 'now' in ${partId}! ("${innerContext.unhashId(unprotectString(piece._id))}")`)
 
 		if (partsUniqueIds[unprotectString(piece._id)]) throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" ids of pieces must be unique! ("${innerContext.unhashId(unprotectString(piece._id))}")`)
 		partsUniqueIds[unprotectString(piece._id)] = true
@@ -46,6 +47,7 @@ export function postProcessPieces (innerContext: RundownContext, pieces: IBluepr
 				const obj = convertTimelineObject(o)
 
 				if (!obj.id) obj.id = innerContext.getHashId(piece._id + '_' + (i++))
+				if (obj.enable.start === 'now')  throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" timelineObjs cannot have a start of 'now'! ("${innerContext.unhashId(unprotectString(piece._id))}")`)
 
 				if (timelineUniqueIds[obj.id]) throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" ids of timelineObjs must be unique! ("${innerContext.unhashId(obj.id)}")`)
 				timelineUniqueIds[obj.id] = true
@@ -82,6 +84,7 @@ export function postProcessAdLibPieces (innerContext: RundownContext, adLibPiece
 				const obj = convertTimelineObject(o)
 
 				if (!obj.id) obj.id = innerContext.getHashId(piece._id + '_adlib_' + (i++))
+				if (obj.enable.start === 'now')  throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" timelineObjs cannot have a start of 'now'! ("${innerContext.unhashId(unprotectString(obj._id))}")`)
 
 				if (timelineUniqueIds[obj.id]) throw new Meteor.Error(400, `Error in blueprint "${blueprintId}" ids of timelineObjs must be unique! ("${innerContext.unhashId(obj.id)}")`)
 				timelineUniqueIds[obj.id] = true
@@ -100,6 +103,7 @@ export function postProcessStudioBaselineObjects (studio: Studio, objs: TSR.TSRT
 		const obj = convertTimelineObject(baseObj)
 
 		if (!obj.id) obj.id = getHash('baseline_' + (i++))
+		if (obj.enable.start === 'now')  throw new Meteor.Error(400, `Error in blueprint "${studio.blueprintId}" timelineObjs cannot have a start of 'now'!`)
 
 		if (timelineUniqueIds[obj.id]) throw new Meteor.Error(400, `Error in blueprint "${studio.blueprintId}": ids of timelineObjs must be unique! ("${obj.id}")`)
 		timelineUniqueIds[obj.id] = true
@@ -124,6 +128,7 @@ export function postProcessRundownBaselineItems (innerContext: RundownContext, b
 		const obj: TimelineObjGeneric = convertTimelineObject(o)
 
 		if (!obj.id) obj.id = innerContext.getHashId('baseline_' + (i++))
+		if (obj.enable.start === 'now')  throw new Meteor.Error(400, `Error in baseline blueprint: timelineObjs cannot have a start of 'now'! ("${innerContext.unhashId(unprotectString(obj._id))}")`)
 
 		if (timelineUniqueIds[obj.id]) throw new Meteor.Error(400, `Error in baseline blueprint: ids of timelineObjs must be unique! ("${innerContext.unhashId(obj.id)}")`)
 		timelineUniqueIds[obj.id] = true

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -296,8 +296,12 @@ export function getResolvedPiecesFromFullTimeline (playoutData: RundownPlaylistP
 	const pieceInststanceMap = normalizeArray(pieceInstances, '_id')
 
 	objs.forEach(o => {
-		if (o.enable.start === 'now') {
-			o.enable.start = now
+		if (o.enable.start === 'now' && o.isGroup) {
+			if ((o as any).isPartGroup) {
+				o.enable.start = now
+			} else if (o.metaData && o.metaData.pieceId) {
+				o.enable.start = 0
+			}
 		}
 	})
 

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -742,17 +742,6 @@ function transformPartIntoTimeline (
 				}
 			}
 
-			if (pieceInstance.piece.infiniteId && pieceInstance.piece.infiniteId === pieceInstance.piece._id) {
-				if (
-					pieceInstance.piece.enable.start &&
-					isNumber(pieceInstance.piece.enable.start) &&
-					pieceInstance.piece.enable.start > 0 &&
-					pieceInstance.piece.startedPlayback
-				) {
-					pieceInstance.piece.enable.start = 0
-				}
-			}
-
 			// create a piece group for the pieces and then place all of them there
 			const pieceGroup = createPieceGroup(pieceInstance, partGroup)
 			timelineObjs.push(pieceGroup)


### PR DESCRIPTION
This fixes a bug introduced in the TV2 contributions. They have fixed this in a different way in their fork, but the changes did not make it into the original batch of PRs.

This was causing some adlib pieces to think they start at 0 within the part, which causes the timings in them to be off. 

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
