### PR TITLE
fix: Hide script line when source duration is undefined

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1762,7 +1762,7 @@ body.no-overflow {
 					box-shadow: 0px 0px 1px 1px rgba(0, 30, 0, 0.18);
 
 					&.hidden {
-						opacity: 0;
+						display: none;
 					}
 				}
 			}

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1760,6 +1760,10 @@ body.no-overflow {
 					border-left: 2px dotted $segment-layer-background-mic;
 					margin-left: -2px;
 					box-shadow: 0px 0px 1px 1px rgba(0, 30, 0, 0.18);
+
+					&.hidden {
+						opacity: 0;
+					}
 				}
 			}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -38,6 +38,14 @@ export const MicSourceRenderer = withTranslation()(
 			this.lineItem.style.left = this.linePosition + 'px'
 		}
 
+		addClassToLine = (className: string) => {
+			this.lineItem.classList.add(className)
+		}
+
+		removeClassFromLine = (className: string) => {
+			this.lineItem.classList.remove(className)
+		}
+
 		refreshLine = () => {
 			if (this.itemElement) {
 				this.itemPosition = this.itemElement.offsetLeft
@@ -46,16 +54,22 @@ export const MicSourceRenderer = withTranslation()(
 				if (content && content.sourceDuration) {
 					scriptReadTime = content.sourceDuration * this.props.timeScale
 					this.readTime = content.sourceDuration
+					const positionByReadTime = this.itemPosition + scriptReadTime
+					const positionByPartEnd = this.props.partDuration * this.props.timeScale
+					const positionByExpectedPartEnd =
+						(this.props.part.instance.part.expectedDuration || this.props.partDuration) * this.props.timeScale
+					if (positionByReadTime !== this.linePosition) {
+						this.linePosition = Math.min(positionByReadTime, positionByPartEnd)
+						this.repositionLine()
+						if (Math.abs(positionByReadTime - positionByExpectedPartEnd) <= 1) {
+							this.addClassToLine('at-end')
+						} else {
+							this.removeClassFromLine('at-end')
+						}
+					}
+					this.removeClassFromLine('hidden')
 				} else {
-					scriptReadTime = getElementWidth(this.itemElement)
-				}
-
-				if (this.itemPosition + scriptReadTime !== this.linePosition) {
-					this.linePosition = Math.min(
-						this.itemPosition + scriptReadTime,
-						this.props.partDuration * this.props.timeScale
-					)
-					this.repositionLine()
+					this.addClassToLine('hidden')
 				}
 			}
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When the duration of a script piece is set to undefined, the "end of script" line is hidden. This also adds a class ('at-end') when the end of script line is positioned at the end of a part, which is used by TV 2 to hide the line in this case through custom css not included in this PR. The use case is parts where the script is Out On Next Part and the duration of the script is either not known, or is tied directly to the duration of the part - so will be expected to be the same duration as the part.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
