### PR TITLE
Feat: Pad piece start when created by action

### DIFF
--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -269,6 +269,20 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			throw new Error(`Piece with id "${rawPiece._id}" already exists`)
 		}
 
+		const lastStartedPlayback = partInstance.part.getLastStartedPlayback()
+		if (part === 'current' && lastStartedPlayback !== undefined) {
+			const time = getCurrentTime()
+			const playheadTime = time - lastStartedPlayback
+
+			if (rawPiece.enable.start !== undefined && _.isNumber(rawPiece.enable.start)) {
+				rawPiece.enable.start += playheadTime
+			}
+
+			if (rawPiece.enable.end !== undefined && _.isNumber(rawPiece.enable.end)) {
+				rawPiece.enable.end += playheadTime
+			}
+		}
+
 		const trimmedPiece: IBlueprintPiece = _.pick(rawPiece, [...IBlueprintPieceSampleKeys, '_id'])
 
 		const piece = postProcessPieces(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This aims to change the behavior of the adLib action function `insertPiece` such that when you insert a piece into the currently playing part, it is inserted relative to the playhead position rather than the start of the part. i.e. a piece with `start: 0, end: 10` would become `start: 0 + playhead, end: 10 + playhead`.

* **Other information**:
Perhaps this should be behind a flag like `insertAtPlayhead: boolean`?

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
