### PR TITLE
Require syncfunctions to be named

### DIFF
--- a/meteor/server/codeControl.ts
+++ b/meteor/server/codeControl.ts
@@ -62,6 +62,12 @@ function getFunctionName<T extends Function> (parent: Function, fcn: T): string 
  */
 export function syncFunction<T extends Function> (fcn: T, id0?: string, timeout: number = 10000, priority: number = 1): T {
 	let id1 = Random.id()
+	if (!Meteor.isProduction) {
+		// Make a check: require function names
+		if (!fcn.name) {
+			throw new Meteor.Error(500, `Self-test error: syncFunction name not set.`)
+		}
+	}
 	return syncFunctionInner(id1, fcn, id0, timeout, priority)
 }
 function syncFunctionInner<T extends Function> (id1: string, fcn: T, id0?: string, timeout: number = 10000, priority: number = 1): T {


### PR DESCRIPTION
(This is a feature suggestion to-be-discussed)

Idea:
Currently most functions we make into syncFunctions are anonymous arrow-functions.
This is an issue when we log for example timeout errors (where we use fcn.name), because it renders the log message unusable.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
