### PR TITLE
fix: race condition in refresh part function

### DIFF
--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -867,10 +867,10 @@ function updateRundownFromIngestData(
 				logger.debug(adLibPiece)
 			},
 			afterUpdate(adLibPiece) {
-				logger.debug('updated piece ' + adLibPiece._id)
+				logger.debug('updated adLibPiece ' + adLibPiece._id)
 			},
 			afterRemove(adLibPiece) {
-				logger.debug('deleted piece ' + adLibPiece._id)
+				logger.debug('deleted adLibPiece ' + adLibPiece._id)
 			},
 		}),
 		savePreparedChangesIntoCache<Part, DBPart>(prepareSaveParts, cache.Parts, {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -82,7 +82,9 @@ export function resetRundown(cache: CacheForRundownPlaylist, rundown: Rundown) {
 
 	const dirtyParts = cache.Parts.findFetch({ rundownId: rundown._id, dirty: true })
 
-	refreshParts(cache, dirtyParts)
+	const playlist = cache.RundownPlaylists.findOne(rundown.playlistId)
+	if (!playlist) throw new Meteor.Error(404, `RundownPlaylist "${rundown.playlistId}" not found in resetRundown`)
+	refreshParts(cache, playlist, dirtyParts)
 
 	// Reset all pieces that were modified for holds
 	cache.Pieces.update(
@@ -239,7 +241,7 @@ export function resetRundownPlaylist(cache: CacheForRundownPlaylist, rundownPlay
 		},
 		dirty: true,
 	})
-	refreshParts(cache, dirtyParts)
+	refreshParts(cache, rundownPlaylist, dirtyParts)
 
 	// Reset all pieces that were modified for holds
 	cache.Pieces.update(
@@ -372,22 +374,30 @@ export function getPreviousPart(cache: CacheForRundownPlaylist, partToCheck: Par
 	}
 	return previousPart
 }
-export function refreshParts(cache: CacheForRundownPlaylist, parts: Part[]) {
-	const ps: Promise<any>[] = []
-	parts.forEach((part) => {
-		const rundown = cache.Rundowns.findOne(part.rundownId)
-		if (!rundown) throw new Meteor.Error(404, `Rundown "${part.rundownId}" not found in refreshParts`)
-		ps.push(
-			refreshPart(cache, rundown, part).then(() => {
-				cache.Parts.update(part._id, {
-					$unset: {
-						dirty: 1,
-					},
-				})
-			})
-		)
-	})
-	waitForPromiseAll(ps)
+export function refreshParts(cache: CacheForRundownPlaylist, playlist: RundownPlaylist, parts: Part[]) {
+	if (parts.length > 0) {
+		const studio = cache.Studios.findOne(playlist.studioId)
+		if (!studio) throw new Meteor.Error(404, `Studio ${playlist.studioId} was not found`)
+
+		const segmentIds = _.uniq(parts.map((p) => p.segmentId))
+		const segments = cache.Segments.findFetch({ _id: { $in: segmentIds } })
+		const groupedSegments = _.groupBy(segments, (s) => s.rundownId)
+
+		const ps = _.map(groupedSegments, async (segments) => {
+			const rundownId = segments[0].rundownId
+			const rundown = cache.Rundowns.findOne(rundownId)
+			if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownId}" not found in refreshParts`)
+
+			const pIngestSegments = segments.map((segment) =>
+				makePromise(() =>
+					loadCachedIngestSegment(rundown._id, rundown.externalId, segment._id, segment.externalId)
+				)
+			)
+			const ingestSegments = await Promise.all(pIngestSegments)
+			updateSegmentsFromIngestData(cache, studio, playlist, rundown, ingestSegments)
+		})
+		waitForPromiseAll(ps)
+	}
 }
 export async function refreshPart(cache: CacheForRundownPlaylist, rundown: Rundown, part: Part) {
 	// TODO:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a bug where `refreshParts` would cause a data race and crash.


* **What is the current behavior?** (You can also link to an open issue here)
The `_initialize` function is called once for every part that is being refreshed.


* **What is the new behavior (if this is a feature change)?**
The `_initialize` should be called once per segment that is affected by the refresh. There is also a lock placed on `_initialize` so that subsequent calls wait for previous to finish executing to avoid data races.


* **Other information**:
CC @Julusian 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
