### PR TITLE
Fix/remove instances on reset rundown

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -53,6 +53,9 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	/** Temporarily track whether this PartInstance has been taken, so we can easily find and prune those which are only nexted */
 	isTaken?: boolean
 
+	/** If the playlist was in rehearsal mode when the PartInstance was created */
+	rehearsal: boolean
+
 	part: DBPart
 }
 
@@ -66,6 +69,7 @@ export class PartInstance implements DBPartInstance {
 	public reset?: boolean
 	public takeCount: number
 	public isTaken?: boolean
+	public rehearsal: boolean
 
 	// From IBlueprintPartInstance:
 	public part: Part
@@ -89,6 +93,7 @@ export function wrapPartToTemporaryInstance(part: DBPart): PartInstance {
 			rundownId: part.rundownId,
 			segmentId: part.segmentId,
 			takeCount: -1,
+			rehearsal: false,
 			part: new Part(part),
 		},
 		true

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -38,30 +38,33 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	_id: PartInstanceId
 	rundownId: RundownId
 
-	isScratch?: true
+	/**
+	 * Whether this PartInstance is a scratch instance - the copy of the Part for the instance
+	 * is still being made and the piece instances are being created.
+	 */
+	readonly isScratch?: true
+
+	/** Whether this instance has been finished with and reset (to restore the original part as the primary version) */
+	reset?: boolean
 
 	/** Rank of the take that this PartInstance belongs to */
 	takeCount: number
+
+	/** Temporarily track whether this PartInstance has been taken, so we can easily find and prune those which are only nexted */
+	isTaken?: boolean
 
 	part: DBPart
 }
 
 export class PartInstance implements DBPartInstance {
+	// Temporary properties (never stored in DB):
 	/** Whether this PartInstance is a temprorary wrapping of a Part */
 	public readonly isTemporary: boolean
 
-	/**
-	 * Whether this PartInstance is a scratch instance - the copy of the Part for the instance
-	 * is still being made and the piece instances are being created.
-	 */
+	// From DBPartInstance:
 	public readonly isScratch?: true
-
-	/** Whether this instance has been finished with and reset (to restore the original part as the primary version) */
 	public reset?: boolean
-
 	public takeCount: number
-
-	/** Temporarily track whether this PartInstance has been taken, so we can easily find and prune those which are only nexted */
 	public isTaken?: boolean
 
 	// From IBlueprintPartInstance:

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -107,6 +107,7 @@ describe('Test blueprint api context', () => {
 				rundownId: part.rundownId,
 				segmentId: part.segmentId,
 				takeCount: i,
+				rehearsal: false,
 				part,
 			})
 

--- a/meteor/server/api/blueprints/__tests__/context.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context.test.ts
@@ -57,6 +57,7 @@ describe('Test blueprint api context', () => {
 				rundownId: part.rundownId,
 				segmentId: part.segmentId,
 				takeCount: i,
+				rehearsal: false,
 				part,
 			})
 

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -392,6 +392,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			rundownId: currentPartInstance.rundownId,
 			segmentId: currentPartInstance.segmentId,
 			takeCount: -1, // Filled in later
+			rehearsal: currentPartInstance.rehearsal,
 			part: new Part({
 				...rawPart,
 				_id: getRandomId(),

--- a/meteor/server/api/ingest/__tests__/updateNext.test.ts
+++ b/meteor/server/api/ingest/__tests__/updateNext.test.ts
@@ -102,6 +102,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment1'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part1'),
 				_rank: 1,
@@ -116,6 +117,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment1'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part2'),
 				_rank: 2,
@@ -130,6 +132,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment1'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part3'),
 				_rank: 3,
@@ -145,6 +148,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment2'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part4'),
 				_rank: 0,
@@ -159,6 +163,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment2'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part5'),
 				_rank: 1,
@@ -174,6 +179,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment3'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part6'),
 				_rank: 0,
@@ -189,6 +195,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment4'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part7'),
 				_rank: 0,
@@ -203,6 +210,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment4'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part8'),
 				_rank: 1,
@@ -218,6 +226,7 @@ function createMockRO() {
 			rundownId: rundownId,
 			segmentId: protectString('mock_segment4'),
 			takeCount: 0,
+			rehearsal: false,
 			part: literal<DBPart>({
 				_id: protectString('mock_part9'),
 				_rank: 2,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -251,6 +251,7 @@ export namespace ServerPlayoutAdLibAPI {
 				rundownId: rundown._id,
 				segmentId: currentPartInstance.segmentId,
 				takeCount: currentPartInstance.takeCount + 1,
+				rehearsal: !!rundownPlaylist.rehearsal,
 				part: new Part({
 					_id: getRandomId(),
 					_rank: 99999, // something high, so it will be placed after current part. The rank will be updated later to its correct value

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -164,6 +164,17 @@ export function resetRundownPlaylist(cache: CacheForRundownPlaylist, rundownPlay
 	const rundownIDs = rundowns.map((i) => i._id)
 	// const rundownLookup = _.object(rundowns.map(i => [ i._id, i ])) as { [key: string]: Rundown }
 
+	const partInstancesToRemove = cache.PartInstances.findFetch({
+		rundownId: { $in: rundownIDs },
+		rehearsal: true,
+	})
+	cache.PartInstances.remove({
+		_id: { $in: partInstancesToRemove.map((pi) => pi._id) },
+	})
+	cache.PieceInstances.remove({
+		partInstanceId: { $in: partInstancesToRemove.map((pi) => pi._id) },
+	})
+
 	cache.PartInstances.update(
 		{
 			rundownId: {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -522,6 +522,7 @@ export function setNextPart(
 				segmentId: nextPart.segmentId,
 				part: nextPart,
 				isScratch: true,
+				rehearsal: !!rundownPlaylist.rehearsal,
 			})
 			/*
 			RundownPlaylists.findOne().nextPartInstanceId


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a fix for a potential performance issue.

There is currently an issue where:
have rundown with 30 parts
do rehearsal (creates 30 partinstances)
reset rundown
do rehearsal (creates 30 partinstances)
reset rundown
do rehearsal (creates 30 partinstances)
reset rundown
Go on air
at the end of the on Air we now will have 120 partinstances.

This PR adds a rehearsal property on the partInstances, and when doing a reset those will be removed. That way we protect the ones that was on air (for as-Run purposes).


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
