### PR TITLE
fix: Add adlib region to dashboard panel

### DIFF
--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -11,6 +11,7 @@ import { Rundown } from '../../../lib/collections/Rundowns'
 import { Bucket } from '../../../lib/collections/Buckets'
 import { BucketPanel } from './BucketPanel'
 import { unprotectString } from '../../../lib/lib'
+import { AdLibRegionPanel } from './AdLibRegionPanel'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -64,6 +65,20 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 							layout={rundownLayout}
 							visible={true}
 							playlist={props.playlist}
+						/>
+					) : RundownLayoutsAPI.isAdLibRegion(panel) ? (
+						<AdLibRegionPanel
+							key={panel._id}
+							includeGlobalAdLibs={true}
+							filter={RundownLayoutsAPI.adLibRegionToFilter(panel)}
+							panel={panel}
+							adlibRank={panel.adlibRank}
+							layout={rundownLayout}
+							visible={true}
+							playlist={props.playlist}
+							showStyleBase={props.showStyleBase}
+							studioMode={props.studioMode}
+							selectedPiece={undefined}
 						/>
 					) : (
 						undefined


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a bug where adLib regions were not being displayed in dashboard layouts.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
