### PR TITLE
Fix/ab lookahead

### DIFF
--- a/meteor/client/lib/utilComponents.tsx
+++ b/meteor/client/lib/utilComponents.tsx
@@ -4,7 +4,8 @@ import * as _ from 'underscore'
 export function makeTableOfObject (o: any) {
 	return (
 		<table><tbody>
-			{_.map(o, (val, key) => {
+			{_.map(_.keys(o), (key) => {
+				const val = o[key]
 
 				let content: any = null
 				if (_.isObject(val)) {

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -13114,13 +13114,13 @@
       "resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-3.20.0.tgz",
       "integrity": "sha512-GNYQ7NYA826nZa/Lii30jNlmUN32OPfOds54J0yk+JNJfsxVK71mBOV7UTJy5I9snRnx76NpWRP1JB6cjRxW8g==",
       "requires": {
-        "tslib": "1.11.2"
+        "tslib": "1.13.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
       }
     },
@@ -13417,20 +13417,20 @@
       }
     },
     "tv-automation-sofie-blueprints-integration": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.11.0.tgz",
-      "integrity": "sha512-Car3wEr1LKrbyWWvJBYiT0YpnVrXMiyvyofrEap28kGvhtoLhNN5UxlBPT8Hb6Vxpir6YIyYcStM3xk89wdaDQ==",
+      "version": "1.12.0-nightly-20200522-143610-38735c5.0",
+      "resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-1.12.0-nightly-20200522-143610-38735c5.0.tgz",
+      "integrity": "sha512-CnMzevmg2rzcKsaVe77W6wxM3/n9dp78cLb8fZ8Q3pRCzmyePjqDyJY/uivXlLByEThE8eWa5SBKMfZEJNtBWw==",
       "requires": {
         "moment": "2.22.2",
         "timeline-state-resolver-types": "3.20.0",
-        "tslib": "1.11.2",
+        "tslib": "1.13.0",
         "underscore": "1.9.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
       }
     },

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -83,7 +83,7 @@
     "soap": "^0.24.0",
     "superfly-timeline": "^7.3.1",
     "timecode": "0.0.4",
-    "tv-automation-sofie-blueprints-integration": "1.11.0",
+    "tv-automation-sofie-blueprints-integration": "1.12.0-nightly-20200522-143610-38735c5.0",
     "underscore": "^1.8.3",
     "velocity-animate": "^1.5.1",
     "velocity-react": "^1.3.3",

--- a/meteor/server/api/blueprints/context.ts
+++ b/meteor/server/api/blueprints/context.ts
@@ -1,6 +1,6 @@
 import * as _ from 'underscore'
 import { Meteor } from 'meteor/meteor'
-import { getHash, formatDateAsTimecode, formatDurationAsTimecode, unprotectString, unprotectObject, unprotectObjectArray, protectString } from '../../../lib/lib'
+import { getHash, formatDateAsTimecode, formatDurationAsTimecode, unprotectString, unprotectObject, unprotectObjectArray, protectString, getCurrentTime } from '../../../lib/lib'
 import { DBPart, PartId } from '../../../lib/collections/Parts'
 import { check, Match } from 'meteor/check'
 import { logger } from '../../../lib/logging'
@@ -249,7 +249,7 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 
 /** Rundown */
 
-export class RundownContext extends ShowStyleContext implements IRundownContext {
+export class RundownContext extends ShowStyleContext implements IRundownContext, IEventContext {
 	readonly rundownId: string
 	readonly rundown: Readonly<IBlueprintRundownDB>
 	readonly _rundown: Rundown
@@ -262,6 +262,10 @@ export class RundownContext extends ShowStyleContext implements IRundownContext 
 		this.rundown = unprotectObject(rundown)
 		this._rundown = rundown
 		this.playlistId = rundown.playlistId
+	}
+	
+	getCurrentTime(): number {
+		return getCurrentTime()
 	}
 }
 
@@ -295,6 +299,10 @@ export class SegmentContext extends RundownContext implements ISegmentContext {
 
 export class EventContext extends CommonContext implements IEventContext {
 	// TDB: Certain actions that can be triggered in Core by the Blueprint
+
+	getCurrentTime(): number {
+		return getCurrentTime()
+	}
 }
 
 export class PartEventContext extends RundownContext implements IPartEventContext {
@@ -304,6 +312,10 @@ export class PartEventContext extends RundownContext implements IPartEventContex
 		super(rundown, new NotesContext(rundown.name, `rundownId=${rundown._id},partInstanceId=${partInstance._id}`, false), studio)
 
 		this.part = unprotectPartInstance(partInstance)
+	}
+	
+	getCurrentTime(): number {
+		return getCurrentTime()
 	}
 }
 

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -23,7 +23,9 @@ export function getLookeaheadObjects (playoutData: RundownPlaylistPlayoutData, s
 		obj.priority = priority
 		obj.enable = enable
 		obj.isLookahead = true
-		delete obj.keyframes
+		if (obj.keyframes) {
+			obj.keyframes = obj.keyframes.filter(kf => (kf as any).preserveForLookahead)
+		}
 		delete obj.inGroup // force it to be cleared
 
 		if (mapping.lookahead === LookaheadMode.PRELOAD) {

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -24,7 +24,7 @@ export function getLookeaheadObjects (playoutData: RundownPlaylistPlayoutData, s
 		obj.enable = enable
 		obj.isLookahead = true
 		if (obj.keyframes) {
-			obj.keyframes = obj.keyframes.filter(kf => (kf as any).preserveForLookahead)
+			obj.keyframes = obj.keyframes.filter(kf => kf.preserveForLookahead)
 		}
 		delete obj.inGroup // force it to be cleared
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Some fixes useful for ab-playback

* **What is the current behavior?** (You can also link to an open issue here)
Lookahead is not working for ab-playback, due to it being done via keyframes which are being stripped off by core.

* **What is the new behavior (if this is a feature change)?**
Keyframes now have a property to say that they should be kept when run through lookahead.

Also a getCurrentTime method is added to the EventContext. This lets ab-playback know what the current time is and so it can make more intelligent decisions based on whether something is already on air or not.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
