### PR TITLE
feat: Allow rundown reset while on-air

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1029,7 +1029,7 @@ const RundownHeader = translate()(
 					}
 				)
 			}
-			if (this.props.playlist.active && !this.props.playlist.rehearsal) {
+			if (this.props.playlist.active && !this.props.playlist.rehearsal && !Settings.allowRundownResetOnAir) {
 				// The rundown is active and not in rehersal
 				doModalDialog({
 					title: this.props.playlist.name,
@@ -1140,7 +1140,11 @@ const RundownHeader = translate()(
 									) : null}
 									{this.props.playlist.active ? <MenuItem onClick={(e) => this.take(e)}>{t('Take')}</MenuItem> : null}
 									{this.props.playlist.active ? <MenuItem onClick={(e) => this.hold(e)}>{t('Hold')}</MenuItem> : null}
-									{!(this.props.playlist.active && !this.props.playlist.rehearsal) ? (
+									{!(
+										this.props.playlist.active &&
+										!this.props.playlist.rehearsal &&
+										!Settings.allowRundownResetOnAir
+									) ? (
 										<MenuItem onClick={(e) => this.resetRundown(e)}>{t('Reset Rundown')}</MenuItem>
 									) : null}
 									<MenuItem onClick={(e) => this.reloadRundownPlaylist(e)}>{t('Reload ENPS Data')}</MenuItem>

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -29,6 +29,8 @@ export interface ISettings {
 	allowGrabbingTimeline: boolean
 	/** Allow Segments to become unsynced, rather than the entire rundown */
 	allowUnsyncedSegments: boolean
+	/** Allow resets while a rundown is on-air */
+	allowRundownResetOnAir: boolean
 }
 
 export let Settings: ISettings
@@ -45,6 +47,7 @@ const DEFAULT_SETTINGS: ISettings = {
 	defaultTimeScale: 1,
 	allowGrabbingTimeline: true,
 	allowUnsyncedSegments: false,
+	allowRundownResetOnAir: false,
 }
 
 Settings = _.clone(DEFAULT_SETTINGS)

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -98,6 +98,7 @@ import {
 	initCacheForNoRundownPlaylist,
 	CacheForStudio,
 } from '../../DatabaseCaches'
+import { Settings } from '../../../lib/Settings'
 
 /**
  * debounce time in ms before we accept another report of "Part started playing that was not selected by core"
@@ -147,7 +148,7 @@ export namespace ServerPlayoutAPI {
 		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
 			let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-			if (playlist.active && !playlist.rehearsal)
+			if (playlist.active && !playlist.rehearsal && !Settings.allowRundownResetOnAir)
 				throw new Meteor.Error(401, `resetRundown can only be run in rehearsal!`)
 
 			const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
@@ -170,7 +171,7 @@ export namespace ServerPlayoutAPI {
 		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
 			let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-			if (playlist.active && !playlist.rehearsal)
+			if (playlist.active && !playlist.rehearsal && !Settings.allowRundownResetOnAir)
 				throw new Meteor.Error(402, `resetAndActivateRundownPlaylist cannot be run when active!`)
 
 			const cache = waitForPromise(initCacheForRundownPlaylist(playlist))

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -37,6 +37,7 @@ import { updateBucketAdlibFromIngestData } from './ingest/bucketAdlibs'
 import { ServerPlayoutAdLibAPI } from './playout/adlib'
 import { BucketsAPI } from './buckets'
 import { BucketAdLib, BucketAdLibs } from '../../lib/collections/BucketAdlibs'
+import { Settings } from '../../lib/Settings'
 
 let MINIMUM_TAKE_SPAN = 1000
 export function setMinimumTakeSpan(span: number) {
@@ -206,7 +207,7 @@ export function resetRundownPlaylist(rundownPlaylistId: RundownPlaylistId): Clie
 	check(rundownPlaylistId, String)
 	let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-	if (playlist.active && !playlist.rehearsal) {
+	if (playlist.active && !playlist.rehearsal && !Settings.allowRundownResetOnAir) {
 		return ClientAPI.responseError(
 			'RundownPlaylist is active but not in rehearsal, please deactivate it or set in in rehearsal to be able to reset it.'
 		)
@@ -221,7 +222,7 @@ export function resetAndActivate(
 	check(rundownPlaylistId, String)
 	let playlist = RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-	if (playlist.active && !playlist.rehearsal) {
+	if (playlist.active && !playlist.rehearsal && !Settings.allowRundownResetOnAir) {
 		return ClientAPI.responseError(
 			'RundownPlaylist is active but not in rehearsal, please deactivate it or set in in rehearsal to be able to reset it.'
 		)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds the meteor setting `allowRundownResetOnAir`, which allows the user to reset a rundown playlist while it is active.

This is useful for use cases where a single rundown is being reused continually across many shows - the rundown can be replaced with new data from the NRCS and the user can use the reset shortcut to jump to the top of the rundown and ensure a safe state.

The setting is disabled by default, so by default resets will not be allowed while a playlist is active.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
