### PR TITLE
feat: streamdeck buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For the purpose of running the system in a studio environment, there are additio
 | `/countdowns/:studioId/presenter` | Countdown clocks for a given studio, to be shown to the studio presenter |
 | `/activeRundown/:studioId`        | Redirects to the rundown currently active in a given studio              |
 | `/activeRundown/:studioId/shelf`  | Shows a Detached Shelf for the current active rundown in a studio        |
+| `/rundown/:rundownId/shelf`       | Shows a Detached Shelf for the rundown                                   |
 | `/prompter/:studioId`             | A simple prompter for the studio presenter                               |
 
 ## Studio mode
@@ -103,6 +104,20 @@ To use a specific layout in these views, you can use the `?layout=...` query str
 ```http://localhost:3000/activeRundown/studio0/shelf?layout=Stream```
 
 The Detached Shelf view with a custom DASHBOARD_LAYOUT allows displaying the Shelf on an auxiliary touch screen, tablet or a Stream Deck device. A specialized Stream Deck view will be used if the view is opened on a device with hardware characteristics matching a Stream Deck device.
+
+The shelf also contains additional elements, not controlled by the Rundown View Layout. These include Buckets and the Inspector. If needed, these
+components can be displayed or hidden using additional url arguments:
+
+| Query parameter                     | Description                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| Default                             | Display the rundown layout (as selected), all buckets and the inspector |
+| `?display=layout,buckets,inspector` | A comma-separated list of features to be displayed in the shelf         |
+| `?buckets=0,1,...`                  | A comma-separated list of buckets to be displayed                       |
+
+* `display`: Available values are: `layout` (for displaying the Rundown Layout), `buckets` (for displaying the Buckets) and `inspector` (for displaying the Inspector).
+* `buckets`: The buckets can be specified as base-0 indices of the buckets as seen by the user. This means that `?buckets=1` will display the second bucket as seen by the user when not filtering the buckets. This allows the user to decide which bucket is displayed on a secondary attached screen simply by reordering the buckets on their main view.
+
+*Note: the Inspector is limited in scope to a particular browser window/screen, so do not expect the contents of the inspector to sync across multiple screens.*
 
 ## Operating the prompter screen
 

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -54,37 +54,69 @@
 		> .container-fluid
 		> .rundown-view__shelf.dark.full-viewport
 		> .rundown-view__shelf__contents
-		> .rundown-view__shelf__contents__pane
-		> .dashboard {
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
-		overflow: hidden;
+		> .rundown-view__shelf__contents__pane {
+		margin-left: 0;
 
-		.dashboard-panel {
-			padding: 0;
-			margin: 0;
-			background: #252627;
+		&.shelf-inspector {
+			display: none;
+		}
 
-			.dashboard-panel__header {
-				display: none;
+		&:last-child {
+			flex-grow: 1;
+		}
+
+		&.fill ~ :last-child {
+			flex-grow: 0;
+		}
+
+		> .rundown-view__shelf__contents__pane__divider {
+			opacity: 0;
+			left: -5px;
+			z-index: 2;
+
+			&:hover {
+				opacity: 1;
 			}
+		}
 
-			.adlib-panel__list-view__toolbar {
-				display: none;
-			}
+		> .dashboard,
+		> .buckets {
+			top: 0;
+			left: 0;
+			bottom: 0;
+			right: 0;
+			overflow: hidden;
 
-			.dashboard-panel__panel {
-				margin: 0 -2px 0 0;
-				max-height: 100%;
-				overflow: hidden;
+			.dashboard-panel {
+				padding: 0;
+				margin: 0;
+				background: #070707;
 
-				> .dashboard-panel__panel__button {
-					> .dashboard-panel__panel__button__label {
-						top: 4px;
+				.dashboard-panel__header {
+					display: none;
+				}
+
+				.adlib-panel__list-view__toolbar {
+					display: none;
+				}
+
+				.dashboard-panel__panel {
+					margin: 0 -2px 0 0;
+					max-height: 100%;
+					overflow: hidden;
+
+					> .dashboard-panel__panel__button,
+					> span > .dashboard-panel__panel__button {
+						> .dashboard-panel__panel__button__label {
+							top: 4px;
+						}
 					}
 				}
+			}
+		}
+
+		> .buckets {
+			> .dashboard-panel__panel--bucket {
 			}
 		}
 	}
@@ -96,18 +128,21 @@
 		> .container-fluid
 		> .rundown-view__shelf.dark.full-viewport
 		> .rundown-view__shelf__contents
-		> .rundown-view__shelf__contents__pane
-		> .dashboard {
-		--dashboard-button-grid-width: 1.5em;
-		--dashboard-button-grid-height: 1.5em;
-		--dashboard-panel-margin-width: 0em;
-		--dashboard-panel-margin-height: 0em;
+		> .rundown-view__shelf__contents__pane {
+		> .dashboard,
+		> .buckets {
+			--dashboard-button-grid-width: 1.5em;
+			--dashboard-button-grid-height: 1.5em;
+			--dashboard-panel-margin-width: 0em;
+			--dashboard-panel-margin-height: 0em;
 
-		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
-			width: 71px;
-			height: 71px;
-			margin: 0px 1px 1px 0px;
-			font-size: 13px;
+			.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button,
+			.dashboard-panel > .dashboard-panel__panel > span > .dashboard-panel__panel__button {
+				width: 71px;
+				height: 71px;
+				margin: 0px 1px 1px 0px;
+				font-size: 13px;
+			}
 		}
 	}
 }
@@ -118,18 +153,21 @@
 		> .container-fluid
 		> .rundown-view__shelf.dark.full-viewport
 		> .rundown-view__shelf__contents
-		> .rundown-view__shelf__contents__pane
-		> .dashboard {
-		--dashboard-button-grid-width: 2.007em;
-		--dashboard-button-grid-height: 2.007em;
-		--dashboard-panel-margin-width: 0em;
-		--dashboard-panel-margin-height: 0em;
+		> .rundown-view__shelf__contents__pane {
+		> .dashboard,
+		> .buckets {
+			--dashboard-button-grid-width: 2.007em;
+			--dashboard-button-grid-height: 2.007em;
+			--dashboard-panel-margin-width: 0em;
+			--dashboard-panel-margin-height: 0em;
 
-		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
-			width: 95px;
-			height: 95px;
-			margin: 0px 1px 1px 0px;
-			font-size: 15px;
+			.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button,
+			.dashboard-panel > .dashboard-panel__panel > span > .dashboard-panel__panel__button {
+				width: 95px;
+				height: 95px;
+				margin: 0px 1px 1px 0px;
+				font-size: 15px;
+			}
 		}
 	}
 }
@@ -140,18 +178,21 @@
 		> .container-fluid
 		> .rundown-view__shelf.dark.full-viewport
 		> .rundown-view__shelf__contents
-		> .rundown-view__shelf__contents__pane
-		> .dashboard {
-		--dashboard-button-grid-width: 1.669em;
-		--dashboard-button-grid-height: 1.669em;
-		--dashboard-panel-margin-width: 0em;
-		--dashboard-panel-margin-height: 0em;
+		> .rundown-view__shelf__contents__pane {
+		> .dashboard,
+		> .buckets {
+			--dashboard-button-grid-width: 1.669em;
+			--dashboard-button-grid-height: 1.669em;
+			--dashboard-panel-margin-width: 0em;
+			--dashboard-panel-margin-height: 0em;
 
-		.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button {
-			width: 79px;
-			height: 79px;
-			margin: 0px 1px 1px 0px;
-			font-size: 13px;
+			.dashboard-panel > .dashboard-panel__panel > .dashboard-panel__panel__button,
+			.dashboard-panel > .dashboard-panel__panel > span > .dashboard-panel__panel__button {
+				width: 79px;
+				height: 79px;
+				margin: 0px 1px 1px 0px;
+				font-size: 13px;
+			}
 		}
 	}
 }

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1304,7 +1304,9 @@ interface ITrackedProps {
 	shelfDisplayOptions: {
 		buckets: boolean
 		layout: boolean
+		inspector: boolean
 	}
+	bucketDisplayFilter: number[] | undefined
 }
 export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((props: IProps) => {
 	let playlistId
@@ -1324,7 +1326,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 	const params = queryStringParse(location.search)
 
-	const displayOptions = ((params['display'] as string) || 'buckets,layout').split(',')
+	const displayOptions = ((params['display'] as string) || 'buckets,layout,inspector').split(',')
+	const bucketDisplayFilter = !(params['buckets'] as string)
+		? undefined
+		: (params['buckets'] as string).split(',').map((v) => parseInt(v))
 
 	// let rundownDurations = calculateDurations(rundown, parts)
 	return {
@@ -1373,7 +1378,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		shelfDisplayOptions: {
 			buckets: displayOptions.includes('buckets'),
 			layout: displayOptions.includes('layout'),
+			inspector: displayOptions.includes('inspector'),
 		},
+		bucketDisplayFilter,
 	}
 })(
 	class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
@@ -2432,6 +2439,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 										onRegisterHotkeys={this.onRegisterHotkeys}
 										rundownLayout={this.state.rundownLayout}
 										shelfDisplayOptions={this.props.shelfDisplayOptions}
+										bucketDisplayFilter={this.props.bucketDisplayFilter}
 									/>
 								</ErrorBoundary>
 								<ErrorBoundary>
@@ -2475,6 +2483,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								rundownLayout={this.state.rundownLayout}
 								fullViewport={true}
 								shelfDisplayOptions={this.props.shelfDisplayOptions}
+								bucketDisplayFilter={this.props.bucketDisplayFilter}
 							/>
 						</ErrorBoundary>
 					)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1301,6 +1301,10 @@ interface ITrackedProps {
 	buckets: Bucket[]
 	casparCGPlayoutDevices?: PeripheralDevice[]
 	rundownLayoutId?: RundownLayoutId
+	shelfDisplayOptions: {
+		buckets: boolean
+		layout: boolean
+	}
 }
 export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((props: IProps) => {
 	let playlistId
@@ -1319,6 +1323,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 	}
 
 	const params = queryStringParse(location.search)
+
+	const displayOptions = ((params['display'] as string) || 'buckets,layout').split(',')
 
 	// let rundownDurations = calculateDurations(rundown, parts)
 	return {
@@ -1364,6 +1370,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				}).fetch()) ||
 			undefined,
 		rundownLayoutId: protectString((params['layout'] as string) || ''),
+		shelfDisplayOptions: {
+			buckets: displayOptions.includes('buckets'),
+			layout: displayOptions.includes('layout'),
+		},
 	}
 })(
 	class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
@@ -1383,7 +1393,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			label: string
 			global?: boolean
 		}> = []
-		private _inspectorShelf: WrappedShelf | null
 		private _segmentZoomOn: boolean = false
 
 		constructor(props: Translated<IProps & ITrackedProps>) {
@@ -2245,10 +2254,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			})
 		}
 
-		setInspectorShelf = (isp: WrappedShelf | null) => {
-			this._inspectorShelf = isp
-		}
-
 		onTake = (e: any) => {
 			const { t } = this.props
 			if (this.state.studioMode && this.props.playlist) {
@@ -2416,7 +2421,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								</ErrorBoundary>
 								<ErrorBoundary>
 									<Shelf
-										ref={this.setInspectorShelf}
 										buckets={this.props.buckets}
 										isExpanded={this.state.isInspectorShelfExpanded}
 										onChangeExpanded={this.onShelfChangeExpanded}
@@ -2427,6 +2431,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 										onChangeBottomMargin={this.onChangeBottomMargin}
 										onRegisterHotkeys={this.onRegisterHotkeys}
 										rundownLayout={this.state.rundownLayout}
+										shelfDisplayOptions={this.props.shelfDisplayOptions}
 									/>
 								</ErrorBoundary>
 								<ErrorBoundary>
@@ -2458,7 +2463,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					return (
 						<ErrorBoundary>
 							<Shelf
-								ref={this.setInspectorShelf}
 								buckets={this.props.buckets}
 								isExpanded={this.state.isInspectorShelfExpanded}
 								onChangeExpanded={this.onShelfChangeExpanded}
@@ -2470,6 +2474,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								onRegisterHotkeys={this.onRegisterHotkeys}
 								rundownLayout={this.state.rundownLayout}
 								fullViewport={true}
+								shelfDisplayOptions={this.props.shelfDisplayOptions}
 							/>
 						</ErrorBoundary>
 					)

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -618,8 +618,6 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 																? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || ''
 																: ''
 														}
-														widthScale={1}
-														heightScale={1}
 														disabled={adlib.showStyleVariantId !== this.props.showStyleVariantId}
 														findAdLib={this.findAdLib}
 														moveAdLib={this.moveAdLib}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -158,7 +158,10 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 		const isList = this.props.displayStyle === PieceDisplayStyle.LIST
 		const isButtons = this.props.displayStyle === PieceDisplayStyle.BUTTONS
 		const hasMediaInfo =
-			this.props.layer.type === SourceLayerType.VT && this.props.metadata && this.props.metadata.mediainfo
+			this.props.layer &&
+			this.props.layer.type === SourceLayerType.VT &&
+			this.props.metadata &&
+			this.props.metadata.mediainfo
 		return (
 			<div
 				className={ClassNames(

--- a/meteor/client/ui/Shelf/RundownViewBuckets.tsx
+++ b/meteor/client/ui/Shelf/RundownViewBuckets.tsx
@@ -30,6 +30,8 @@ interface IBucketsProps {
 	playlist: RundownPlaylist
 	showStyleBase: ShowStyleBase
 	shouldQueue: boolean
+	fullViewport: boolean
+	displayBuckets?: number[]
 }
 
 interface IState {
@@ -406,6 +408,12 @@ export const RundownViewBuckets = withTranslation()(
 			)
 		}
 
+		private bucketPanelStyle = (index: number): React.CSSProperties => {
+			return {
+				minWidth: this.state.panelWidths[index] * 100 + 'vw',
+			}
+		}
+
 		render() {
 			const { playlist, showStyleBase, shouldQueue, t } = this.props
 			const { localBuckets: buckets } = this.state
@@ -448,52 +456,57 @@ export const RundownViewBuckets = withTranslation()(
 						</ContextMenu>
 					</Escape>
 					{buckets &&
-						buckets.map((bucket, index) => (
-							<div
-								className="rundown-view__shelf__contents__pane"
-								key={unprotectString(bucket._id)}
-								style={{
-									minWidth: this.state.panelWidths[index] * 100 + 'vw',
-								}}>
+						buckets.map((bucket, index) =>
+							!this.props.displayBuckets || this.props.displayBuckets.includes(index) ? (
 								<div
-									className="rundown-view__shelf__contents__pane__divider"
-									onMouseDown={(e) => this.grabHandle(e, bucket)}
-									onTouchStart={(e) => this.touchOnHandle(e, bucket)}>
-									<div className="rundown-view__shelf__contents__pane__handle">
-										<FontAwesomeIcon icon={faBars} />
-									</div>
+									className="rundown-view__shelf__contents__pane"
+									key={unprotectString(bucket._id)}
+									style={this.bucketPanelStyle(index)}>
+									{!this.props.fullViewport || index > 0 ? (
+										<div
+											className="rundown-view__shelf__contents__pane__divider"
+											onMouseDown={(e) => this.grabHandle(e, bucket)}
+											onTouchStart={(e) => this.touchOnHandle(e, bucket)}>
+											<div className="rundown-view__shelf__contents__pane__handle">
+												<FontAwesomeIcon icon={faBars} />
+											</div>
+										</div>
+									) : null}
+									<ContextMenuTrigger
+										id="bucket-context-menu"
+										attributes={{
+											className: 'buckets',
+										}}
+										collect={() =>
+											new Promise((resolve) => {
+												this.setState(
+													{
+														contextBucket: bucket,
+														contextBucketAdLib: undefined,
+													},
+													resolve
+												)
+											})
+										}
+										holdToDisplay={contextMenuHoldToDisplayTime()}>
+										{this.state.panelWidths[index] > 0 && (
+											<BucketPanel
+												playlist={playlist}
+												showStyleBase={showStyleBase}
+												shouldQueue={shouldQueue}
+												bucket={bucket}
+												editableName={this.state.editedNameId === bucket._id}
+												onNameChanged={(e, name) => this.finishRenameBucket(e, bucket, name)}
+												moveBucket={this.moveBucket}
+												findBucket={this.findBucket}
+												onBucketReorder={this.onBucketReorder}
+												onAdLibContext={this.onAdLibContext}
+											/>
+										)}
+									</ContextMenuTrigger>
 								</div>
-								<ContextMenuTrigger
-									id="bucket-context-menu"
-									collect={() =>
-										new Promise((resolve) => {
-											this.setState(
-												{
-													contextBucket: bucket,
-													contextBucketAdLib: undefined,
-												},
-												resolve
-											)
-										})
-									}
-									holdToDisplay={contextMenuHoldToDisplayTime()}>
-									{this.state.panelWidths[index] > 0 && (
-										<BucketPanel
-											playlist={playlist}
-											showStyleBase={showStyleBase}
-											shouldQueue={shouldQueue}
-											bucket={bucket}
-											editableName={this.state.editedNameId === bucket._id}
-											onNameChanged={(e, name) => this.finishRenameBucket(e, bucket, name)}
-											moveBucket={this.moveBucket}
-											findBucket={this.findBucket}
-											onBucketReorder={this.onBucketReorder}
-											onAdLibContext={this.onAdLibContext}
-										/>
-									)}
-								</ContextMenuTrigger>
-							</div>
-						))}
+							) : null
+						)}
 				</>
 			)
 		}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -45,6 +45,10 @@ export interface IShelfProps extends React.ComponentPropsWithRef<any> {
 	}>
 	rundownLayout?: RundownLayoutBase
 	fullViewport?: boolean
+	shelfDisplayOptions: {
+		buckets: boolean
+		layout: boolean
+	}
 
 	onChangeExpanded: (value: boolean) => void
 	onRegisterHotkeys: (
@@ -411,6 +415,7 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 
 	render() {
 		const { t, fullViewport } = this.props
+		console.log(this.props.shelfDisplayOptions)
 		return (
 			<div
 				className={ClassNames('rundown-view__shelf dark', {

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -48,7 +48,9 @@ export interface IShelfProps extends React.ComponentPropsWithRef<any> {
 	shelfDisplayOptions: {
 		buckets: boolean
 		layout: boolean
+		inspector: boolean
 	}
+	bucketDisplayFilter: number[] | undefined
 
 	onChangeExpanded: (value: boolean) => void
 	onRegisterHotkeys: (
@@ -415,7 +417,6 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 
 	render() {
 		const { t, fullViewport } = this.props
-		console.log(this.props.shelfDisplayOptions)
 		return (
 			<div
 				className={ClassNames('rundown-view__shelf dark', {
@@ -433,72 +434,75 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 					</div>
 				)}
 				<div className="rundown-view__shelf__contents">
-					<ContextMenuTrigger
-						id="bucket-context-menu"
-						attributes={{
-							className: 'rundown-view__shelf__contents__pane fill',
-						}}
-						holdToDisplay={contextMenuHoldToDisplayTime()}>
+					{!this.props.fullViewport || this.props.shelfDisplayOptions.layout ? (
+						<ContextMenuTrigger
+							id="bucket-context-menu"
+							attributes={{
+								className: 'rundown-view__shelf__contents__pane fill',
+							}}
+							holdToDisplay={contextMenuHoldToDisplayTime()}>
+							<ErrorBoundary>
+								{this.props.rundownLayout && RundownLayoutsAPI.isRundownLayout(this.props.rundownLayout) ? (
+									<ShelfRundownLayout
+										playlist={this.props.playlist}
+										showStyleBase={this.props.showStyleBase}
+										studioMode={this.props.studioMode}
+										hotkeys={this.props.hotkeys}
+										rundownLayout={this.props.rundownLayout}
+										selectedTab={this.state.selectedTab}
+										selectedPiece={this.state.selectedPiece}
+										onSelectPiece={this.selectPiece}
+										onSwitchTab={this.switchTab}
+									/>
+								) : this.props.rundownLayout && RundownLayoutsAPI.isDashboardLayout(this.props.rundownLayout) ? (
+									<ShelfDashboardLayout
+										playlist={this.props.playlist}
+										showStyleBase={this.props.showStyleBase}
+										buckets={this.props.buckets}
+										studioMode={this.props.studioMode}
+										rundownLayout={this.props.rundownLayout}
+										shouldQueue={this.state.shouldQueue}
+										onChangeQueueAdLib={this.changeQueueAdLib}
+									/>
+								) : (
+									// ultimate fallback if not found
+									<ShelfRundownLayout
+										playlist={this.props.playlist}
+										showStyleBase={this.props.showStyleBase}
+										studioMode={this.props.studioMode}
+										hotkeys={this.props.hotkeys}
+										rundownLayout={undefined}
+										selectedTab={this.state.selectedTab}
+										selectedPiece={this.state.selectedPiece}
+										onSelectPiece={this.selectPiece}
+										onSwitchTab={this.switchTab}
+									/>
+								)}
+							</ErrorBoundary>
+						</ContextMenuTrigger>
+					) : null}
+					{!this.props.fullViewport || this.props.shelfDisplayOptions.buckets ? (
 						<ErrorBoundary>
-							{this.props.rundownLayout && RundownLayoutsAPI.isRundownLayout(this.props.rundownLayout) ? (
-								<ShelfRundownLayout
-									playlist={this.props.playlist}
-									showStyleBase={this.props.showStyleBase}
-									studioMode={this.props.studioMode}
-									hotkeys={this.props.hotkeys}
-									rundownLayout={this.props.rundownLayout}
-									selectedTab={this.state.selectedTab}
-									selectedPiece={this.state.selectedPiece}
-									onSelectPiece={this.selectPiece}
-									onSwitchTab={this.switchTab}
-								/>
-							) : this.props.rundownLayout && RundownLayoutsAPI.isDashboardLayout(this.props.rundownLayout) ? (
-								<ShelfDashboardLayout
-									playlist={this.props.playlist}
-									showStyleBase={this.props.showStyleBase}
-									buckets={this.props.buckets}
-									studioMode={this.props.studioMode}
-									rundownLayout={this.props.rundownLayout}
-									shouldQueue={this.state.shouldQueue}
-									onChangeQueueAdLib={this.changeQueueAdLib}
-								/>
-							) : this.props.rundownLayout && RundownLayoutsAPI.isDashboardLayout(this.props.rundownLayout) ? (
-								<ShelfDashboardLayout
-									playlist={this.props.playlist}
-									showStyleBase={this.props.showStyleBase}
-									buckets={this.props.buckets}
-									studioMode={this.props.studioMode}
-									rundownLayout={this.props.rundownLayout}
-									shouldQueue={this.state.shouldQueue}
-									onChangeQueueAdLib={this.changeQueueAdLib}
-								/>
-							) : (
-								// ultimate fallback if not found
-								<ShelfRundownLayout
-									playlist={this.props.playlist}
-									showStyleBase={this.props.showStyleBase}
-									studioMode={this.props.studioMode}
-									hotkeys={this.props.hotkeys}
-									rundownLayout={undefined}
-									selectedTab={this.state.selectedTab}
-									selectedPiece={this.state.selectedPiece}
-									onSelectPiece={this.selectPiece}
-									onSwitchTab={this.switchTab}
-								/>
-							)}
+							<RundownViewBuckets
+								buckets={this.props.buckets}
+								playlist={this.props.playlist}
+								shouldQueue={this.state.shouldQueue}
+								showStyleBase={this.props.showStyleBase}
+								fullViewport={
+									!!this.props.fullViewport &&
+									this.props.shelfDisplayOptions.buckets === true &&
+									this.props.shelfDisplayOptions.inspector === false &&
+									this.props.shelfDisplayOptions.layout === false
+								}
+								displayBuckets={this.props.bucketDisplayFilter}
+							/>
 						</ErrorBoundary>
-					</ContextMenuTrigger>
-					<ErrorBoundary>
-						<RundownViewBuckets
-							buckets={this.props.buckets}
-							playlist={this.props.playlist}
-							shouldQueue={this.state.shouldQueue}
-							showStyleBase={this.props.showStyleBase}
-						/>
-					</ErrorBoundary>
-					<ErrorBoundary>
-						<ShelfInspector selected={this.state.selectedPiece} showStyleBase={this.props.showStyleBase} />
-					</ErrorBoundary>
+					) : null}
+					{!this.props.fullViewport || this.props.shelfDisplayOptions.inspector ? (
+						<ErrorBoundary>
+							<ShelfInspector selected={this.state.selectedPiece} showStyleBase={this.props.showStyleBase} />
+						</ErrorBoundary>
+					) : null}
 				</div>
 			</div>
 		)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR creates a feature for displaying bucket adlibs in auxiliary screens, like Stream Decks.

* **What is the current behavior?** (You can also link to an open issue here)

If buckets are created, a Stream Deck display will be malformed.

* **What is the new behavior (if this is a feature change)?**

There are now url parameters for controlling displaying of Buckets and the Inspector in a Detached Shelf. If needed, these
components can be displayed or hidden using the following additional url arguments:

| Query parameter                     | Description                                                             |
| ----------------------------------- | ----------------------------------------------------------------------- |
| Default                             | Display the rundown layout (as selected), all buckets and the inspector |
| `?display=layout,buckets,inspector` | A comma-separated list of features to be displayed in the shelf         |
| `?buckets=0,1,...`                  | A comma-separated list of buckets to be displayed                       |

* `display`: Available values are: `layout` (for displaying the Rundown Layout), `buckets` (for displaying the Buckets) and `inspector` (for displaying the Inspector).
* `buckets`: The buckets can be specified as base-0 indices of the buckets as seen by the user. This means that `?buckets=1` will display the second bucket as seen by the user when not filtering the buckets. This allows the user to decide which bucket is displayed on a secondary attached screen simply by reordering the buckets on their main view.

*Note: the Inspector is limited in scope to a particular browser window/screen, so do not expect the contents of the inspector to sync across multiple screens.*


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
