### PR TITLE
feat: additional NB keyboard aliases

### DIFF
--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -136,7 +136,7 @@ mousetrap.addKeycodes({
 	90220: '\\', // on ANSI-based keyboards, this is the key with single quote
 	91220: '|', // this key is not present on ANSI-based keyboards
 
-	90187: 'nbPlus', // this is also listed as 'add' below
+	187: 'nbPlus', // this is also listed as 'add' below
 	219: 'nbBackslash',
 	221: 'å',
 	186: '¨',
@@ -161,6 +161,6 @@ mousetrap.addKeycodes({
 	109: 'numSub',
 	110: 'numDot',
 	111: 'numDiv',
-	187: 'add',
+	// 187: 'add',
 	188: 'comma'
 })

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -143,7 +143,7 @@ mousetrap.addKeycodes({
 	192: 'ø',
 	222: 'æ',
 	191: '\'',
-	190: '.',
+	190: 'nbPeriod',
 	189: 'nbMinus',
 
 	96: 'num0',

--- a/meteor/client/lib/mousetrapHelper.ts
+++ b/meteor/client/lib/mousetrapHelper.ts
@@ -15,7 +15,7 @@ export namespace mousetrapHelper {
 		[key: string]: IWrappedCallback[]
 	} = {}
 
-	function handleKey (keys: string, e: ExtendedKeyboardEvent) {
+	function handleKey(keys: string, e: ExtendedKeyboardEvent) {
 		if (_boundHotkeys[keys] === undefined) {
 			return
 		}
@@ -28,7 +28,7 @@ export namespace mousetrapHelper {
 		})
 	}
 
-	export function bindGlobal (keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
+	export function bindGlobal(keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
 		let index = keys
 		if (action) index = keys + '_' + action
 		if (
@@ -52,7 +52,7 @@ export namespace mousetrapHelper {
 		})
 	}
 
-	export function bind (keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
+	export function bind(keys: string, callback: (e: Event) => void, action?: string, tag?: string, allowInModal?: boolean) {
 		let index = keys
 		if (action) index = keys + '_' + action
 		if (_boundHotkeys[index] === undefined) {
@@ -71,7 +71,7 @@ export namespace mousetrapHelper {
 		})
 	}
 
-	export function unbindAll (keys: string[], action?: string, tag?: string) {
+	export function unbindAll(keys: string[], action?: string, tag?: string) {
 		keys.forEach(key => {
 			if (!tag) {
 				let index = key
@@ -85,7 +85,7 @@ export namespace mousetrapHelper {
 		})
 	}
 
-	export function unbind (keys: string, callbackOrTag: ((e: Event) => void) | string, action?: string) {
+	export function unbind(keys: string, callbackOrTag: ((e: Event) => void) | string, action?: string) {
 		let index = keys
 		if (action) index = keys + '_' + action
 
@@ -110,7 +110,7 @@ export namespace mousetrapHelper {
 		}
 	}
 
-	export function shortcutLabel (hotkey: string, isMacLike: boolean = false): string {
+	export function shortcutLabel(hotkey: string, isMacLike: boolean = false): string {
 		if (isMacLike) {
 			hotkey = hotkey.replace(/mod/i, '\u2318')
 		} else {
@@ -135,6 +135,16 @@ mousetrap.addKeycodes({
 	// but can still be used, as they will generally map onto .which === 220
 	90220: '\\', // on ANSI-based keyboards, this is the key with single quote
 	91220: '|', // this key is not present on ANSI-based keyboards
+
+	90187: 'nbPlus', // this is also listed as 'add' below
+	219: 'nbBackslash',
+	221: 'å',
+	186: '¨',
+	192: 'ø',
+	222: 'æ',
+	191: '\'',
+	190: '.',
+	189: 'nbMinus',
 
 	96: 'num0',
 	97: 'num1',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds additional key aliases for NOB keyboard. Some keys are prefixed with `nb` to make it easier.

* **What is the new behavior (if this is a feature change)?**

New keys aliases:

* `nbPlus` - this is the `+` key that follows the number keys in the main keyboard area
* `nbBackslash` - this is the `\` key, followint the `+` and the number keys 
* `å` - this is the key next to the `P` key
* `¨` - this is the key next to the `å` key, in the same row as the `P` key
* `ø` - this is the key next to the `L` key
* `æ` - this is the key next to the `ø` key, in the same row as the `L` key
* `'` - this is the key next to the `æ` key, in the same row as the `L` key
* `nbPeriod` - this (`.`) is the key between the comma (`,`) and the minus (`-`)
* `nbMinus` - this is the key after the period (`.`) key

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
