### PR TITLE
feat: Multiline config manifest entry + device manifest entry

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -253,6 +253,12 @@ const EditAttributeMultilineText = wrapEditAttribute(
 				this.handleDiscard()
 			}
 		}
+		handleEnterKey(event) {
+			let e = event as KeyboardEvent
+			if (e.key === 'Enter') {
+				e.stopPropagation()
+			}
+		}
 		render() {
 			return (
 				<textarea
@@ -269,6 +275,7 @@ const EditAttributeMultilineText = wrapEditAttribute(
 					onChange={this.handleChange}
 					onBlur={this.handleBlur}
 					onKeyUp={this.handleEscape}
+					onKeyPress={this.handleEnterKey}
 				/>
 			)
 		}

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -99,6 +99,21 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, Doc
 					className="input text-input input-l"
 				/>
 			)
+		case ConfigManifestEntryType.MULTILINE_STRING:
+			return (
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={attribute}
+					obj={object}
+					type="multiline"
+					collection={collection}
+					className="input text-input input-l"
+					mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? undefined : v.join('\n'))}
+					mutateUpdateValue={(v) =>
+						v === undefined || v.length === 0 ? undefined : v.split('\n').map((i) => i.trimStart())
+					}
+				/>
+			)
 		case ConfigManifestEntryType.NUMBER:
 			return (
 				<EditAttribute

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -47,6 +47,19 @@ export const ConfigManifestEntryComponent = translate()(
 						type="multiline"
 						className="input text-input input-l"></EditAttribute>
 				)
+			} else if (configField.type === ConfigManifestEntryType.MULTILINE_STRING) {
+				return (
+					<EditAttribute
+						{...opts}
+						modifiedClassName="bghl"
+						type="multiline"
+						className="input text-input input-l"
+						mutateDisplayValue={(v) => (v === undefined || v.length === 0 ? undefined : v.join('\n'))}
+						mutateUpdateValue={(v) =>
+							v === undefined || v.length === 0 ? undefined : v.split('\n').map((i) => i.trimStart())
+						}
+					/>
+				)
 			}
 		}
 

--- a/meteor/lib/api/deviceConfig.ts
+++ b/meteor/lib/api/deviceConfig.ts
@@ -19,6 +19,7 @@ export enum ConfigManifestEntryType {
 	LABEL = 'label',
 	LINK = 'link',
 	STRING = 'string',
+	MULTILINE_STRING = 'multiline_string',
 	BOOLEAN = 'boolean',
 	NUMBER = 'float',
 	FLOAT = 'float',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the MULTILINE_STRING config manifest entry type, allowing devices and blueprints to request input that may include newlines. Each new line in the text field is stored as a string in an array for strings. IE:

```
Hello
World
```

Is stored as `["Hello", "World"]`.

This entry type is useful for devices such as Viz which need to send plain-text commands that are sent as one batch, but as separate messages; represented to the user as multiple lines of commands to be sent together.

* **Other information**:
Requires https://github.com/nrkno/tv-automation-sofie-blueprints-integration/pull/66
Requires https://github.com/nrkno/tv-automation-server-core-integration/pull/31

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
