### PR TITLE
feat: show rundown name in document title

### DIFF
--- a/meteor/client/lib/documentTitle.ts
+++ b/meteor/client/lib/documentTitle.ts
@@ -1,0 +1,3 @@
+import { ReactiveVar } from 'meteor/reactive-var'
+
+export const documentTitle = new ReactiveVar<null | string>(null)

--- a/meteor/client/ui/ConnectionStatusNotification.tsx
+++ b/meteor/client/ui/ConnectionStatusNotification.tsx
@@ -14,14 +14,15 @@ import { NotificationCenterPopUps } from '../lib/notifications/NotificationCente
 import { PubSub } from '../../lib/api/pubsub'
 import { CoreSystem, ICoreSystem, ServiceMessage, Criticality } from '../../lib/collections/CoreSystem'
 import { notDeepEqual } from 'assert'
+import { documentTitle } from '../lib/documentTitle'
 
 export class ConnectionStatusNotifier extends WithManagedTracker {
 	private _notificationList: NotificationList
 	private _notifier: NotifierHandle
 	private _translator: TranslationFunction
-	private _serviceMessageRegistry: {[index: string]: ServiceMessage}
+	private _serviceMessageRegistry: { [index: string]: ServiceMessage }
 
-	constructor (t: TranslationFunction) {
+	constructor(t: TranslationFunction) {
 		super()
 
 		this.subscribe(PubSub.coreSystem, null)
@@ -53,7 +54,9 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 				}
 			}
 
-			document.title = 'Sofie' + (cs && cs.name ? ' - ' + cs.name : '')
+			const doc = documentTitle.get()
+
+			document.title = (doc === null ? '' : `${doc} - `) + 'Sofie' + (cs && cs.name ? ` - ${cs.name}` : '')
 
 			let systemNotification: Notification | undefined = createSystemNotification(cs)
 			let newNotification = this.createNewStatusNotification(meteorStatus)
@@ -76,13 +79,13 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 		})
 	}
 
-	stop () {
+	stop() {
 		super.stop()
 
 		this._notifier.stop()
 	}
 
-	private getNoticeLevel (status: string) {
+	private getNoticeLevel(status: string) {
 		switch (status) {
 			case 'connected':
 				return NoticeLevel.NOTIFICATION
@@ -93,7 +96,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 		}
 	}
 
-	private getNoticeLevelForCriticality (criticality: Criticality) {
+	private getNoticeLevelForCriticality(criticality: Criticality) {
 		switch (criticality) {
 			case Criticality.CRITICAL:
 				return NoticeLevel.CRITICAL
@@ -107,7 +110,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 		}
 	}
 
-	private getStatusText (
+	private getStatusText(
 		status: DDP.Status,
 		reason: string | undefined,
 		retryTime: number | undefined
@@ -129,7 +132,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 		return null
 	}
 
-	private createNewStatusNotification (meteorStatus: DDP.DDPStatus): Notification {
+	private createNewStatusNotification(meteorStatus: DDP.DDPStatus): Notification {
 		const { status, reason, retryTime, connected } = meteorStatus
 		const t = this._translator
 		const notification = new Notification(
@@ -140,20 +143,20 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 			Date.now(),
 			!connected,
 			(status === 'failed' || status === 'waiting' || status === 'offline')
-			? [
-				{
-					label: t('Reconnect now'),
-					type: 'primary',
-					icon: 'icon-retry',
-					action: () => { Meteor.reconnect() }
-				}
-			] : undefined,
+				? [
+					{
+						label: t('Reconnect now'),
+						type: 'primary',
+						icon: 'icon-retry',
+						action: () => { Meteor.reconnect() }
+					}
+				] : undefined,
 			-100)
 
 		return notification
 	}
 
-	private updateServiceMessages (serviceMessages: {[index: string]: ServiceMessage}): void {
+	private updateServiceMessages(serviceMessages: { [index: string]: ServiceMessage }): void {
 		const systemMessageIds = Object.keys(serviceMessages)
 
 		// remove from internal list where ids not in active list
@@ -188,7 +191,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 
 	}
 
-	private createNotificationFromServiceMessage (message: ServiceMessage): Notification {
+	private createNotificationFromServiceMessage(message: ServiceMessage): Notification {
 		return new Notification(
 			message.id,
 			this.getNoticeLevelForCriticality(message.criticality),
@@ -196,11 +199,11 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 			message.sender || '(service message)',
 			message.timestamp.getMilliseconds(),
 			true
-			)
+		)
 	}
 }
 
-function createSystemNotification (cs: ICoreSystem | undefined): Notification | undefined {
+function createSystemNotification(cs: ICoreSystem | undefined): Notification | undefined {
 	if (cs && cs.systemInfo && cs.systemInfo.enabled) {
 		return new Notification(
 			Random.id(),
@@ -226,20 +229,20 @@ interface IState {
 export const ConnectionStatusNotification = translate()(class ConnectionStatusNotification extends React.Component<Translated<IProps>, IState> {
 	private notifier: ConnectionStatusNotifier
 
-	constructor (props: Translated<IProps>) {
+	constructor(props: Translated<IProps>) {
 		super(props)
 
 	}
 
-	componentDidMount () {
+	componentDidMount() {
 		this.notifier = new ConnectionStatusNotifier(this.props.t)
 	}
 
-	componentWillUnmount () {
+	componentWillUnmount() {
 		this.notifier.stop()
 	}
 
-	render () {
+	render() {
 		// this.props.connected
 		return <NotificationCenterPopUps />
 	}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -70,6 +70,7 @@ import { Settings } from '../../lib/Settings'
 import { MeteorCall } from '../../lib/api/methods'
 import { PointerLockCursor } from '../lib/PointerLockCursor'
 import { AdLibPieceUi } from './Shelf/AdLibPanel'
+import { documentTitle } from '../lib/documentTitle'
 
 export const MAGIC_TIME_SCALE_FACTOR = 0.03
 
@@ -1348,6 +1349,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 			window.addEventListener(RundownViewEvents.goToLiveSegment, this.onGoToLiveSegment)
 			window.addEventListener(RundownViewEvents.goToTop, this.onGoToTop)
+
+			if (this.props.playlist) {
+				documentTitle.set(this.props.playlist.name)
+			}
+
+			const themeColor = document.head.querySelector('meta[name="theme-color"]')
+			if (themeColor) {
+				themeColor.setAttribute('data-content', themeColor.getAttribute('content') || '')
+				themeColor.setAttribute('content', '#000000')
+			}
 		}
 
 		componentDidUpdate(prevProps: IProps & ITrackedProps, prevState: IState) {
@@ -1398,6 +1409,15 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			if (typeof this.props.showStyleBase !== typeof prevProps.showStyleBase ||
 				this.props.showStyleBase && this.props.showStyleBase.runtimeArguments) {
 				this.refreshHotkeys()
+			}
+
+			if (typeof this.props.playlist !== typeof prevProps.playlist ||
+				(this.props.playlist || { name: '' }).name !== (prevProps.playlist || { name: '' }).name) {
+				if (this.props.playlist && this.props.playlist.name) {
+					documentTitle.set(this.props.playlist.name)
+				} else {
+					documentTitle.set(null)
+				}
 			}
 		}
 
@@ -1499,6 +1519,13 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					mousetrapHelper.unbind(k.key, 'RuntimeArguments', 'keydown')
 				}
 			})
+
+			documentTitle.set(null)
+
+			const themeColor = document.head.querySelector('meta[name="theme-color"]')
+			if (themeColor) {
+				themeColor.setAttribute('content', themeColor.getAttribute('data-content') || '#ffffff')
+			}
 
 			window.removeEventListener(RundownViewEvents.goToLiveSegment, this.onGoToLiveSegment)
 			window.removeEventListener(RundownViewEvents.goToTop, this.onGoToTop)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature to set the title of the tab/window to the name of the currently open rundown. Also the theme-color is changed for RundownViews to black.

* **What is the current behavior?** (You can also link to an open issue here)

The title of the tab/window is the same for all Sofie views.

* **Other information**:

With the current setup, if multiple views of Sofie are open, it's impossible to differentiate between them. With this change, it's now clear, at least for the RundownViews, which Rundown is open in every window. I didn't make the other views change the title, because that's a bit more complicated due to their general tree structure, so a more informed change is needed there.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
