### PR TITLE
Allow adlib actions to call take

### DIFF
--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -129,6 +129,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 	public currentPartState: ActionPartChange = ActionPartChange.NONE
 	/** To be set by any mutation methods on this context. Indicates to core how extensive the changes are to the next partInstance */
 	public nextPartState: ActionPartChange = ActionPartChange.NONE
+	public takeAfterExecute: boolean
 
 	constructor(
 		cache: CacheForRundownPlaylist,
@@ -141,6 +142,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 		this.cache = cache
 		this.rundownPlaylist = rundownPlaylist
 		this.rundown = rundown
+		this.takeAfterExecute = false
 	}
 
 	private _getPartInstanceId(part: 'current' | 'next'): PartInstanceId | null {
@@ -450,6 +452,12 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			(pieceInstance) => pieceInstanceIds.indexOf(unprotectString(pieceInstance._id)) !== -1,
 			timeOffset
 		)
+	}
+
+	takeAfterExecuteAction(take: boolean): boolean {
+		this.takeAfterExecute = take
+
+		return this.takeAfterExecute
 	}
 
 	private _stopPiecesByRule(filter: (pieceInstance: PieceInstance) => boolean, timeOffset: number | undefined) {

--- a/meteor/server/api/playout/__tests__/playout-executeAction.test.ts
+++ b/meteor/server/api/playout/__tests__/playout-executeAction.test.ts
@@ -393,6 +393,10 @@ describe('Playout API', () => {
 		})
 
 		testInFiber('take after execute', () => {
+			const api = ServerPlayoutAPI
+			const mockTake = jest.fn().mockReturnThis()
+			api.takeNextpartInner = mockTake
+
 			const BLUEPRINT_TYPE = BlueprintManifestType.SHOWSTYLE
 			const STATE_NONE = ActionPartChange.NONE
 			const STATE_SAFE = ActionPartChange.SAFE_CHANGE
@@ -423,9 +427,11 @@ describe('Playout API', () => {
 
 			const actionId = 'some-action'
 			const userData = { blobby: true }
-			ServerPlayoutAPI.executeAction(playlistId, actionId, userData)
+			api.executeAction(playlistId, actionId, userData)
 
-			expect(updateTimelineMock).toHaveBeenCalledTimes(1)
+			const timesTakeCalled = mockTake.mock.calls.length
+			mockTake.mockRestore()
+			expect(timesTakeCalled).toBe(1)
 		})
 	})
 })

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -314,7 +314,7 @@ export namespace ServerPlayoutAPI {
 		})
 	}
 
-	function takeNextpartInner(rundownPlaylistId: RundownPlaylistId, existingCache?: CacheForRundownPlaylist) {
+	export function takeNextpartInner(rundownPlaylistId: RundownPlaylistId, existingCache?: CacheForRundownPlaylist) {
 		let now = getCurrentTime()
 
 		let playlist = RundownPlaylists.findOne(rundownPlaylistId)
@@ -1485,7 +1485,7 @@ export namespace ServerPlayoutAPI {
 			}
 
 			if (context.takeAfterExecute) {
-				return takeNextpartInner(rundownPlaylistId, cache)
+				return ServerPlayoutAPI.takeNextpartInner(rundownPlaylistId, cache)
 			} else {
 				if (
 					context.currentPartState !== ActionPartChange.NONE ||

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1491,7 +1491,7 @@ export namespace ServerPlayoutAPI {
 		})
 
 		if (takeAfterExecute) {
-			Meteor.call(UserActionAPIMethods.take, 'e', rundownPlaylistId)
+			ServerPlayoutAPI.takeNextPart(rundownPlaylistId)
 		}
 	}
 	export function sourceLayerOnPartStop(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This adds the function `takeAfterExecuteAction` which sets a flag on the action execution context of a given action. If this flag is set after the action has finished executing, take will be called.

Currently, the flag is set to the boolean value passed to `takeAfterExecuteAction` directly, allowing an action to request a take and then retract this request later in its execution. The value of the flag is returned to the caller, so if safety checks are added in the future an action can react to being unable to take.

* **Other information**:
Requires https://github.com/nrkno/tv-automation-sofie-blueprints-integration/pull/70

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
