### PR TITLE
feat: Default display duration setting

### DIFF
--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -5,7 +5,6 @@ import { Timecode } from 'timecode'
 import { Settings } from '../../lib/Settings'
 import { SourceLayerType, getPieceGroupId, PieceLifespan } from 'tv-automation-sofie-blueprints-integration'
 import {
-	DEFAULT_DISPLAY_DURATION,
 	SegmentExtended,
 	PartExtended,
 	getPieceInstancesForPartInstance,
@@ -36,7 +35,7 @@ export namespace RundownUtils {
 				(part.instance.part.duration ||
 					part.instance.part.expectedDuration ||
 					part.renderedDuration ||
-					(display ? DEFAULT_DISPLAY_DURATION : 0))
+					(display ? Settings.defaultDisplayDuration : 0))
 			)
 		}, 0)
 	}
@@ -449,8 +448,8 @@ export namespace RundownUtils {
 					}
 				})
 
-				// use the expectedDuration and fallback to the DEFAULT_DISPLAY_DURATION for the part
-				partE.renderedDuration = partE.instance.part.expectedDuration || DEFAULT_DISPLAY_DURATION // furthestDuration
+				// use the expectedDuration and fallback to the default display duration for the part
+				partE.renderedDuration = partE.instance.part.expectedDuration || Settings.defaultDisplayDuration // furthestDuration
 
 				// displayDuration groups are sets of Parts that share their expectedDurations.
 				// If a member of the group has a displayDuration > 0, this displayDuration is used as the renderedDuration of a part.

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -42,7 +42,6 @@ import { RundownUtils } from '../lib/rundown'
 import * as mousetrap from 'mousetrap'
 import { ErrorBoundary } from '../lib/ErrorBoundary'
 import { ModalDialog, doModalDialog, isModalShowing } from '../lib/ModalDialog'
-import { DEFAULT_DISPLAY_DURATION } from '../../lib/Rundown'
 import { MeteorReactComponent } from '../lib/MeteorReactComponent'
 import { getAllowStudio, getAllowDeveloper, getHelpMode, getAllowConfigure, getAllowService } from '../lib/localStorage'
 import { ClientAPI } from '../../lib/api/client'
@@ -2224,7 +2223,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			if (this.state.subsReady) {
 				if (this.props.playlist && this.props.studio && this.props.showStyleBase && !this.props.onlyShelf) {
 					return (
-						<RundownTimingProvider playlist={this.props.playlist} defaultDuration={DEFAULT_DISPLAY_DURATION}>
+						<RundownTimingProvider playlist={this.props.playlist} defaultDuration={Settings.defaultDisplayDuration}>
 							<div
 								className={ClassNames('rundown-view', {
 									'notification-center-open': this.state.isNotificationsCenterOpen,

--- a/meteor/client/ui/RundownView/RundownTiming.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming.tsx
@@ -12,7 +12,7 @@ import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import * as ClassNames from 'classnames'
 import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { PartInstance, findPartInstanceOrWrapToTemporary, PartInstanceId } from '../../../lib/collections/PartInstances'
-import { DEFAULT_DISPLAY_DURATION } from '../../../lib/Rundown'
+import { Settings } from '../../../lib/Settings'
 
 // Minimum duration that a part can be assigned. Used by gap parts to allow them to "compress" to indicate time running out.
 const MINIMAL_NONZERO_DURATION = 1
@@ -111,7 +111,6 @@ export namespace RundownTiming {
 const TIMING_DEFAULT_REFRESH_INTERVAL = 1000 / 60 // the interval for high-resolution events (timeupdateHR)
 const LOW_RESOLUTION_TIMING_DECIMATOR = 15 // the low-resolution events will be called every
 // LOW_RESOLUTION_TIMING_DECIMATOR-th time of the high-resolution events
-const DEFAULT_DURATION = 3000
 
 /**
  * RundownTimingProvider properties.
@@ -348,7 +347,9 @@ export const RundownTimingProvider = withTracker<
 							Math.max(
 								0,
 								this.displayDurationGroups[partInstance.part.displayDurationGroup],
-								partInstance.part.gap ? MINIMAL_NONZERO_DURATION : this.props.defaultDuration || DEFAULT_DURATION
+								partInstance.part.gap
+									? MINIMAL_NONZERO_DURATION
+									: this.props.defaultDuration || Settings.defaultDisplayDuration
 							)
 						memberOfDisplayDurationGroup = true
 					}
@@ -374,7 +375,7 @@ export const RundownTimingProvider = withTracker<
 							partInstance.part.duration ||
 							(memberOfDisplayDurationGroup ? displayDurationFromGroup : partInstance.part.expectedDuration) ||
 							this.props.defaultDuration ||
-							DEFAULT_DURATION
+							Settings.defaultDisplayDuration
 						partDisplayDuration = Math.max(partDisplayDurationNoPlayback, now - lastStartedPlayback)
 						this.partPlayed[unprotectString(partInstance.part._id)] = now - lastStartedPlayback
 					} else {
@@ -385,7 +386,7 @@ export const RundownTimingProvider = withTracker<
 								displayDurationFromGroup ||
 								partInstance.part.expectedDuration ||
 								this.props.defaultDuration ||
-								DEFAULT_DURATION
+								Settings.defaultDisplayDuration
 						)
 						partDisplayDurationNoPlayback = partDisplayDuration
 						this.partPlayed[unprotectString(partInstance.part._id)] = (partInstance.part.duration || 0) - playOffset
@@ -430,7 +431,7 @@ export const RundownTimingProvider = withTracker<
 
 					// Handle invalid parts by overriding the values to preset values for Invalid parts
 					if (partInstance.part.invalid && !partInstance.part.gap) {
-						partDisplayDuration = this.props.defaultDuration || DEFAULT_DURATION
+						partDisplayDuration = this.props.defaultDuration || Settings.defaultDisplayDuration
 						this.partPlayed[unprotectString(partInstance.part._id)] = 0
 					}
 
@@ -911,7 +912,7 @@ export function computeSegmentDuration(
 		const pId = unprotectString(partId)
 		const partDuration =
 			(partDurations ? (partDurations[pId] !== undefined ? partDurations[pId] : 0) : 0) ||
-			(display ? DEFAULT_DISPLAY_DURATION : 0)
+			(display ? Settings.defaultDisplayDuration : 0)
 		return memo + partDuration
 	}, 0)
 }

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -38,7 +38,6 @@ import { getAllowSpeaking } from '../../lib/localStorage'
 import { showPointerLockCursor, hidePointerLockCursor } from '../../lib/PointerLockCursor'
 import { Settings } from '../../../lib/Settings'
 import { MAGIC_TIME_SCALE_FACTOR, RundownViewEvents, IContextMenuContext } from '../RundownView'
-import { DEFAULT_DISPLAY_DURATION } from '../../../lib/Rundown'
 import { literal, unprotectString } from '../../../lib/lib'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { PartId } from '../../../lib/collections/Parts'
@@ -144,7 +143,7 @@ const SegmentTimelineZoom = class SegmentTimelineZoom extends React.Component<
 				const duration = Math.max(
 					item.instance.part.duration || item.renderedDuration || 0,
 					(durations.partDisplayDurations && durations.partDisplayDurations[unprotectString(item.instance.part._id)]) ||
-						DEFAULT_DISPLAY_DURATION
+						Settings.defaultDisplayDuration
 				)
 				total += duration
 			})

--- a/meteor/lib/Rundown.ts
+++ b/meteor/lib/Rundown.ts
@@ -8,8 +8,6 @@ import { PartId } from './collections/Parts'
 import { PartInstance } from './collections/PartInstances'
 import { PieceInstance, PieceInstances, wrapPieceToTemporaryInstance } from './collections/PieceInstances'
 
-export const DEFAULT_DISPLAY_DURATION = 3000
-
 export interface SegmentExtended extends DBSegment {
 	/** Output layers available in the installation used by this segment */
 	outputLayers: {

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -29,6 +29,8 @@ export interface ISettings {
 	allowGrabbingTimeline: boolean
 	/** Allow Segments to become unsynced, rather than the entire rundown */
 	allowUnsyncedSegments: boolean
+	/** Default duration to use to render parts when no duration is provided */
+	defaultDisplayDuration: number
 }
 
 export let Settings: ISettings
@@ -45,6 +47,7 @@ const DEFAULT_SETTINGS: ISettings = {
 	defaultTimeScale: 1,
 	allowGrabbingTimeline: true,
 	allowUnsyncedSegments: false,
+	defaultDisplayDuration: 3000
 }
 
 Settings = _.clone(DEFAULT_SETTINGS)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds the core setting `defaultDisplayDuration` (default value 3000) to make this hard-coded value configurable. This allows different Sofie installations to set a different "default duration" of parts that have no timing information set.

Although this would be a 1-line difference between the NRK version of Sofie and any fork, this setting would allow this entirely cosmetic change to be adjusted using pre-built Sofie images, and would allow different installations within one organisation to use different default durations.

* **Other information**:
The motivator for this setting is that the origin fork for this feature branch uses a default duration of 4 seconds for parts.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
