### PR TITLE
fix: Don't set adlib piece duration if queued or infinite

### DIFF
--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -28,6 +28,7 @@ import {
 	TimelineObjectCoreExt,
 	OnGenerateTimelineObj,
 	TSR,
+	PieceLifespan,
 } from 'tv-automation-sofie-blueprints-integration'
 import { transformTimeline, TimelineContentObject } from '../../../lib/timeline'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
@@ -443,7 +444,7 @@ export function convertAdLibToPieceInstance(
 			partId: partInstance.part._id,
 			enable: {
 				start: queue ? 0 : 'now',
-				duration: duration,
+				duration: !queue && adLibPiece.infiniteMode === PieceLifespan.Normal ? duration : undefined,
 			},
 			adLibSourceId: adLibPiece._id,
 			dynamicallyInserted: !queue,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes a bug where an adlib such as an infinite VT piece with an expectedDuration set would have its duration set, causing the infinite to become stopped when moving to the next part. This also stops duration being set on the queued adlibs. The part will inherit the expected duration from the adlib, but if the user goes beyond the expected duration then they will not end up cutting to black / falling back to the baseline due to the piece stopping.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
