### PR TITLE
feat: Show bucket setting

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2427,6 +2427,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 										onChangeBottomMargin={this.onChangeBottomMargin}
 										onRegisterHotkeys={this.onRegisterHotkeys}
 										rundownLayout={this.state.rundownLayout}
+										showBuckets={this.state.rundownLayout && this.state.rundownLayout.showBuckets}
 									/>
 								</ErrorBoundary>
 								<ErrorBoundary>
@@ -2470,6 +2471,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								onRegisterHotkeys={this.onRegisterHotkeys}
 								rundownLayout={this.state.rundownLayout}
 								fullViewport={true}
+								showBuckets={this.state.rundownLayout && this.state.rundownLayout.showBuckets}
 							/>
 						</ErrorBoundary>
 					)

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -1080,6 +1080,19 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 
 			return (
 				<React.Fragment>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Show Buckets')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={'showBuckets'}
+								obj={item}
+								options={RundownLayoutType}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"></EditAttribute>
+						</label>
+					</div>
 					<h4 className="mod mhs">{isRundownLayout ? t('Tabs') : isDashboardLayout ? t('Panels') : null}</h4>
 					{item.filters.map((tab, index) => (
 						<div className="rundown-layout-editor-filter mod pan mas" key={tab._id}>

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -45,6 +45,7 @@ export interface IShelfProps extends React.ComponentPropsWithRef<any> {
 	}>
 	rundownLayout?: RundownLayoutBase
 	fullViewport?: boolean
+	showBuckets: boolean
 
 	onChangeExpanded: (value: boolean) => void
 	onRegisterHotkeys: (
@@ -483,14 +484,16 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 							)}
 						</ErrorBoundary>
 					</ContextMenuTrigger>
-					<ErrorBoundary>
-						<RundownViewBuckets
-							buckets={this.props.buckets}
-							playlist={this.props.playlist}
-							shouldQueue={this.state.shouldQueue}
-							showStyleBase={this.props.showStyleBase}
-						/>
-					</ErrorBoundary>
+					{this.props.showBuckets && (
+						<ErrorBoundary>
+							<RundownViewBuckets
+								buckets={this.props.buckets}
+								playlist={this.props.playlist}
+								shouldQueue={this.state.shouldQueue}
+								showStyleBase={this.props.showStyleBase}
+							/>
+						</ErrorBoundary>
+					)}
 					<ErrorBoundary>
 						<ShelfInspector selected={this.state.selectedPiece} showStyleBase={this.props.showStyleBase} />
 					</ErrorBoundary>

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -137,6 +137,7 @@ export interface RundownLayoutBase {
 	name: string
 	type: RundownLayoutType.RUNDOWN_LAYOUT | RundownLayoutType.DASHBOARD_LAYOUT
 	filters: RundownLayoutElementBase[]
+	showBuckets: boolean
 }
 
 export interface RundownLayout extends RundownLayoutBase {

--- a/meteor/server/api/rundownLayouts.ts
+++ b/meteor/server/api/rundownLayouts.ts
@@ -22,7 +22,8 @@ export function createRundownLayout(
 	type: RundownLayoutType,
 	showStyleBaseId: ShowStyleBaseId,
 	blueprintId: BlueprintId | undefined,
-	userId?: string | undefined
+	userId?: string | undefined,
+	showBuckets?: boolean
 ) {
 	const id: RundownLayoutId = getRandomId()
 	RundownLayouts.insert(
@@ -34,6 +35,7 @@ export function createRundownLayout(
 			filters: [],
 			type,
 			userId,
+			showBuckets: showBuckets === undefined ? true : showBuckets,
 		})
 	)
 	return id


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This adds a setting to the rundown layout editor to allow buckets to be hidden per shelf layout. This is because some dashboard layouts require the use of the full screen. Buckets are shown by default.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
