### PR TITLE
fix: service messages types

### DIFF
--- a/meteor/client/ui/ConnectionStatusNotification.tsx
+++ b/meteor/client/ui/ConnectionStatusNotification.tsx
@@ -216,7 +216,7 @@ export class ConnectionStatusNotifier extends WithManagedTracker {
 			this.getNoticeLevelForCriticality(message.criticality),
 			message.message,
 			message.sender || '(service message)',
-			message.timestamp.getMilliseconds(),
+			message.timestamp,
 			true
 		)
 	}

--- a/meteor/lib/collections/CoreSystem.ts
+++ b/meteor/lib/collections/CoreSystem.ts
@@ -31,6 +31,10 @@ export interface ServiceMessage {
 	criticality: Criticality
 	message: string
 	sender?: string
+	timestamp: number
+}
+
+export interface ExternalServiceMessage extends Omit<ServiceMessage, 'timestamp'> {
 	timestamp: Date
 }
 

--- a/meteor/server/__tests__/api/serviceMessages/postHandler.test.ts
+++ b/meteor/server/__tests__/api/serviceMessages/postHandler.test.ts
@@ -1,5 +1,5 @@
 import { postHandler, BodyParsingIncomingMessage } from '../../../api/serviceMessages/postHandler'
-import { Criticality, ServiceMessage } from '../../../../lib/collections/CoreSystem'
+import { Criticality, ServiceMessage, ExternalServiceMessage } from '../../../../lib/collections/CoreSystem'
 import { IncomingMessage, ServerResponse } from 'http'
 import { Socket } from 'net'
 import * as serviceMessagesApi from '../../../api/serviceMessages/serviceMessagesApi'
@@ -12,7 +12,7 @@ jest.mock('../../../api/serviceMessages/serviceMessagesApi', () => {
 	}
 })
 
-const validInput: ServiceMessage = {
+const validInput: ExternalServiceMessage = {
 	id: '294a7079efdce49fb553e52d9e352e24',
 	criticality: Criticality.CRITICAL,
 	message: 'Something is wrong that should have been right',

--- a/meteor/server/__tests__/api/serviceMessages/postHandler.test.ts
+++ b/meteor/server/__tests__/api/serviceMessages/postHandler.test.ts
@@ -313,7 +313,7 @@ describe('ServiceMessages API POST endpoint', () => {
 		})
 
 		it('should call API writeMessage with the given timestamp', () => {
-			const expected = new Date(validInput.timestamp)
+			const expected = new Date(validInput.timestamp).getTime()
 			mockRequest.body = JSON.parse(JSON.stringify(validInput))
 
 			postHandler({}, mockRequest, mockResponse)

--- a/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
+++ b/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
@@ -78,8 +78,8 @@ describe('Service messages internal API', () => {
 
 			const actual = readAllMessages()
 
-			expect(actual).toContainEqual(message1)
-			expect(actual).toContainEqual(message2)
+			expect(actual).toContainEqual(convertExternalToServiceMessage(message1))
+			expect(actual).toContainEqual(convertExternalToServiceMessage(message2))
 			spy.mockRestore()
 		})
 	})
@@ -132,7 +132,7 @@ describe('Service messages internal API', () => {
 
 		it('should write message to CoreSystem.serviceMessages', () => {
 			const expected = {}
-			expected[message2.id] = message2
+			expected[message2.id] = convertExternalToServiceMessage(message2)
 			const cs = Object.assign({}, fakeCoreSystem, {
 				serviceMessages: {},
 			})
@@ -140,14 +140,18 @@ describe('Service messages internal API', () => {
 
 			writeMessage(convertExternalToServiceMessage(message2))
 
-			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, { $set: { serviceMessages: expected } })
+			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, {
+				$set: {
+					serviceMessages: expected,
+				},
+			})
 			spyGetCoreSystem.mockRestore()
 		})
 
 		it('should leave existing messages untouched', () => {
 			const expected = {}
-			expected[message1.id] = message1
-			expected[message2.id] = message2
+			expected[message1.id] = convertExternalToServiceMessage(message1)
+			expected[message2.id] = convertExternalToServiceMessage(message2)
 			const cs = Object.assign({}, fakeCoreSystem, {
 				serviceMessages: {},
 			})
@@ -155,7 +159,11 @@ describe('Service messages internal API', () => {
 			const spy = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
 			const actual = writeMessage(convertExternalToServiceMessage(message2))
 
-			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, { $set: { serviceMessages: expected } })
+			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, {
+				$set: {
+					serviceMessages: expected,
+				},
+			})
 			spy.mockRestore()
 		})
 

--- a/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
+++ b/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
@@ -1,10 +1,13 @@
-import {
-	readAllMessages,
-	writeMessage,
-	convertExternalToServiceMessage,
-} from '../../../api/serviceMessages/serviceMessagesApi'
+import { readAllMessages, writeMessage } from '../../../api/serviceMessages/serviceMessagesApi'
 import * as CoreSystem from '../../../../lib/collections/CoreSystem'
 import { protectString } from '../../../../lib/lib'
+
+function convertExternalToServiceMessage(message: CoreSystem.ExternalServiceMessage): CoreSystem.ServiceMessage {
+	return {
+		...message,
+		timestamp: new Date(message.timestamp).getTime(),
+	}
+}
 
 jest.mock('../../../../lib/collections/CoreSystem')
 

--- a/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
+++ b/meteor/server/__tests__/api/serviceMessages/serviceMessagesApi.test.ts
@@ -1,10 +1,14 @@
-import { readAllMessages, writeMessage } from '../../../api/serviceMessages/serviceMessagesApi'
+import {
+	readAllMessages,
+	writeMessage,
+	convertExternalToServiceMessage,
+} from '../../../api/serviceMessages/serviceMessagesApi'
 import * as CoreSystem from '../../../../lib/collections/CoreSystem'
 import { protectString } from '../../../../lib/lib'
 
 jest.mock('../../../../lib/collections/CoreSystem')
 
-const message1: CoreSystem.ServiceMessage = {
+const message1: CoreSystem.ExternalServiceMessage = {
 	id: '294a7079efdce49fb553e52d9e352e24',
 	criticality: CoreSystem.Criticality.CRITICAL,
 	message: 'Something is wrong that should have been right',
@@ -12,7 +16,7 @@ const message1: CoreSystem.ServiceMessage = {
 	timestamp: new Date(),
 }
 
-const message2: CoreSystem.ServiceMessage = {
+const message2: CoreSystem.ExternalServiceMessage = {
 	id: '4d6fb1e005ac3364784acc7194e329c2',
 	criticality: CoreSystem.Criticality.WARNING,
 	message: 'Something is rotten in the state of Denmark',
@@ -68,8 +72,8 @@ describe('Service messages internal API', () => {
 
 		it('should return all service messages as an array', () => {
 			const cs = { ...fakeCoreSystem }
-			cs.serviceMessages[message1.id] = message1
-			cs.serviceMessages[message2.id] = message2
+			cs.serviceMessages[message1.id] = convertExternalToServiceMessage(message1)
+			cs.serviceMessages[message2.id] = convertExternalToServiceMessage(message2)
 			const spy = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
 
 			const actual = readAllMessages()
@@ -105,10 +109,10 @@ describe('Service messages internal API', () => {
 			const cs = Object.assign({}, fakeCoreSystem, {
 				serviceMessages: {},
 			})
-			cs.serviceMessages[message1.id] = message1
+			cs.serviceMessages[message1.id] = convertExternalToServiceMessage(message1)
 			const spy = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
 
-			const actual = writeMessage(message1)
+			const actual = writeMessage(convertExternalToServiceMessage(message1))
 
 			expect(actual).toHaveProperty('isUpdate', true)
 			spy.mockRestore()
@@ -118,9 +122,9 @@ describe('Service messages internal API', () => {
 			const cs = Object.assign({}, fakeCoreSystem, {
 				serviceMessages: {},
 			})
-			cs.serviceMessages[message1.id] = message1
+			cs.serviceMessages[message1.id] = convertExternalToServiceMessage(message1)
 			const spy = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
-			const actual = writeMessage(message2)
+			const actual = writeMessage(convertExternalToServiceMessage(message2))
 
 			expect(actual).toHaveProperty('isUpdate', false)
 			spy.mockRestore()
@@ -134,7 +138,7 @@ describe('Service messages internal API', () => {
 			})
 			const spyGetCoreSystem = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
 
-			writeMessage(message2)
+			writeMessage(convertExternalToServiceMessage(message2))
 
 			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, { $set: { serviceMessages: expected } })
 			spyGetCoreSystem.mockRestore()
@@ -147,9 +151,9 @@ describe('Service messages internal API', () => {
 			const cs = Object.assign({}, fakeCoreSystem, {
 				serviceMessages: {},
 			})
-			cs.serviceMessages[message1.id] = message1
+			cs.serviceMessages[message1.id] = convertExternalToServiceMessage(message1)
 			const spy = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
-			const actual = writeMessage(message2)
+			const actual = writeMessage(convertExternalToServiceMessage(message2))
 
 			expect(CoreSystem.CoreSystem.update).toHaveBeenCalledWith(cs._id, { $set: { serviceMessages: expected } })
 			spy.mockRestore()
@@ -165,7 +169,7 @@ describe('Service messages internal API', () => {
 			const spyGetCoreSystem = jest.spyOn(CoreSystem, 'getCoreSystem').mockImplementation(() => cs)
 
 			expect(() => {
-				writeMessage(message2)
+				writeMessage(convertExternalToServiceMessage(message2))
 			}).toThrow()
 
 			spyGetCoreSystem.mockRestore()

--- a/meteor/server/api/serviceMessages/postHandler.ts
+++ b/meteor/server/api/serviceMessages/postHandler.ts
@@ -66,7 +66,7 @@ function postHandler(params, req: BodyParsingIncomingMessage, res: ServerRespons
 		criticality: Number(criticality),
 		message,
 		sender,
-		timestamp: new Date(timestamp),
+		timestamp: new Date(timestamp).getTime(),
 	} as ServiceMessage
 
 	try {

--- a/meteor/server/api/serviceMessages/serviceMessagesApi.ts
+++ b/meteor/server/api/serviceMessages/serviceMessagesApi.ts
@@ -1,7 +1,7 @@
 import { CoreSystem, getCoreSystem, ServiceMessage, ExternalServiceMessage } from '../../../lib/collections/CoreSystem'
 import { logger } from '../../logging'
 
-export { deleteMessage, readAllMessages, writeMessage, WriteStatus, convertExternalToServiceMessage }
+export { deleteMessage, readAllMessages, writeMessage, WriteStatus }
 
 interface WriteStatus {
 	isUpdate?: boolean
@@ -25,13 +25,6 @@ function readAllMessages(): Array<ServiceMessage> {
 	const messages = Object.keys(serviceMessages).map((key) => serviceMessages[key])
 
 	return messages
-}
-
-function convertExternalToServiceMessage(message: ExternalServiceMessage): ServiceMessage {
-	return {
-		...message,
-		timestamp: new Date(message.timestamp).getTime(),
-	}
 }
 
 /**

--- a/meteor/server/api/serviceMessages/serviceMessagesApi.ts
+++ b/meteor/server/api/serviceMessages/serviceMessagesApi.ts
@@ -1,7 +1,7 @@
-import { CoreSystem, getCoreSystem, ServiceMessage } from '../../../lib/collections/CoreSystem'
+import { CoreSystem, getCoreSystem, ServiceMessage, ExternalServiceMessage } from '../../../lib/collections/CoreSystem'
 import { logger } from '../../logging'
 
-export { deleteMessage, readAllMessages, writeMessage, WriteStatus }
+export { deleteMessage, readAllMessages, writeMessage, WriteStatus, convertExternalToServiceMessage }
 
 interface WriteStatus {
 	isUpdate?: boolean
@@ -25,6 +25,13 @@ function readAllMessages(): Array<ServiceMessage> {
 	const messages = Object.keys(serviceMessages).map((key) => serviceMessages[key])
 
 	return messages
+}
+
+function convertExternalToServiceMessage(message: ExternalServiceMessage): ServiceMessage {
+	return {
+		...message,
+		timestamp: new Date(message.timestamp).getTime(),
+	}
 }
 
 /**

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -1,4 +1,5 @@
 import { addMigrationSteps, CURRENT_SYSTEM_VERSION } from './databaseMigration'
+import { CoreSystem } from '../../lib/collections/CoreSystem'
 
 /*
  * **************************************************************************************
@@ -23,4 +24,34 @@ addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 	// 		//
 	// 	}
 	// },
+
+	{
+		id: 'Fix serviceMessages in CoreSystem',
+		canBeRunAutomatically: true,
+		validate: () => {
+			const core = CoreSystem.findOne()
+			if (core) {
+				for (let [key, message] of Object.entries(core.serviceMessages)) {
+					if (typeof message.timestamp === 'string') {
+						return true
+					}
+				}
+				return false
+			}
+			return false
+		},
+		migrate: () => {
+			const core = CoreSystem.findOne()
+			if (core) {
+				for (let [key, message] of Object.entries(core.serviceMessages)) {
+					if (typeof message.timestamp !== 'number') {
+						core.serviceMessages[key] = {
+							...message,
+							timestamp: new Date(message.timestamp).getTime(),
+						}
+					}
+				}
+			}
+		},
+	},
 ])


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix for a typing/database serialization issue with Service Messages.

* **What is the current behavior?** (You can also link to an open issue here)

At some points, there will be an Error message logged to console:
```TypeError: message.timestamp.getMilliseconds() is not a function```

* **What is the new behavior (if this is a feature change)?**

No error message should be thrown. Existing ServiceMessages should be upgraded by migrations.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
