### PR TITLE
fix: measure HEADER_HEIGHT value for viewPort intersection and scrollTo

### DIFF
--- a/meteor/client/lib/viewPort.ts
+++ b/meteor/client/lib/viewPort.ts
@@ -90,8 +90,21 @@ export async function scrollToPart(partId: PartId, forceScroll?: boolean, noAnim
 	return Promise.reject('Could not find part')
 }
 
-export const HEADER_HEIGHT = 150 // TV2 has: 54
-export const HEADER_MARGIN = 15
+const FALLBACK_HEADER_HEIGHT = 150
+let HEADER_HEIGHT: number | undefined = undefined
+export const HEADER_MARGIN = 25
+
+export function getHeaderHeight(): number {
+	if (HEADER_HEIGHT === undefined) {
+		const root = document.querySelector('#render-target > .container-fluid > .rundown-view > .header')
+		if (!root) {
+			return FALLBACK_HEADER_HEIGHT
+		}
+		const { height } = root.getBoundingClientRect()
+		HEADER_HEIGHT = height
+	}
+	return HEADER_HEIGHT
+}
 
 export function scrollToSegment(
 	elementToScrollToOrSegmentId: HTMLElement | SegmentId,
@@ -114,7 +127,7 @@ export function scrollToSegment(
 	if (
 		forceScroll ||
 		bottom > window.scrollY + window.innerHeight ||
-		top < window.scrollY + HEADER_HEIGHT + HEADER_MARGIN
+		top < window.scrollY + getHeaderHeight() + HEADER_MARGIN
 	) {
 		return scrollToPosition(top, noAnimation).then(() => true)
 	}
@@ -126,7 +139,7 @@ export function scrollToPosition(scrollPosition: number, noAnimation?: boolean):
 	if (noAnimation) {
 		return new Promise((resolve, reject) => {
 			window.scroll({
-				top: Math.max(0, scrollPosition - HEADER_HEIGHT - HEADER_MARGIN),
+				top: Math.max(0, scrollPosition - getHeaderHeight() - HEADER_MARGIN),
 				left: 0,
 			})
 			resolve()
@@ -136,7 +149,7 @@ export function scrollToPosition(scrollPosition: number, noAnimation?: boolean):
 			window.requestIdleCallback(
 				() => {
 					window.scroll({
-						top: Math.max(0, scrollPosition - HEADER_HEIGHT - HEADER_MARGIN),
+						top: Math.max(0, scrollPosition - getHeaderHeight() - HEADER_MARGIN),
 						left: 0,
 						behavior: 'smooth',
 					})

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -21,7 +21,7 @@ import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { SpeechSynthesiser } from '../../lib/speechSynthesis'
 import { NoteType, SegmentNote } from '../../../lib/api/notes'
 import { getElementWidth } from '../../utils/dimensions'
-import { isMaintainingFocus, scrollToSegment, HEADER_HEIGHT } from '../../lib/viewPort'
+import { isMaintainingFocus, scrollToSegment, getHeaderHeight } from '../../lib/viewPort'
 import { PubSub } from '../../../lib/api/pubsub'
 import { unprotectString } from '../../../lib/lib'
 import { RundownUtils } from '../../lib/rundown'
@@ -580,7 +580,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 				// As of Chrome 76, IntersectionObserver rootMargin works in screen pixels when root
 				// is viewport. This seems like an implementation bug and IntersectionObserver is
 				// an Experimental Feature in Chrome, so this might change in the future.
-				rootMargin: `-${HEADER_HEIGHT * zoomFactor}px 0px -${20 * zoomFactor}px 0px`,
+				rootMargin: `-${getHeaderHeight() * zoomFactor}px 0px -${20 * zoomFactor}px 0px`,
 				threshold: [0, 0.25, 0.5, 0.75, 0.98],
 			})
 			this.intersectionObserver.observe(this.timelineDiv.parentElement!.parentElement!)


### PR DESCRIPTION

* **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Does not use a hard-coded value for Header height, but instead attempts to measure it from the DOM.

* **What is the current behavior? (You can also link to an open issue here)**

The header height is a hard-coded constant, thus causing some problems with Follow On Air (broadly speaking).

* **What is the new behavior (if this is a feature change)?**

The height of the header is measured when it's first used, allowing customizations of the header to not affect "Follow On Air".
* **Other Information:**
Original author @jstarpl 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
