### PR TITLE
feat: JSON config manifest entry type

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -8,7 +8,7 @@ import { Mongo } from 'meteor/mongo'
 
 import { MultiSelect, MultiSelectEvent } from './multiSelect'
 import { TransformedCollection } from '../../lib/typings/meteor'
-import * as classNames from 'classnames'
+import ClassNames from 'classnames'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType

--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -687,7 +687,7 @@ const EditAttributeJson = wrapEditAttribute(
 			return (
 				<input
 					type="text"
-					className={classNames(
+					className={ClassNames(
 						'form-control',
 						this.props.className,
 						this.state.valueError && this.props.invalidClassName

--- a/meteor/client/styles/editAttribute.scss
+++ b/meteor/client/styles/editAttribute.scss
@@ -5,3 +5,7 @@
 		color: #000;
 	}
 }
+
+.warn:focus {
+	color: #FFFFFF;
+}

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -134,6 +134,18 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, Doc
 					className="input text-input input-l"
 				/>
 			)
+		case ConfigManifestEntryType.JSON:
+			return (
+				<EditAttribute
+					modifiedClassName="bghl"
+					invalidClassName="error"
+					attribute={attribute}
+					obj={object}
+					type="json"
+					collection={collection}
+					className="input text-input input-l"
+				/>
+			)
 		case ConfigManifestEntryType.SELECT:
 			const selectFromOptions = item as ConfigManifestEntrySelectFromOptions<true | false>
 			return (

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -138,7 +138,7 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, Doc
 			return (
 				<EditAttribute
 					modifiedClassName="bghl"
-					invalidClassName="error"
+					invalidClassName="warn"
 					attribute={attribute}
 					obj={object}
 					type="json"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the JSON config manifest entry type, which is automatically checked to be valid JSON.

An example use case is to allow Sofie admins to add a new DVE layout by building the layout on an ATEM and using the atem connection library to pull the JSON representation of this layout. They can then copy the JSON into showstyle settings, where it will be validated to prevent copying errors.

* **Other information**:
Requires https://github.com/nrkno/tv-automation-sofie-blueprints-integration/pull/65
**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
