### PR TITLE
fix: revert rundown.playlistExternalId change if a playing rundown is…

### DIFF
--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -482,7 +482,7 @@ function updateRundownFromIngestData(
 	const showStyleBlueprintDb = (Blueprints.findOne(showStyle.base.blueprintId) as Blueprint) || {}
 
 	const dbRundownData: DBRundown = _.extend(
-		existingDbRundown || {},
+		_.clone(existingDbRundown) || {},
 		_.omit(
 			literal<DBRundown>({
 				...rundownRes.rundown,

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -503,26 +503,47 @@ function updateRundownFromIngestData(
 				},
 
 				// omit the below fields:
-				created: 0,
-				modified: 0,
-
-				peripheralDeviceId: protectString<PeripheralDeviceId>(''), // added later
-				dataSource: '', // added later
-
-				playlistId: protectString<RundownPlaylistId>(''), // added later
-				_rank: 0, // added later
+				created: 0, // omitted, set later, below
+				modified: 0, // omitted, set later, below
+				peripheralDeviceId: protectString(''), // omitted, set later, below
+				dataSource: '', // omitted, set later, below
+				playlistId: protectString<RundownPlaylistId>(''), // omitted, set later, in produceRundownPlaylistInfo
+				_rank: 0, // omitted, set later, in produceRundownPlaylistInfo
 			}),
 			['created', 'modified', 'peripheralDeviceId', 'dataSource', 'playlistId', '_rank']
 		)
 	)
-	dbRundownData.peripheralDeviceId = peripheralDevice
-		? peripheralDevice._id
-		: existingDbRundown
-		? existingDbRundown.peripheralDeviceId
-		: protectString('')
-
+	if (peripheralDevice) {
+		dbRundownData.peripheralDeviceId = peripheralDevice._id
+	}
 	if (dataSource) {
 		dbRundownData.dataSource = dataSource
+	}
+	// Do a check if we're allowed to move out of currently playing playlist:
+	if (existingDbRundown && existingDbRundown.playlistExternalId !== dbRundownData.playlistExternalId) {
+		// The rundown is going to change playlist
+
+		const existingPlaylist = RundownPlaylists.findOne(existingDbRundown.playlistId)
+		if (existingPlaylist) {
+			const { currentPartInstance } = existingPlaylist.getSelectedPartInstances()
+
+			if (currentPartInstance && currentPartInstance.rundownId === existingDbRundown._id) {
+				// The rundown contains a PartInstance that is currently on air.
+				// We're trying for a "soft approach" here, instead of rejecting the change altogether,
+				// and will just revert the playlist change:
+
+				dbRundownData.playlistExternalId = existingDbRundown.playlistExternalId
+				dbRundownData.playlistId = existingDbRundown.playlistId
+
+				rundownNotes.push({
+					type: NoteType.WARNING,
+					message: `The Rundown was attempted to be moved out of the Playlist when it was on Air. Move it back and try again later.`,
+					origin: {
+						name: 'Data update',
+					},
+				})
+			}
+		}
 	}
 
 	// Save rundown into database:

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -522,16 +522,10 @@ function updateRundownFromIngestData(
 	// Do a check if we're allowed to move out of currently playing playlist:
 	if (existingDbRundown && existingDbRundown.playlistExternalId !== dbRundownData.playlistExternalId) {
 		// The rundown is going to change playlist
-		logger.info(
-			`TMP: playlistExternalId changed ${dbRundownData.playlistExternalId}, ${existingDbRundown.playlistExternalId}`
-		)
 		const existingPlaylist = RundownPlaylists.findOne(existingDbRundown.playlistId)
 		if (existingPlaylist) {
 			const { currentPartInstance } = existingPlaylist.getSelectedPartInstances()
 
-			logger.info(
-				`TMP: currentPartInstance.rundownId ${currentPartInstance ? currentPartInstance.rundownId : 'N/A'}`
-			)
 			if (
 				existingPlaylist.active &&
 				currentPartInstance &&
@@ -554,7 +548,7 @@ function updateRundownFromIngestData(
 				})
 			}
 		} else {
-			logger.error(`Existing playlist "${existingDbRundown.playlistId}" not found`)
+			logger.warn(`Existing playlist "${existingDbRundown.playlistId}" not found`)
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue where a currently playing rundown can be moved outside of the playlist, thus creating a pretty exotic problem in the data structures...

Needs testing before merging.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
