### PR TITLE
chore: fix lint-staged on Windows

### DIFF
--- a/meteor/.prettierignore
+++ b/meteor/.prettierignore
@@ -1,2 +1,4 @@
 package*.json
 CHANGELOG*.md
+*.snap
+*.xml

--- a/meteor/lint-staged.config.js
+++ b/meteor/lint-staged.config.js
@@ -1,0 +1,18 @@
+const jsCssJsonMdScssCommands = ['prettier --write', 'git add']
+const tsTsxCommands = ['npm run lintfix --', 'git add']
+
+function chunkWrapAndRun(commands, fileNames) {
+	const fileCount = fileNames.length
+	let result = []
+	for (var i = 0; i < fileCount; i = i + 10) {
+		const chunk = fileNames.slice(i, i + 10)
+		const wrappedAndJoined = chunk.map((fileName) => `"${fileName}"`).join(' ')
+		result = result.concat(result.map((command) => `${command} ${wrappedAndJoined}`))
+	}
+	return result
+}
+
+module.exports = {
+	'*.{js,css,json,md,scss}': (fileNames) => chunkWrapAndRun(jsCssJsonMdScssCommands, fileNames),
+	'*.{ts,tsx}': (fileNames) => chunkWrapAndRun(tsTsxCommands, fileNames),
+}

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -26,7 +26,7 @@
     "license-validate": "node-license-validator -p -d --allow-licenses MIT BSD BSD-3-Clause ISC Apache Public-Domain 'Public Domain' Unlicense WTFPL CC-BY-4.0 --allow-packages cycle @fortawesome/fontawesome-common-types",
     "lint": "tslint --project tsconfig.test.json --config tslint.json",
     "lintfix": "npm run lint --fix",
-    "quickformat": "(prettier \"__mocks__/**\" --write || true) && (prettier \"lib/**\" --write || true) && (prettier \"server/**\" --write || true) && (prettier \"client/**\" --write || true) && (prettier \"*.json\" --write || true) && (prettier \"*.js\" --write || true) && (prettier \"*.md\" --write || true)",
+    "quickformat": "prettier \"__mocks__/**\" --write ; prettier \"lib/**\" --write ; prettier \"server/**\" --write ; prettier \"client/**\" --write ; prettier \"*.json\" --write ; prettier \"*.js\" --write ; prettier \"*.md\" --write",
     "i18n-extract-pot": "i18next-extract-gettext --files=\"{./client/ui/**/*.+(ts|tsx),./lib/mediaObjects.ts}\" --output=i18n/template.pot",
     "i18n-compile-json": "npm run i18n-compile-json-nb & npm run i18n-compile-json-nn & npm run i18n-compile-json-sv",
     "i18n-compile-json-nb": "i18next-conv -l nb -s i18n/nb.po -t public/locales/nb/translations.json --skipUntranslated",
@@ -149,15 +149,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.{ts,tsx}": [
-      "npm run lintfix --",
-      "git add"
-    ]
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes a workflow bug where lint-staged could produce commands that are too long for the Windows shell to work.

* **What is the current behavior?** (You can also link to an open issue here)

The lint-staged can fail if there are a lot of files staged. `meteor npm run quickformat` won't work at all on Windows.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
