### PR TITLE
fix: Timeline dashboard panel crashing due to missing props

### DIFF
--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -17,9 +17,16 @@ import {
 import { DashboardPieceButton } from './DashboardPieceButton'
 import { ensureHasTrailingSlash } from '../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
-import { DashboardPanelInner, dashboardElementPosition, getUnfinishedPieceInstancesReactive } from './DashboardPanel'
+import {
+	DashboardPanelInner,
+	dashboardElementPosition,
+	getUnfinishedPieceInstancesReactive,
+	IDashboardPanelTrackedProps,
+	IDashboardPanelProps,
+} from './DashboardPanel'
 import { PieceInstanceId, PieceInstance } from '../../../lib/collections/PieceInstances'
 import { unprotectString, protectString } from '../../../lib/lib'
+import { getNextPiecesReactive } from './AdLibRegionPanel'
 interface IState {
 	outputLayers: {
 		[key: string]: IOutputLayer
@@ -30,27 +37,17 @@ interface IState {
 	searchFilter: string | undefined
 }
 
-interface IDashboardPanelProps {
-	shouldQueue: boolean
-}
-
-interface IDashboardPanelTrackedProps {
-	studio?: Studio
-	// unfinishedPieceInstanceIds: {
-	// 	[adlibId: string]: PieceInstance[]
-	// }
-}
-
 export const TimelineDashboardPanel = translateWithTracker<
 	Translated<IAdLibPanelProps & IDashboardPanelProps>,
 	IState,
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
-	(props: Translated<IAdLibPanelProps>) => {
+	(props: Translated<IAdLibPanelProps & IDashboardPanelProps>) => {
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			// unfinishedPieceInstanceIds: getUnfinishedPieceInstancesReactive(props.playlist.currentPartInstanceId)
+			unfinishedPieceInstances: getUnfinishedPieceInstancesReactive(props.playlist.currentPartInstanceId),
+			nextPieces: getNextPiecesReactive(props.playlist.nextPartInstanceId),
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug where the Timeline dashboard panel would crash due to missing props when the component was mounted.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
