### PR TITLE
Fix: timeout errors

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -476,11 +476,7 @@ export namespace PeripheralDeviceAPI {
 				} else if (getCurrentTime() - (cmd.time || 0) >= timeoutTime) {
 					// timeout
 					cb(
-						'Timeout when executing the function "' +
-							cmd.functionName +
-							'" on device "' +
-							cmd.deviceId +
-							'" ',
+						`Timeout after ${timeoutTime} ms when executing the function "${cmd.functionName}" on device "${cmd.deviceId}"`,
 						null
 					)
 					if (observer) observer.stop()

--- a/meteor/server/cronjobs.ts
+++ b/meteor/server/cronjobs.ts
@@ -104,7 +104,7 @@ Meteor.startup(() => {
 
 						ps.push(
 							new Promise((resolve, reject) => {
-								PeripheralDeviceAPI.executeFunction(
+								PeripheralDeviceAPI.executeFunctionWithCustomTimeout(
 									subDevice._id,
 									(err) => {
 										if (err) {
@@ -127,6 +127,7 @@ Meteor.startup(() => {
 											resolve()
 										}
 									},
+									10000,
 									'restartCasparCG'
 								)
 							})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Bug fix:
There are a lot of timeouts on the restartCasparCG cronjobs currently. this PR aims to fix that issue by increasing the timeout from the default 1s to 10s.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
