### PR TITLE
Adlib actions in dashboard

### DIFF
--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -84,7 +84,7 @@ export const AdLibListItem = translateWithTracker<IListViewItemProps, {}, IAdLib
 				const piece = (this.props.adLibListItem as any) as AdLibPieceUi
 				let objId: string | undefined = undefined
 
-				if (piece.content) {
+				if (piece.content && piece.content.fileName) {
 					switch (this.props.layer.type) {
 						case SourceLayerType.VT:
 							objId = (piece.content as VTContent).fileName.toUpperCase()

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -628,6 +628,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 							_rank: action.display._rank || 0,
 							content: content,
 							adlibAction: action,
+							tags: action.display.tags,
 						}),
 					]
 				}),

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -711,30 +711,28 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 							sort: { sourceLayerId: 1, _rank: 1, name: 1 },
 						}
 					).fetch()
-					rundownBaselineAdLibs = rundownAdLibItems
-						.concat(
-							props.showStyleBase.sourceLayers
-								.filter((i) => i.isSticky)
-								.sort((a, b) => a._rank - b._rank)
-								.map((layer) =>
-									literal<AdLibPieceUi>({
-										_id: protectString(`sticky_${layer._id}`),
-										hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
-										name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
-										status: RundownAPI.PieceStatusCode.UNKNOWN,
-										isSticky: true,
-										isGlobal: true,
-										expectedDuration: 0,
-										disabled: false,
-										externalId: layer._id,
-										rundownId: protectString(''),
-										sourceLayerId: layer._id,
-										outputLayerId: '',
-										_rank: 0,
-									})
-								)
-						)
-						.sort((a, b) => a._rank - b._rank)
+					rundownBaselineAdLibs = rundownAdLibItems.concat(
+						props.showStyleBase.sourceLayers
+							.filter((i) => i.isSticky && i.activateStickyKeyboardHotkey)
+							.sort((a, b) => a._rank - b._rank)
+							.map((layer) =>
+								literal<AdLibPieceUi>({
+									_id: protectString(`sticky_${layer._id}`),
+									hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
+									name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
+									status: RundownAPI.PieceStatusCode.UNKNOWN,
+									isSticky: true,
+									isGlobal: true,
+									expectedDuration: 0,
+									disabled: false,
+									externalId: layer._id,
+									rundownId: protectString(''),
+									sourceLayerId: layer._id,
+									outputLayerId: '',
+									_rank: 0,
+								})
+							)
+					)
 
 					const globalAdLibActions = memoizedIsolatedAutorun(
 						(rundownIds, partIds) =>
@@ -815,7 +813,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 						})
 						.sort((a, b) => a._rank - b._rank)
 
-					return rundownBaselineAdLibs
+					return rundownBaselineAdLibs.sort((a, b) => a._rank - b._rank)
 				},
 				'rundownBaselineAdLibs',
 				currentRundown._id,

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -798,9 +798,10 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 										_rank: action.display._rank || 0,
 										content: content,
 										adlibAction: action,
+										tags: action.display.tags,
 									})
 								}),
-						'adLibActions',
+						'globalAdLibActions',
 						rundownIds,
 						partIds
 					)

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -645,6 +645,10 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 		}
 	})
 
+	uiPartSegmentMap.forEach((segment) => {
+		segment.pieces = segment.pieces.sort((a, b) => a._rank - b._rank)
+	})
+
 	if (liveSegment) {
 		liveSegment.pieces.forEach((item) => {
 			let sourceLayer = item.sourceLayerId && sourceLayerLookup[item.sourceLayerId]
@@ -707,28 +711,30 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 							sort: { sourceLayerId: 1, _rank: 1, name: 1 },
 						}
 					).fetch()
-					rundownBaselineAdLibs = rundownAdLibItems.concat(
-						props.showStyleBase.sourceLayers
-							.filter((i) => i.isSticky)
-							.sort((a, b) => a._rank - b._rank)
-							.map((layer) =>
-								literal<AdLibPieceUi>({
-									_id: protectString(`sticky_${layer._id}`),
-									hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
-									name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
-									status: RundownAPI.PieceStatusCode.UNKNOWN,
-									isSticky: true,
-									isGlobal: true,
-									expectedDuration: 0,
-									disabled: false,
-									externalId: layer._id,
-									rundownId: protectString(''),
-									sourceLayerId: layer._id,
-									outputLayerId: '',
-									_rank: 0,
-								})
-							)
-					)
+					rundownBaselineAdLibs = rundownAdLibItems
+						.concat(
+							props.showStyleBase.sourceLayers
+								.filter((i) => i.isSticky)
+								.sort((a, b) => a._rank - b._rank)
+								.map((layer) =>
+									literal<AdLibPieceUi>({
+										_id: protectString(`sticky_${layer._id}`),
+										hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
+										name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
+										status: RundownAPI.PieceStatusCode.UNKNOWN,
+										isSticky: true,
+										isGlobal: true,
+										expectedDuration: 0,
+										disabled: false,
+										externalId: layer._id,
+										rundownId: protectString(''),
+										sourceLayerId: layer._id,
+										outputLayerId: '',
+										_rank: 0,
+									})
+								)
+						)
+						.sort((a, b) => a._rank - b._rank)
 
 					const globalAdLibActions = memoizedIsolatedAutorun(
 						(rundownIds, partIds) =>
@@ -781,30 +787,33 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 						partIds
 					)
 
-					rundownBaselineAdLibs = rundownBaselineAdLibs.concat(globalAdLibActions).map((item) => {
-						// automatically assign hotkeys based on adLibItem index
-						const uiAdLib: AdLibPieceUi = _.clone(item)
-						uiAdLib.isGlobal = true
+					rundownBaselineAdLibs = rundownBaselineAdLibs
+						.concat(globalAdLibActions)
+						.map((item) => {
+							// automatically assign hotkeys based on adLibItem index
+							const uiAdLib: AdLibPieceUi = _.clone(item)
+							uiAdLib.isGlobal = true
 
-						let sourceLayer = item.sourceLayerId && sourceLayerLookup[item.sourceLayerId]
-						if (sourceLayer && sourceLayer.activateKeyboardHotkeys && sourceLayer.assignHotkeysToGlobalAdlibs) {
-							let keyboardHotkeysList = sourceLayer.activateKeyboardHotkeys.split(',')
-							const sourceHotKeyUseLayerId =
-								sharedHotkeyList[sourceLayer.activateKeyboardHotkeys][0]._id || item.sourceLayerId
-							if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length) {
-								uiAdLib.hotkey = keyboardHotkeysList[sourceHotKeyUse[sourceHotKeyUseLayerId] || 0]
-								// add one to the usage hash table
-								sourceHotKeyUse[sourceHotKeyUseLayerId] = (sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) + 1
+							let sourceLayer = item.sourceLayerId && sourceLayerLookup[item.sourceLayerId]
+							if (sourceLayer && sourceLayer.activateKeyboardHotkeys && sourceLayer.assignHotkeysToGlobalAdlibs) {
+								let keyboardHotkeysList = sourceLayer.activateKeyboardHotkeys.split(',')
+								const sourceHotKeyUseLayerId =
+									sharedHotkeyList[sourceLayer.activateKeyboardHotkeys][0]._id || item.sourceLayerId
+								if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length) {
+									uiAdLib.hotkey = keyboardHotkeysList[sourceHotKeyUse[sourceHotKeyUseLayerId] || 0]
+									// add one to the usage hash table
+									sourceHotKeyUse[sourceHotKeyUseLayerId] = (sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) + 1
+								}
 							}
-						}
 
-						if (sourceLayer && sourceLayer.isHidden) {
-							uiAdLib.isHidden = true
-						}
+							if (sourceLayer && sourceLayer.isHidden) {
+								uiAdLib.isHidden = true
+							}
 
-						// always add them to the list
-						return uiAdLib
-					})
+							// always add them to the list
+							return uiAdLib
+						})
+						.sort((a, b) => a._rank - b._rank)
 
 					return rundownBaselineAdLibs
 				},

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -707,53 +707,28 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 							sort: { sourceLayerId: 1, _rank: 1, name: 1 },
 						}
 					).fetch()
-					rundownBaselineAdLibs = rundownAdLibItems
-						.map((item) => {
-							// automatically assign hotkeys based on adLibItem index
-							const uiAdLib: AdLibPieceUi = _.clone(item)
-							uiAdLib.isGlobal = true
-
-							let sourceLayer = item.sourceLayerId && sourceLayerLookup[item.sourceLayerId]
-							if (sourceLayer && sourceLayer.activateKeyboardHotkeys && sourceLayer.assignHotkeysToGlobalAdlibs) {
-								let keyboardHotkeysList = sourceLayer.activateKeyboardHotkeys.split(',')
-								const sourceHotKeyUseLayerId =
-									sharedHotkeyList[sourceLayer.activateKeyboardHotkeys][0]._id || item.sourceLayerId
-								if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length) {
-									uiAdLib.hotkey = keyboardHotkeysList[sourceHotKeyUse[sourceHotKeyUseLayerId] || 0]
-									// add one to the usage hash table
-									sourceHotKeyUse[sourceHotKeyUseLayerId] = (sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) + 1
-								}
-							}
-
-							if (sourceLayer && sourceLayer.isHidden) {
-								uiAdLib.isHidden = true
-							}
-
-							// always add them to the list
-							return uiAdLib
-						})
-						.concat(
-							props.showStyleBase.sourceLayers
-								.filter((i) => i.isSticky)
-								.sort((a, b) => a._rank - b._rank)
-								.map((layer) =>
-									literal<AdLibPieceUi>({
-										_id: protectString(`sticky_${layer._id}`),
-										hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
-										name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
-										status: RundownAPI.PieceStatusCode.UNKNOWN,
-										isSticky: true,
-										isGlobal: true,
-										expectedDuration: 0,
-										disabled: false,
-										externalId: layer._id,
-										rundownId: protectString(''),
-										sourceLayerId: layer._id,
-										outputLayerId: '',
-										_rank: 0,
-									})
-								)
-						)
+					rundownBaselineAdLibs = rundownAdLibItems.concat(
+						props.showStyleBase.sourceLayers
+							.filter((i) => i.isSticky)
+							.sort((a, b) => a._rank - b._rank)
+							.map((layer) =>
+								literal<AdLibPieceUi>({
+									_id: protectString(`sticky_${layer._id}`),
+									hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
+									name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
+									status: RundownAPI.PieceStatusCode.UNKNOWN,
+									isSticky: true,
+									isGlobal: true,
+									expectedDuration: 0,
+									disabled: false,
+									externalId: layer._id,
+									rundownId: protectString(''),
+									sourceLayerId: layer._id,
+									outputLayerId: '',
+									_rank: 0,
+								})
+							)
+					)
 
 					const globalAdLibActions = memoizedIsolatedAutorun(
 						(rundownIds, partIds) =>
@@ -806,7 +781,30 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 						partIds
 					)
 
-					rundownBaselineAdLibs = rundownBaselineAdLibs.concat(globalAdLibActions)
+					rundownBaselineAdLibs = rundownBaselineAdLibs.concat(globalAdLibActions).map((item) => {
+						// automatically assign hotkeys based on adLibItem index
+						const uiAdLib: AdLibPieceUi = _.clone(item)
+						uiAdLib.isGlobal = true
+
+						let sourceLayer = item.sourceLayerId && sourceLayerLookup[item.sourceLayerId]
+						if (sourceLayer && sourceLayer.activateKeyboardHotkeys && sourceLayer.assignHotkeysToGlobalAdlibs) {
+							let keyboardHotkeysList = sourceLayer.activateKeyboardHotkeys.split(',')
+							const sourceHotKeyUseLayerId =
+								sharedHotkeyList[sourceLayer.activateKeyboardHotkeys][0]._id || item.sourceLayerId
+							if ((sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) < keyboardHotkeysList.length) {
+								uiAdLib.hotkey = keyboardHotkeysList[sourceHotKeyUse[sourceHotKeyUseLayerId] || 0]
+								// add one to the usage hash table
+								sourceHotKeyUse[sourceHotKeyUseLayerId] = (sourceHotKeyUse[sourceHotKeyUseLayerId] || 0) + 1
+							}
+						}
+
+						if (sourceLayer && sourceLayer.isHidden) {
+							uiAdLib.isHidden = true
+						}
+
+						// always add them to the list
+						return uiAdLib
+					})
 
 					return rundownBaselineAdLibs
 				},

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -95,7 +95,12 @@ export class AdLibRegionPanelInner extends MeteorReactComponent<
 		const currentPartInstanceId = this.props.playlist.currentPartInstanceId
 
 		if ((!this.isAdLibOnAir(piece) || queueWhenOnAir) && this.props.playlist && currentPartInstanceId) {
-			if (!piece.isGlobal) {
+			if (piece.isAction && piece.adlibAction) {
+				const action = piece.adlibAction
+				doUserAction(t, e, piece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB, (e) =>
+					MeteorCall.userAction.executeAction(e, this.props.playlist._id, action.actionId, action.userData)
+				)
+			} else if (!piece.isGlobal && !piece.isAction) {
 				doUserAction(t, e, UserAction.START_ADLIB, (e) =>
 					MeteorCall.userAction.segmentAdLibPieceStart(
 						e,

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -421,7 +421,12 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		if (this.props.playlist && this.props.playlist.currentPartInstanceId) {
 			const currentPartInstanceId = this.props.playlist.currentPartInstanceId
 			if (!this.isAdLibOnAir(adlibPiece) || !(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
-				if (!adlibPiece.isGlobal) {
+				if (adlibPiece.isAction && adlibPiece.adlibAction) {
+					const action = adlibPiece.adlibAction
+					doUserAction(t, e, adlibPiece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB, (e) =>
+						MeteorCall.userAction.executeAction(e, this.props.playlist._id, action.actionId, action.userData)
+					)
+				} else if (!adlibPiece.isGlobal && !adlibPiece.isAction) {
 					doUserAction(t, e, UserAction.START_ADLIB, (e) =>
 						MeteorCall.userAction.segmentAdLibPieceStart(
 							e,

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -80,7 +80,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 			const piece = (this.props.adLibListItem as any) as AdLibPieceUi
 			let objId: string | undefined = undefined
 
-			if (piece.content) {
+			if (piece.content && piece.content.fileName) {
 				switch (this.props.layer.type) {
 					case SourceLayerType.VT:
 						objId = (piece.content as VTContent).fileName.toUpperCase()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR includes a number of changes to allow adLib actions to display and be executed withing dashboard layouts.

Changes include:
- Copying tags for adLib actions
- Fixed a bug where two memoizedIsolatedAutorun functions had the same name but different return types causing dashboards to crash
- Call the correct user action when taking an adLib action from a dashboard
- Sort adLibs and actions together according to rank

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
