### PR TITLE
feat: elastic APM tracing

### DIFF
--- a/meteor/.meteor/packages
+++ b/meteor/.meteor/packages
@@ -36,3 +36,4 @@ ostrio:meteor-root
 underscore@1.0.10
 #mdg:validated-method
 accounts-password
+kschingiz:meteor-elastic-apm

--- a/meteor/.meteor/versions
+++ b/meteor/.meteor/versions
@@ -33,9 +33,12 @@ geojson-utils@1.0.10
 hot-code-push@1.0.4
 html-tools@1.0.11
 htmljs@1.0.11
+http@1.4.2
 hwillson:stub-collections@1.0.8
 id-map@1.1.0
 inter-process-messaging@0.1.1
+kschingiz:meteor-elastic-apm@2.4.0
+kschingiz:meteor-measured@1.0.3
 launch-screen@1.2.0
 livedata@1.0.18
 localstorage@1.2.0
@@ -55,6 +58,7 @@ mongo@1.10.0
 mongo-decimal@0.1.1
 mongo-dev-server@1.1.0
 mongo-id@1.0.7
+mongo-livedata@1.0.12
 nerdmed:catiline@0.0.1
 npm-bcrypt@0.9.3
 npm-mongo@3.7.1
@@ -86,5 +90,6 @@ tmeasday:check-npm-versions@0.3.2
 tracker@1.2.0
 typescript@3.7.6
 underscore@1.0.10
+url@1.3.1
 webapp@1.9.1
 webapp-hashing@1.0.9

--- a/meteor/__mocks__/_setupMocks.ts
+++ b/meteor/__mocks__/_setupMocks.ts
@@ -17,6 +17,9 @@ jest.mock('meteor/accounts-base', (...args) => require('./accounts-base').setup(
 
 jest.mock('meteor/meteorhacks:picker', (...args) => require('./meteorhacks-picker').setup(args), { virtual: true })
 jest.mock('meteor/mdg:validated-method', (...args) => require('./validated-method').setup(args), { virtual: true })
+jest.mock('meteor/kschingiz:meteor-elastic-apm', (...args) => require('./meteor-elastic-apm').setup(args), {
+	virtual: true,
+})
 
 jest.mock('meteor/mongo', (...args) => require('./mongo').setup(args), { virtual: true })
 

--- a/meteor/__mocks__/meteor-elastic-apm.ts
+++ b/meteor/__mocks__/meteor-elastic-apm.ts
@@ -1,0 +1,18 @@
+export class Agent {
+	start() {
+		return undefined
+	}
+	startSpan() {
+		return undefined
+	}
+	startTransaction() {
+		return undefined
+	}
+}
+
+export function setup() {
+	return {
+		__esModule: true,
+		default: new Agent(),
+	}
+}

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -16,7 +16,7 @@ import DeviceSettings from './Settings/DeviceSettings'
 import ShowStyleSettings from './Settings/ShowStyleBaseSettings'
 import SnapshotsView from './Settings/SnapshotsView'
 import BlueprintSettings from './Settings/BlueprintSettings'
-import SystemMessages from './Settings/SystemMessages'
+import SystemManagement from './Settings/SystemManagement'
 import { NotificationCenter, Notification, NoticeLevel } from '../lib/notifications/notifications'
 
 import { faPlus, faTrash, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
@@ -417,8 +417,8 @@ const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMenuState
 							<NavLink
 								activeClassName="selectable-selected"
 								className="settings-menu__settings-menu-item selectable clickable"
-								to="/settings/tools/messages">
-								<h3>{t('System Messages')}</h3>
+								to="/settings/tools/system">
+								<h3>{t('System management')}</h3>
 							</NavLink>
 							<NavLink
 								activeClassName="selectable-selected"
@@ -487,7 +487,7 @@ export const Settings = withTranslation()(
 										/>
 										<Route path="/settings/tools/snapshots" component={SnapshotsView} />
 										<Route path="/settings/tools/migration" component={MigrationView} />
-										<Route path="/settings/tools/messages" component={SystemMessages} />
+										<Route path="/settings/tools/system" component={SystemManagement} />
 										<Redirect to="/settings" />
 									</Switch>
 								</ErrorBoundary>

--- a/meteor/client/ui/Settings.tsx
+++ b/meteor/client/ui/Settings.tsx
@@ -418,7 +418,7 @@ const SettingsMenu = translateWithTracker<ISettingsMenuProps, ISettingsMenuState
 								activeClassName="selectable-selected"
 								className="settings-menu__settings-menu-item selectable clickable"
 								to="/settings/tools/system">
-								<h3>{t('System management')}</h3>
+								<h3>{t('Core System settings')}</h3>
 							</NavLink>
 							<NavLink
 								activeClassName="selectable-selected"

--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -16,7 +16,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 		coreSystem: CoreSystem.findOne(),
 	}
 })(
-	class SystemMessages extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
+	class SystemManagement extends MeteorReactComponent<Translated<IProps & ITrackedProps>> {
 		componentDidMount() {
 			meteorSubscribe(PubSub.coreSystem, null)
 		}
@@ -41,6 +41,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 								<span className="mdfx"></span>
 							</div>
 						</label>
+
 						<h2 className="mhn mtn">{t('System-wide Notification Message')}</h2>
 						<label className="field">
 							{t('Message')}
@@ -66,6 +67,7 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 									collection={CoreSystem}></EditAttribute>
 							</div>
 						</div>
+
 						<h2 className="mhn">{t('Edit Support Panel')}</h2>
 						<label className="field">
 							{t('HTML that will be shown in the Support Panel')}
@@ -75,6 +77,32 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 									attribute="support.message"
 									obj={this.props.coreSystem}
 									type="multiline"
+									collection={CoreSystem}
+									className="mdinput"
+								/>
+								<span className="mdfx"></span>
+							</div>
+						</label>
+
+						<h2 className="mhn">{t('Application Performance Monitoring')}</h2>
+						<div className="field">
+							{t('Enabled')}
+							<div className="mdi">
+								<EditAttribute
+									attribute="apm.enabled"
+									obj={this.props.coreSystem}
+									type="checkbox"
+									collection={CoreSystem}></EditAttribute>
+							</div>
+						</div>
+						<label className="field">
+							{t('Transaction Sample Rate')}
+							<div className="mdi">
+								<EditAttribute
+									modifiedClassName="bghl"
+									attribute="apm.transactionSampleRate"
+									obj={this.props.coreSystem}
+									type="text"
 									collection={CoreSystem}
 									className="mdinput"
 								/>

--- a/meteor/client/ui/Settings/SystemManagement.tsx
+++ b/meteor/client/ui/Settings/SystemManagement.tsx
@@ -102,12 +102,20 @@ export default translateWithTracker<IProps, {}, ITrackedProps>((props: IProps) =
 									modifiedClassName="bghl"
 									attribute="apm.transactionSampleRate"
 									obj={this.props.coreSystem}
-									type="text"
+									type="float"
 									collection={CoreSystem}
 									className="mdinput"
 								/>
 								<span className="mdfx"></span>
 							</div>
+							<div>
+								(
+								{t(
+									'How many of the transactions to monitor. Set to -1 to log nothing (max performance), 0.5 to log 50% of the transactions, 1 to log all transactions'
+								)}
+								)
+							</div>
+							<div>{t('Note: Core needs to be restarted to apply these settings')}</div>
 						</label>
 					</div>
 				</div>

--- a/meteor/lib/__tests__/lib.test.ts
+++ b/meteor/lib/__tests__/lib.test.ts
@@ -30,6 +30,7 @@ import {
 	protectString,
 	mongoFindOptions,
 	ProtectedString,
+	SaveIntoDbOptions,
 } from '../lib'
 import { Timeline, TimelineObjType, TimelineObjGeneric } from '../collections/Timeline'
 import { TSR } from 'tv-automation-sofie-blueprints-integration'
@@ -108,7 +109,7 @@ describe('lib/lib', () => {
 			studioId: protectString('myStudio2'),
 		})
 
-		const options = {
+		const options: SaveIntoDbOptions<any, any> = {
 			beforeInsert: jest.fn((o) => o),
 			beforeUpdate: jest.fn((o, pre) => o),
 			beforeRemove: jest.fn((o) => o),
@@ -116,15 +117,15 @@ describe('lib/lib', () => {
 			// insert: jest.fn((o) => o),
 			// update: jest.fn((id, o,) => { return undefined }),
 			// remove: jest.fn((o) => { return undefined }),
-			afterInsert: jest.fn((o) => {
-				return undefined
-			}),
-			afterUpdate: jest.fn((o) => {
-				return undefined
-			}),
-			afterRemove: jest.fn((o) => {
-				return undefined
-			}),
+			// afterInsert: jest.fn((o) => {
+			// 	return undefined
+			// }),
+			// afterUpdate: jest.fn((o) => {
+			// 	return undefined
+			// }),
+			// afterRemove: jest.fn((o) => {
+			// 	return undefined
+			// }),
 		}
 
 		const changes = saveIntoDb(
@@ -184,9 +185,9 @@ describe('lib/lib', () => {
 		// expect(options.insert).toHaveBeenCalledTimes(1)
 		// expect(options.update).toHaveBeenCalledTimes(1)
 		// expect(options.remove).toHaveBeenCalledTimes(1)
-		expect(options.afterInsert).toHaveBeenCalledTimes(1)
-		expect(options.afterUpdate).toHaveBeenCalledTimes(1)
-		expect(options.afterRemove).toHaveBeenCalledTimes(1)
+		// expect(options.afterInsert).toHaveBeenCalledTimes(1)
+		// expect(options.afterUpdate).toHaveBeenCalledTimes(1)
+		// expect(options.afterRemove).toHaveBeenCalledTimes(1)
 
 		expect(changes).toMatchObject({
 			added: 1,

--- a/meteor/lib/collections/CoreSystem.ts
+++ b/meteor/lib/collections/CoreSystem.ts
@@ -79,7 +79,14 @@ export interface ICoreSystem {
 	/** elastic APM (application performance monitoring) settings */
 	apm?: {
 		enabled?: boolean
-		transactionSampleRate?: number /** set to -1 for performance, 0.5 for 50% and 1 for all */
+		/**
+		 * How many of the transactions to monitor.
+		 * Set to:
+		 * -1 to log nothing (max performance),
+		 * 0.5 to log 50% of the transactions,
+		 * 1 to log all transactions
+		 */
+		transactionSampleRate?: number
 	}
 }
 

--- a/meteor/lib/collections/CoreSystem.ts
+++ b/meteor/lib/collections/CoreSystem.ts
@@ -75,6 +75,12 @@ export interface ICoreSystem {
 	serviceMessages: {
 		[index: string]: ServiceMessage
 	}
+
+	/** elastic APM (application performance monitoring) settings */
+	apm: {
+		enabled: boolean
+		transactionSampleRate: number /** set to -1 for performance, 0.5 for 50% and 1 for all */
+	}
 }
 
 /** In the beginning, there was the database, and the database was with Sofie, and the database was Sofie.

--- a/meteor/lib/collections/CoreSystem.ts
+++ b/meteor/lib/collections/CoreSystem.ts
@@ -77,9 +77,9 @@ export interface ICoreSystem {
 	}
 
 	/** elastic APM (application performance monitoring) settings */
-	apm: {
-		enabled: boolean
-		transactionSampleRate: number /** set to -1 for performance, 0.5 for 50% and 1 for all */
+	apm?: {
+		enabled?: boolean
+		transactionSampleRate?: number /** set to -1 for performance, 0.5 for 50% and 1 for all */
 	}
 }
 

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -84,7 +84,7 @@ export interface DBObj {
 	_id: ProtectedString<any>
 	[key: string]: any
 }
-interface SaveIntoDbOptions<DocClass, DBInterface> {
+export interface SaveIntoDbOptions<DocClass, DBInterface> {
 	beforeInsert?: (o: DBInterface) => DBInterface
 	beforeUpdate?: (o: DBInterface, pre?: DocClass) => DBInterface
 	beforeRemove?: (o: DocClass) => DBInterface
@@ -226,13 +226,13 @@ export function savePreparedChanges<DocClass extends DBInterface, DBInterface ex
 	const removedDocs: DocClass['_id'][] = []
 
 	_.each(preparedChanges.changed || [], (oUpdate) => {
-		checkInsertId(oUpdate.doc._id)
+		checkInsertId(oUpdate._id)
 		updates.push({
 			replaceOne: {
 				filter: {
-					_id: oUpdate.oldId as any,
+					_id: oUpdate._id as any,
 				},
-				replacement: oUpdate.doc,
+				replacement: oUpdate,
 			},
 		})
 		change.updated++
@@ -266,7 +266,7 @@ export function savePreparedChanges<DocClass extends DBInterface, DBInterface ex
 		})
 	}
 
-	const pBulkWriteResult = asyncCollectionBulkWrite(this._collection, updates)
+	const pBulkWriteResult = asyncCollectionBulkWrite(collection, updates)
 
 	if (options.unchanged) {
 		_.each(preparedChanges.unchanged || [], (o) => {

--- a/meteor/server/DatabaseCache.ts
+++ b/meteor/server/DatabaseCache.ts
@@ -21,7 +21,6 @@ import {
 } from '../lib/lib'
 import * as _ from 'underscore'
 import { TransformedCollection, MongoModifier, FindOptions, MongoQuery } from '../lib/typings/meteor'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export function isDbCacheCollection(o: any): o is DbCacheCollection<any, any> {
@@ -355,7 +354,7 @@ export function saveIntoCache<DocClass extends DBInterface, DBInterface extends 
 
 	const changes = savePreparedChangesIntoCache(preparedChanges, collection, options)
 
-	if (span) span.addLabels(changes)
+	if (span) span.addLabels(changes as any)
 	if (span) span.end()
 	return changes
 }

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -25,7 +25,6 @@ import { RundownBaselineAdLibItem, RundownBaselineAdLibPieces } from '../lib/col
 import { AdLibAction, AdLibActions } from '../lib/collections/AdLibActions'
 import { RundownBaselineAdLibAction, RundownBaselineAdLibActions } from '../lib/collections/RundownBaselineAdLibActions'
 import { isInTestWrite } from './security/lib/securityVerify'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 type DeferredFunction<Cache> = (cache: Cache) => void

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -25,6 +25,8 @@ import { RundownBaselineAdLibItem, RundownBaselineAdLibPieces } from '../lib/col
 import { AdLibAction, AdLibActions } from '../lib/collections/AdLibActions'
 import { RundownBaselineAdLibAction, RundownBaselineAdLibActions } from '../lib/collections/RundownBaselineAdLibActions'
 import { isInTestWrite } from './security/lib/securityVerify'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 type DeferredFunction<Cache> = (cache: Cache) => void
 
@@ -65,6 +67,7 @@ export class Cache {
 		})
 	}
 	async saveAllToDatabase() {
+		const span = Agent.startSpan('Cache.saveAllToDatabase')
 		this._abortActiveTimeout()
 
 		// shouldn't the deferred functions be executed after updating the db?
@@ -78,6 +81,7 @@ export class Cache {
 				}
 			})
 		)
+		if (span) span.end()
 	}
 	/** Defer provided function (it will be run just before cache.saveAllToDatabase() ) */
 	defer(fcn: DeferredFunction<Cache>): void {
@@ -188,6 +192,7 @@ async function fillCacheForRundownPlaylistWithData(
 	playlist: RundownPlaylist,
 	initializeImmediately: boolean
 ) {
+	const span = Agent.startSpan('Cache.fillCacheForRundownPlaylistWithData')
 	const ps: Promise<any>[] = []
 	cache.Rundowns.prepareInit({ playlistId: playlist._id }, true)
 
@@ -274,6 +279,7 @@ async function fillCacheForRundownPlaylistWithData(
 	)
 
 	await Promise.all(ps)
+	if (span) span.end()
 }
 export async function initCacheForRundownPlaylist(
 	playlist: RundownPlaylist,

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -80,7 +80,7 @@ function handleAsRunEvent(event: AsRunLogEvent): void {
 
 				if (blueprint.onAsRunEvent) {
 					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
-					const context = new AsRunEventContext(rundown, cache, undefined, event)
+					const context = new AsRunEventContext(rundown, cache, event)
 
 					Promise.resolve(blueprint.onAsRunEvent(context))
 						.then((messages: Array<IBlueprintExternalMessageQueueObj>) => {

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -30,7 +30,6 @@ import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/
 import { PartInstance, PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../lib/collections/PieceInstances'
 import { CacheForRundownPlaylist } from '../DatabaseCaches'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 const EVENT_WAIT_TIME = 500

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -30,6 +30,8 @@ import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/
 import { PartInstance, PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../lib/collections/PieceInstances'
 import { CacheForRundownPlaylist } from '../DatabaseCaches'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 const EVENT_WAIT_TIME = 500
 
@@ -162,6 +164,7 @@ export function reportRundownDataHasChanged(
 
 export function reportPartHasStarted(cache: CacheForRundownPlaylist, partInstance: PartInstance, timestamp: Time) {
 	if (partInstance) {
+		const span = Agent.startSpan('reportPartHasStarted')
 		cache.PartInstances.update(partInstance._id, {
 			$set: {
 				'part.startedPlayback': true,
@@ -204,6 +207,7 @@ export function reportPartHasStarted(cache: CacheForRundownPlaylist, partInstanc
 				`RundownPlaylist "${cache.containsDataFromPlaylist}" not found in reportPartHasStarted "${partInstance._id}"`
 			)
 		}
+		if (span) span.end()
 	}
 }
 export function reportPartHasStopped(playlistId: RundownPlaylistId, partInstance: PartInstance, timestamp: Time) {

--- a/meteor/server/api/blueprints/__tests__/context.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context.test.ts
@@ -397,7 +397,7 @@ describe('Test blueprint api context', () => {
 			}
 
 			const tmpPart = wrapPartToTemporaryInstance(mockPart as DBPart)
-			const context = new PartEventContext(rundown, cache, undefined, tmpPart)
+			const context = new PartEventContext(rundown, cache, tmpPart)
 			expect(context.getStudio()).toBeTruthy()
 
 			expect(context.part).toEqual(tmpPart)
@@ -421,7 +421,7 @@ describe('Test blueprint api context', () => {
 
 			let cache = waitForPromise(initCacheForRundownPlaylist(playlist))
 
-			return new AsRunEventContext(rundown, cache, undefined, mockEvent)
+			return new AsRunEventContext(rundown, cache, mockEvent)
 		}
 		testInFiber('getAllAsRunEvents', () => {
 			const { rundownId } = setupDefaultRundownPlaylist(env)
@@ -442,7 +442,7 @@ describe('Test blueprint api context', () => {
 				content: IBlueprintAsRunLogEventContent.STARTEDPLAYBACK,
 			}
 
-			const context = new AsRunEventContext(rundown, cache, undefined, mockEvent)
+			const context = new AsRunEventContext(rundown, cache, mockEvent)
 			expect(context.getStudio()).toBeTruthy()
 			expect(context.asRunEvent).toEqual(mockEvent)
 

--- a/meteor/server/api/blueprints/__tests__/postProcess.test.ts
+++ b/meteor/server/api/blueprints/__tests__/postProcess.test.ts
@@ -75,7 +75,7 @@ describe('Test blueprint post-process', () => {
 		let cache = waitForPromise(initCacheForRundownPlaylist(playlist))
 
 		const rundownNotesContext = new NotesContext(rundown.name, `rundownId=${rundown._id}`, true)
-		return new RundownContext(rundown, cache, rundownNotesContext, getStudio())
+		return new RundownContext(rundown, cache, rundownNotesContext)
 	}
 
 	function ensureAllKeysDefined<T>(template: T, objects: T[]) {

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -289,14 +289,9 @@ export class RundownContext extends ShowStyleContext implements IRundownContext,
 	readonly _rundown: Rundown
 	readonly playlistId: RundownPlaylistId
 
-	constructor(
-		rundown: Rundown,
-		cache: CacheForRundownPlaylist,
-		notesContext: NotesContext | undefined,
-		studio?: Studio
-	) {
+	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, notesContext: NotesContext | undefined) {
 		super(
-			studio || rundown.getStudio(),
+			cache.activationCache.getStudio(),
 			cache,
 			rundown,
 			rundown.showStyleBaseId,
@@ -316,13 +311,8 @@ export class RundownContext extends ShowStyleContext implements IRundownContext,
 }
 
 export class SegmentContext extends RundownContext implements ISegmentContext {
-	constructor(
-		rundown: Rundown,
-		cache: CacheForRundownPlaylist,
-		studio: Studio | undefined,
-		notesContext: NotesContext
-	) {
-		super(rundown, cache, notesContext, studio)
+	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, notesContext: NotesContext) {
+		super(rundown, cache, notesContext)
 	}
 }
 
@@ -339,17 +329,11 @@ export class EventContext extends CommonContext implements IEventContext {
 export class PartEventContext extends RundownContext implements IPartEventContext {
 	readonly part: Readonly<IBlueprintPartInstance>
 
-	constructor(
-		rundown: Rundown,
-		cache: CacheForRundownPlaylist,
-		studio: Studio | undefined,
-		partInstance: PartInstance
-	) {
+	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, partInstance: PartInstance) {
 		super(
 			rundown,
 			cache,
-			new NotesContext(rundown.name, `rundownId=${rundown._id},partInstanceId=${partInstance._id}`, false),
-			studio
+			new NotesContext(rundown.name, `rundownId=${rundown._id},partInstanceId=${partInstance._id}`, false)
 		)
 
 		this.part = unprotectPartInstance(partInstance)
@@ -363,17 +347,11 @@ export class PartEventContext extends RundownContext implements IPartEventContex
 export class AsRunEventContext extends RundownContext implements IAsRunEventContext {
 	public readonly asRunEvent: Readonly<IBlueprintAsRunLogEvent>
 
-	constructor(
-		rundown: Rundown,
-		cache: CacheForRundownPlaylist,
-		studio: Studio | undefined,
-		asRunEvent: AsRunLogEvent
-	) {
+	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, asRunEvent: AsRunLogEvent) {
 		super(
 			rundown,
 			cache,
-			new NotesContext(rundown.name, `rundownId=${rundown._id},asRunEventId=${asRunEvent._id}`, false),
-			studio
+			new NotesContext(rundown.name, `rundownId=${rundown._id},asRunEventId=${asRunEvent._id}`, false)
 		)
 		this.asRunEvent = unprotectObject(asRunEvent)
 	}

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -13,14 +13,12 @@ import {
 	anythingChanged,
 	ReturnType,
 	waitForPromise,
-	PreparedChanges,
-	prepareSaveIntoDb,
 	unprotectString,
 	protectString,
 	ProtectedString,
 	Omit,
-	PreparedChangesChangesDoc,
 	getRandomId,
+	PreparedChanges,
 } from '../../../lib/lib'
 import {
 	IngestRundown,
@@ -109,7 +107,7 @@ import {
 import { PartInstances } from '../../../lib/collections/PartInstances'
 import { MethodContext } from '../../../lib/api/methods'
 import { CacheForRundownPlaylist, initCacheForRundownPlaylist } from '../../DatabaseCaches'
-import { prepareSaveIntoCache, savePreparedChangesIntoCache, saveIntoCache } from '../../DatabaseCache'
+import { prepareSaveIntoCache, savePreparedChangesIntoCache } from '../../DatabaseCache'
 import { reportRundownDataHasChanged } from '../asRunLog'
 import { Settings } from '../../../lib/Settings'
 import { AdLibAction, AdLibActions } from '../../../lib/collections/AdLibActions'
@@ -603,7 +601,7 @@ function updateRundownFromIngestData(
 
 	// Save the baseline
 	const rundownNotesContext = new NotesContext(dbRundown.name, `rundownId=${dbRundown._id}`, true)
-	const blueprintRundownContext = new RundownContext(dbRundown, cache, rundownNotesContext, studio)
+	const blueprintRundownContext = new RundownContext(dbRundown, cache, rundownNotesContext)
 	logger.info(`Building baseline objects for ${dbRundown._id}...`)
 	logger.info(`... got ${rundownRes.baseline.length} objects from baseline.`)
 
@@ -652,7 +650,7 @@ function updateRundownFromIngestData(
 		ingestSegment.parts = _.sortBy(ingestSegment.parts, (part) => part.rank)
 
 		const notesContext = new NotesContext(ingestSegment.name, `rundownId=${rundownId},segmentId=${segmentId}`, true)
-		const context = new SegmentContext(dbRundown, cache, studio, notesContext)
+		const context = new SegmentContext(dbRundown, cache, notesContext)
 		const res = blueprint.getSegment(context, ingestSegment)
 
 		const segmentContents = generateSegmentContents(
@@ -699,8 +697,8 @@ function updateRundownFromIngestData(
 		},
 		adlibPieces
 	)
-	const prepareSaveAdLibActions = prepareSaveIntoDb<AdLibAction, AdLibAction>(
-		AdLibActions,
+	const prepareSaveAdLibActions = prepareSaveIntoCache<AdLibAction, AdLibAction>(
+		cache.AdLibActions,
 		{
 			rundownId: rundownId,
 		},
@@ -713,7 +711,7 @@ function updateRundownFromIngestData(
 				cache,
 				dbPlaylist,
 				dbRundown,
-				{ changed: [{ doc: dbRundown, oldId: dbRundown._id }] },
+				{ changed: [dbRundown] },
 				prepareSaveSegments,
 				prepareSaveParts
 			)
@@ -735,7 +733,7 @@ function updateRundownFromIngestData(
 						cache,
 						dbPlaylist,
 						dbRundown,
-						{ changed: [{ doc: dbRundown, oldId: dbRundown._id }] },
+						{ changed: [dbRundown] },
 						segmentChange.segment,
 						segmentChange.parts
 					)
@@ -790,7 +788,7 @@ function updateRundownFromIngestData(
 				cache,
 				dbPlaylist,
 				dbRundown,
-				{ changed: [{ doc: dbRundown, oldId: dbRundown._id }] },
+				{ changed: [dbRundown] },
 				prepareSaveSegments,
 				prepareSaveParts
 			)
@@ -1082,7 +1080,7 @@ function updateSegmentFromIngestData(
 	ingestSegment.parts = _.sortBy(ingestSegment.parts, (s) => s.rank)
 
 	const notesContext = new NotesContext(ingestSegment.name, `rundownId=${rundown._id},segmentId=${segmentId}`, true)
-	const context = new SegmentContext(rundown, cache, studio, notesContext)
+	const context = new SegmentContext(rundown, cache, notesContext)
 	const res = blueprint.getSegment(context, ingestSegment)
 
 	const { parts, segmentPieces, adlibPieces, adlibActions, newSegment } = generateSegmentContents(
@@ -1129,8 +1127,8 @@ function updateSegmentFromIngestData(
 		},
 		adlibPieces
 	)
-	const prepareSaveAdLibActions = prepareSaveIntoDb<AdLibAction, AdLibAction>(
-		AdLibActions,
+	const prepareSaveAdLibActions = prepareSaveIntoCache<AdLibAction, AdLibAction>(
+		cache.AdLibActions,
 		{
 			rundownId: rundown._id,
 			partId: { $in: parts.map((p) => p._id) },
@@ -1139,16 +1137,7 @@ function updateSegmentFromIngestData(
 	)
 
 	// determine if update is allowed here
-	if (
-		!isUpdateAllowed(
-			cache,
-			playlist,
-			rundown,
-			{},
-			{ changed: [{ doc: newSegment, oldId: newSegment._id }] },
-			prepareSaveParts
-		)
-	) {
+	if (!isUpdateAllowed(cache, playlist, rundown, {}, { changed: [newSegment] }, prepareSaveParts)) {
 		ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
 		return null
 	}
@@ -1330,7 +1319,7 @@ export function handleUpdatedPartInner(
 		rundownId: rundown._id,
 	})
 
-	if (part && !isUpdateAllowed(cache, playlist, rundown, {}, {}, { changed: [{ doc: part, oldId: part._id }] })) {
+	if (part && !isUpdateAllowed(cache, playlist, rundown, {}, {}, { changed: [part] })) {
 		ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
 	} else {
 		// Blueprints will handle the creation of the Part
@@ -1564,7 +1553,7 @@ export function isUpdateAllowed(
 function printChanges(changes: Partial<PreparedChanges<{ _id: ProtectedString<any> }>>): string {
 	let str = ''
 
-	if (changes.changed) str += _.map(changes.changed, (doc) => 'change:' + doc.doc._id).join(',')
+	if (changes.changed) str += _.map(changes.changed, (doc) => 'change:' + doc._id).join(',')
 	if (changes.inserted) str += _.map(changes.inserted, (doc) => 'insert:' + doc._id).join(',')
 	if (changes.removed) str += _.map(changes.removed, (doc) => 'remove:' + doc._id).join(',')
 
@@ -1589,10 +1578,10 @@ function splitIntoSegments(
 	const partsToSegments: PartIdToSegmentId = new Map()
 
 	prepareSaveParts.changed.forEach((part) => {
-		partsToSegments.set(part.doc._id, part.doc.segmentId)
-		const index = changes.findIndex((c) => c.segmentId === part.doc.segmentId)
+		partsToSegments.set(part._id, part.segmentId)
+		const index = changes.findIndex((c) => c.segmentId === part.segmentId)
 		if (index === -1) {
-			const newChange = makeChangeObj(part.doc.segmentId)
+			const newChange = makeChangeObj(part.segmentId)
 			newChange.parts.changed.push(part)
 			changes.push(newChange)
 		} else {
@@ -1614,9 +1603,9 @@ function splitIntoSegments(
 	})
 
 	for (const piece of prepareSavePieces.changed) {
-		const segmentId = partsToSegments.get(piece.doc.startPartId)
+		const segmentId = partsToSegments.get(piece.startPartId)
 		if (!segmentId) {
-			logger.warning(`SegmentId could not be found when trying to modify piece ${piece.doc._id}`)
+			logger.warning(`SegmentId could not be found when trying to modify piece ${piece._id}`)
 			break // In theory this shouldn't happen, but reject 'orphaned' changes
 		}
 		const index = changes.findIndex((c) => c.segmentId === segmentId)
@@ -1648,9 +1637,9 @@ function splitIntoSegments(
 	})
 
 	for (const adlib of prepareSaveAdLibPieces.changed) {
-		const segmentId = adlib.doc.partId ? partsToSegments.get(adlib.doc.partId) : undefined
+		const segmentId = adlib.partId ? partsToSegments.get(adlib.partId) : undefined
 		if (!segmentId) {
-			logger.warning(`SegmentId could not be found when trying to modify adlib ${adlib.doc._id}`)
+			logger.warning(`SegmentId could not be found when trying to modify adlib ${adlib._id}`)
 			break // In theory this shouldn't happen, but reject 'orphaned' changes
 		}
 		const index = changes.findIndex((c) => c.segmentId === segmentId)
@@ -1684,27 +1673,20 @@ function splitIntoSegments(
 	return changes
 }
 
-function processChangeGroup<
-	ChangeType extends keyof PreparedChanges<DBSegment>,
-	ChangedObj extends DBSegment | DBPart | Piece | AdLibPiece
->(changes: SegmentChanges[], preparedChanges: PreparedChanges<ChangedObj>, changeField: ChangeType) {
+function processChangeGroup<ChangeType extends keyof PreparedChanges<DBSegment>>(
+	changes: SegmentChanges[],
+	preparedChanges: PreparedChanges<DBSegment>,
+	changeField: ChangeType
+) {
 	const subset = preparedChanges[changeField]
 	// @ts-ignore
 	subset.forEach((ch) => {
 		if (changeField === 'changed') {
-			const existing = changes.findIndex(
-				(c) => (ch as PreparedChangesChangesDoc<ChangedObj>).doc._id === c.segmentId
-			)
-			processChangeGroupInner(
-				existing,
-				changes,
-				changeField,
-				ch,
-				(ch as PreparedChangesChangesDoc<ChangedObj>).doc._id
-			)
+			const existing = changes.findIndex((c) => ch._id === c.segmentId)
+			processChangeGroupInner(existing, changes, changeField, ch, ch._id)
 		} else {
-			const existing = changes.findIndex((c) => (ch as ChangedObj)._id === c.segmentId)
-			processChangeGroupInner(existing, changes, changeField, ch, (ch as ChangedObj)._id)
+			const existing = changes.findIndex((c) => ch._id === c.segmentId)
+			processChangeGroupInner(existing, changes, changeField, ch, ch._id)
 		}
 	})
 }
@@ -1713,7 +1695,7 @@ function processChangeGroupInner<ChangeType extends keyof PreparedChanges<DBSegm
 	existing: number,
 	changes: SegmentChanges[],
 	changeField: ChangeType,
-	changedObject: PreparedChangesChangesDoc<DBSegment> | DBSegment,
+	changedObject: DBSegment,
 	segmentId
 ) {
 	if (existing !== -1) {

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -24,6 +24,8 @@ import { getActiveRundownPlaylistsInStudio } from './studio'
 import { RundownPlaylists, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PartInstances } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export function activateRundownPlaylist(
 	cache: CacheForRundownPlaylist,
@@ -106,6 +108,7 @@ export function deactivateRundownPlaylistInner(
 	cache: CacheForRundownPlaylist,
 	rundownPlaylist: RundownPlaylist
 ): Rundown | undefined {
+	const span = Agent.startSpan('deactivateRundownPlaylistInner')
 	logger.info(`Deactivating rundown playlist "${rundownPlaylist._id}"`)
 
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, rundownPlaylist)
@@ -158,6 +161,7 @@ export function deactivateRundownPlaylistInner(
 			},
 		})
 	}
+	if (span) span.end()
 	return rundown
 }
 /**

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -24,7 +24,6 @@ import { getActiveRundownPlaylistsInStudio } from './studio'
 import { RundownPlaylists, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PartInstances } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export function activateRundownPlaylist(

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -84,9 +84,12 @@ export function activateRundownPlaylist(
 
 	cache.defer(() => {
 		if (!rundown) return // if the proper rundown hasn't been found, there's little point doing anything else
-		const { blueprint } = getBlueprintOfRundown(undefined, rundown)
+		const { blueprint } = getBlueprintOfRundown(
+			waitForPromise(cache.activationCache.getShowStyleBase(rundown)),
+			rundown
+		)
 		if (blueprint.onRundownActivate) {
-			Promise.resolve(blueprint.onRundownActivate(new RundownContext(rundown, cache, undefined, studio))).catch(
+			Promise.resolve(blueprint.onRundownActivate(new RundownContext(rundown, cache, undefined))).catch(
 				logger.error
 			)
 		}
@@ -97,9 +100,12 @@ export function deactivateRundownPlaylist(cache: CacheForRundownPlaylist, rundow
 
 	updateTimeline(cache, rundownPlaylist.studioId)
 
-	cache.defer(() => {
+	cache.defer((cache) => {
 		if (rundown) {
-			const { blueprint } = getBlueprintOfRundown(undefined, rundown)
+			const { blueprint } = getBlueprintOfRundown(
+				waitForPromise(cache.activationCache.getShowStyleBase(rundown)),
+				rundown
+			)
 			if (blueprint.onRundownDeActivate) {
 				Promise.resolve(blueprint.onRundownDeActivate(new RundownContext(rundown, cache, undefined))).catch(
 					logger.error

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -37,6 +37,8 @@ import { MongoQuery } from '../../../lib/typings/meteor'
 import { syncPlayheadInfinitesForNextPartInstance, DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { ShowStyleBases, ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export namespace ServerPlayoutAdLibAPI {
 	export function pieceTakeNow(
@@ -238,6 +240,7 @@ export namespace ServerPlayoutAdLibAPI {
 		currentPartInstance: PartInstance,
 		adLibPiece: AdLibPiece | BucketAdLib
 	) {
+		const span = Agent.startSpan('innerStartOrQueueAdLibPiece')
 		if (queue || adLibPiece.toBeQueued) {
 			const newPartInstance = new PartInstance({
 				_id: getRandomId(),
@@ -270,6 +273,8 @@ export namespace ServerPlayoutAdLibAPI {
 		syncPlayheadInfinitesForNextPartInstance(cache, rundownPlaylist)
 
 		updateTimeline(cache, rundownPlaylist.studioId)
+
+		if (span) span.end()
 	}
 
 	export function sourceLayerStickyPieceStart(rundownPlaylist: RundownPlaylist, sourceLayerId: string) {
@@ -323,6 +328,7 @@ export namespace ServerPlayoutAdLibAPI {
 		originalOnly: boolean,
 		customQuery?: MongoQuery<PieceInstance>
 	) {
+		const span = Agent.startSpan('innerFindLastPieceOnLayer')
 		const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
 
 		const query = {
@@ -340,6 +346,8 @@ export namespace ServerPlayoutAdLibAPI {
 				$ne: true,
 			}
 		}
+
+		if (span) span.end()
 
 		// Note: This does not want to use the cache, as we want to search as far back as we can
 		// TODO - will this cause problems?
@@ -359,6 +367,7 @@ export namespace ServerPlayoutAdLibAPI {
 		newPartInstance: PartInstance,
 		newPieceInstances: PieceInstance[]
 	) {
+		const span = Agent.startSpan('innerStartQueuedAdLib')
 		logger.info('adlibQueueInsertPartInstance')
 
 		// check if there's already a queued part after this:
@@ -402,6 +411,8 @@ export namespace ServerPlayoutAdLibAPI {
 		updatePartRanks(cache, rundownPlaylist, [newPartInstance.part.segmentId])
 
 		setNextPart(cache, rundownPlaylist, newPartInstance)
+
+		if (span) span.end()
 	}
 
 	export function innerStartAdLibPiece(
@@ -411,6 +422,7 @@ export namespace ServerPlayoutAdLibAPI {
 		existingPartInstance: PartInstance,
 		newPieceInstance: PieceInstance
 	) {
+		const span = Agent.startSpan('innerStartAdLibPiece')
 		// Ensure it is labelled as dynamic
 		newPieceInstance.partInstanceId = existingPartInstance._id
 		newPieceInstance.piece.startPartId = existingPartInstance.part._id
@@ -419,6 +431,7 @@ export namespace ServerPlayoutAdLibAPI {
 		// exclusiveGroup is handled at runtime by processAndPrunePieceInstanceTimings
 
 		cache.PieceInstances.insert(newPieceInstance)
+		if (span) span.end()
 	}
 
 	export function innerStopPieces(
@@ -428,6 +441,7 @@ export namespace ServerPlayoutAdLibAPI {
 		filter: (pieceInstance: PieceInstance) => boolean,
 		timeOffset: number | undefined
 	) {
+		const span = Agent.startSpan('innerStopPieces')
 		const stoppedInstances: PieceInstanceId[] = []
 
 		const lastStartedPlayback = currentPartInstance.part.getLastStartedPlayback()
@@ -511,6 +525,7 @@ export namespace ServerPlayoutAdLibAPI {
 			}
 		}
 
+		if (span) span.end()
 		return stoppedInstances
 	}
 	export function startBucketAdlibPiece(

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -37,7 +37,6 @@ import { MongoQuery } from '../../../lib/typings/meteor'
 import { syncPlayheadInfinitesForNextPartInstance, DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { ShowStyleBases, ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export namespace ServerPlayoutAdLibAPI {

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -15,6 +15,8 @@ import {
 	buildPiecesStartingInThisPartQuery,
 	buildPastInfinitePiecesForThisPartQuery,
 } from '../../../lib/rundown/infinites'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 // /** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
 export const DEFINITELY_ENDED_FUTURE_DURATION = 10 * 1000
@@ -29,6 +31,7 @@ function canContinueAdlibOnEndInfinites(
 	part: DBPart
 ): boolean {
 	if (previousPartInstance && playlist) {
+		const span = Agent.startSpan('canContinueAdlibOnEndInfinites')
 		// TODO - if we don't have an index for previousPartInstance, what should we do?
 
 		const expectedNextPart = selectNextPart(playlist, previousPartInstance, orderedParts)
@@ -39,14 +42,17 @@ function canContinueAdlibOnEndInfinites(
 			} else {
 				const partIndex = orderedParts.findIndex((p) => p._id === part._id)
 				if (partIndex >= expectedNextPart.index) {
+					if (span) span.end()
 					// Somewhere after the auto-next part, so we can use that
 					return true
 				} else {
+					if (span) span.end()
 					// It isnt ahead, so we cant take it
 					return false
 				}
 			}
 		} else {
+			if (span) span.end()
 			// selectNextPart gave nothing, so we must be at the end?
 			return false
 		}
@@ -57,6 +63,7 @@ function canContinueAdlibOnEndInfinites(
 }
 
 function getIdsBeforeThisPart(cache: CacheForRundownPlaylist, nextPart: DBPart) {
+	const span = Agent.startSpan('getIdsBeforeThisPart')
 	// Note: This makes the assumption that nextPart is a part found in this cache
 	const partsBeforeThisInSegment = cache.Parts.findFetch({
 		segmentId: nextPart.segmentId,
@@ -70,6 +77,7 @@ function getIdsBeforeThisPart(cache: CacheForRundownPlaylist, nextPart: DBPart) 
 		  }).map((p) => p._id)
 		: []
 
+	if (span) span.end()
 	return {
 		partsBeforeThisInSegment,
 		segmentsBeforeThisInRundown,
@@ -80,6 +88,7 @@ export async function fetchPiecesThatMayBeActiveForPart(
 	cache: CacheForRundownPlaylist,
 	part: DBPart
 ): Promise<Piece[]> {
+	const span = Agent.startSpan('fetchPiecesThatMayBeActiveForPart')
 	const pPiecesStartingInPart = asyncCollectionFindFetch(Pieces, buildPiecesStartingInThisPartQuery(part))
 
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, part)
@@ -90,6 +99,7 @@ export async function fetchPiecesThatMayBeActiveForPart(
 	)
 
 	const [piecesStartingInPart, infinitePieces] = await Promise.all([pPiecesStartingInPart, pInfinitePieces])
+	if (span) span.end()
 	return [...piecesStartingInPart, ...infinitePieces]
 }
 
@@ -97,6 +107,7 @@ export function syncPlayheadInfinitesForNextPartInstance(
 	cache: CacheForRundownPlaylist,
 	playlist: RundownPlaylist
 ): void {
+	const span = Agent.startSpan('syncPlayheadInfinitesForNextPartInstance')
 	const { nextPartInstance, currentPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
 	if (nextPartInstance && currentPartInstance) {
 		const infinites = getPlayheadTrackingInfinitesForPart(cache, playlist, currentPartInstance, nextPartInstance)
@@ -110,6 +121,7 @@ export function syncPlayheadInfinitesForNextPartInstance(
 			infinites
 		)
 	}
+	if (span) span.end()
 }
 
 function getPlayheadTrackingInfinitesForPart(
@@ -118,6 +130,7 @@ function getPlayheadTrackingInfinitesForPart(
 	playingPartInstance: PartInstance,
 	nextPartInstance: PartInstance
 ): PieceInstance[] {
+	const span = Agent.startSpan('getPlayheadTrackingInfinitesForPart')
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, nextPartInstance.part)
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)
@@ -130,7 +143,7 @@ function getPlayheadTrackingInfinitesForPart(
 	)
 	const playingPieceInstances = cache.PieceInstances.findFetch((p) => p.partInstanceId === playingPartInstance._id)
 
-	return libgetPlayheadTrackingInfinitesForPart(
+	const res = libgetPlayheadTrackingInfinitesForPart(
 		new Set(partsBeforeThisInSegment),
 		new Set(segmentsBeforeThisInRundown),
 		playingPartInstance,
@@ -140,6 +153,8 @@ function getPlayheadTrackingInfinitesForPart(
 		canContinueAdlibOnEnds,
 		false
 	)
+	if (span) span.end()
+	return res
 }
 
 export function getPieceInstancesForPart(
@@ -151,6 +166,7 @@ export function getPieceInstancesForPart(
 	newInstanceId: PartInstanceId,
 	isTemporary: boolean
 ): PieceInstance[] {
+	const span = Agent.startSpan('getPieceInstancesForPart')
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, part)
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)
@@ -160,7 +176,7 @@ export function getPieceInstancesForPart(
 
 	const canContinueAdlibOnEnds = canContinueAdlibOnEndInfinites(playlist, orderedParts, playingPartInstance, part)
 
-	return libgetPieceInstancesForPart(
+	const res = libgetPieceInstancesForPart(
 		playingPartInstance,
 		playingPieceInstances,
 		part,
@@ -172,4 +188,6 @@ export function getPieceInstancesForPart(
 		canContinueAdlibOnEnds,
 		isTemporary
 	)
+	if (span) span.end()
+	return res
 }

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -15,7 +15,6 @@ import {
 	buildPiecesStartingInThisPartQuery,
 	buildPastInfinitePiecesForThisPartQuery,
 } from '../../../lib/rundown/infinites'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 // /** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -29,6 +29,8 @@ import { RundownPlaylistContentWriteAccess } from '../../security/rundownPlaylis
 import { MethodContext } from '../../../lib/api/methods'
 import { MongoQuery } from '../../../lib/typings/meteor'
 import { RundownBaselineAdLibActions } from '../../../lib/collections/RundownBaselineAdLibActions'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 /**
  * Reset the rundown:
@@ -283,6 +285,7 @@ export function selectNextPart(
 	previousPartInstance: PartInstance | null,
 	parts: Part[]
 ): SelectNextPartResult | undefined {
+	const span = Agent.startSpan('selectNextPart')
 	const findFirstPlayablePart = (
 		offset: number,
 		condition?: (part: Part) => boolean
@@ -326,7 +329,9 @@ export function selectNextPart(
 	// TODO - rundownPlaylist.loop
 
 	// Filter to after and find the first playabale
-	return nextPart || findFirstPlayablePart(offset)
+	const res = nextPart || findFirstPlayablePart(offset)
+	if (span) span.end()
+	return res
 }
 export function setNextPart(
 	cache: CacheForRundownPlaylist,
@@ -335,6 +340,7 @@ export function setNextPart(
 	setManually?: boolean,
 	nextTimeOffset?: number | undefined
 ) {
+	const span = Agent.startSpan('setNextPart')
 	const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(
 		cache,
@@ -497,12 +503,15 @@ export function setNextPart(
 		})
 		// delete rundownPlaylist.nextSegmentId
 	}
+
+	if (span) span.end()
 }
 export function setNextSegment(
 	cache: CacheForRundownPlaylist,
 	rundownPlaylist: RundownPlaylist,
 	nextSegment: Segment | null
 ) {
+	const span = Agent.startSpan('setNextSegment')
 	const acceptableRundowns = getRundownIDsFromCache(cache, rundownPlaylist)
 	if (nextSegment) {
 		if (acceptableRundowns.indexOf(nextSegment.rundownId) === -1) {
@@ -530,6 +539,7 @@ export function setNextSegment(
 			},
 		})
 	}
+	if (span) span.end()
 }
 
 function resetPart(cache: CacheForRundownPlaylist, part: Part): void {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -29,7 +29,6 @@ import { RundownPlaylistContentWriteAccess } from '../../security/rundownPlaylis
 import { MethodContext } from '../../../lib/api/methods'
 import { MongoQuery } from '../../../lib/typings/meteor'
 import { RundownBaselineAdLibActions } from '../../../lib/collections/RundownBaselineAdLibActions'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 /**

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -21,6 +21,8 @@ import {
 import { PartInstanceId, PartInstance } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { sortPiecesByStart } from './pieces'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 const LOOKAHEAD_OBJ_PRIORITY = 0.1
 
@@ -52,6 +54,7 @@ function getOrderedPartsAfterPlayhead(
 	if (partCount <= 0) {
 		return []
 	}
+	const span = Agent.startSpan('getOrderedPartsAfterPlayhead')
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
@@ -99,9 +102,11 @@ function getOrderedPartsAfterPlayhead(
 		// Note: We only add it once, as lookahead is unlikely to show anything new in a second pass
 		res.push(...playableParts)
 
+		if (span) span.end()
 		// Final trim to ensure it is within bounds
 		return res.slice(0, partCount)
 	} else {
+		if (span) span.end()
 		// We reached the target or ran out of parts
 		return res.slice(0, partCount)
 	}
@@ -112,10 +117,12 @@ export async function getLookeaheadObjects(
 	studio: Studio,
 	playlist: RundownPlaylist
 ): Promise<Array<TimelineObjGeneric>> {
+	const span = Agent.startSpan('getLookeaheadObjects')
 	const mappingsToConsider = Object.entries(studio.mappings ?? {}).filter(
 		([id, map]) => map.lookahead !== LookaheadMode.NONE
 	)
 	if (mappingsToConsider.length === 0) {
+		if (span) span.end()
 		return []
 	}
 
@@ -265,6 +272,7 @@ export async function getLookeaheadObjects(
 			mutateAndPushObject(entry.obj, `future${i}`, enable, mapping, priority)
 		})
 	}
+	if (span) span.end()
 	return timelineObjs
 }
 
@@ -289,6 +297,7 @@ function findLookaheadForlayer(
 	lookaheadTargetObjects: number,
 	lookaheadMaxSearchDistance: number
 ): LookaheadResult {
+	const span = Agent.startSpan('findLookaheadForlayer')
 	const res: LookaheadResult = {
 		timed: [],
 		future: [],
@@ -361,6 +370,7 @@ function findLookaheadForlayer(
 		}
 	}
 
+	if (span) span.end()
 	return res
 }
 
@@ -375,6 +385,7 @@ function findObjectsForPart(
 	if (!partInfo || partInfo.pieces.length === 0) {
 		return []
 	}
+	const span = Agent.startSpan('findObjectsForPart')
 
 	let allObjs: TimelineObjRundown[] = []
 	for (const piece of partInfo.pieces) {
@@ -400,9 +411,11 @@ function findObjectsForPart(
 	}
 
 	if (allObjs.length === 0) {
+		if (span) span.end()
 		// Should never happen. suggests something got 'corrupt' during this process
 		return []
 	} else if (allObjs.length === 1) {
+		if (span) span.end()
 		// Only one, just return it
 		return allObjs
 	} else {
@@ -473,6 +486,7 @@ function findObjectsForPart(
 				)
 			}
 		})
+		if (span) span.end()
 		return res
 	}
 }

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -21,7 +21,6 @@ import {
 import { PartInstanceId, PartInstance } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { sortPiecesByStart } from './pieces'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 const LOOKAHEAD_OBJ_PRIORITY = 0.1

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -40,7 +40,6 @@ import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { processAndPrunePieceInstanceTimings } from '../../../lib/rundown/infinites'
 import { createPieceGroupAndCap } from '../../../lib/rundown/pieces'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 function comparePieceStart<T extends PieceInstancePiece>(a: T, b: T, nowInPart: number): 0 | 1 | -1 {

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -242,7 +242,7 @@ export function getResolvedPiecesFromFullTimeline(
 	playlist: RundownPlaylist,
 	allObjs: TimelineObjGeneric[]
 ): { pieces: ResolvedPieceInstance[]; time: number } {
-	const span = Agent.startSpan('untitled')
+	const span = Agent.startSpan('getResolvedPiecesFromFullTimeline')
 	const objs = clone(
 		allObjs.filter((o) => o.isGroup && ((o as any).isPartGroup || (o.metaData && o.metaData.pieceId)))
 	)

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -44,6 +44,8 @@ import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { PieceInstanceWithTimings, processAndPrunePieceInstanceTimings } from '../../../lib/rundown/infinites'
 import { createPieceGroupAndCap } from '../../../lib/rundown/pieces'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 function comparePieceStart<T extends PieceInstancePiece>(a: T, b: T, nowInPart: number): 0 | 1 | -1 {
 	const aStart = a.enable.start === 'now' ? nowInPart : a.enable.start
@@ -203,6 +205,7 @@ export function getResolvedPieces(
 	showStyleBase: ShowStyleBase,
 	partInstance: PartInstance
 ): ResolvedPieceInstance[] {
+	const span = Agent.startSpan('getResolvedPieces')
 	const pieceInstances = cache.PieceInstances.findFetch({ partInstanceId: partInstance._id })
 
 	const pieceInststanceMap = normalizeArray(pieceInstances, '_id')
@@ -250,6 +253,7 @@ export function getResolvedPieces(
 	// 	}
 	// })
 
+	if (span) span.end()
 	return resolvedPieces
 }
 export function getResolvedPiecesFromFullTimeline(
@@ -257,6 +261,7 @@ export function getResolvedPiecesFromFullTimeline(
 	playlist: RundownPlaylist,
 	allObjs: TimelineObjGeneric[]
 ): { pieces: ResolvedPieceInstance[]; time: number } {
+	const span = Agent.startSpan('untitled')
 	const objs = clone(
 		allObjs.filter((o) => o.isGroup && ((o as any).isPartGroup || (o.metaData && o.metaData.pieceId)))
 	)
@@ -319,6 +324,7 @@ export function getResolvedPiecesFromFullTimeline(
 	// 	}
 	// })
 
+	if (span) span.end()
 	return {
 		pieces: resolvedPieces,
 		time: now,
@@ -326,6 +332,7 @@ export function getResolvedPiecesFromFullTimeline(
 }
 
 export function convertPieceToAdLibPiece(piece: PieceInstancePiece): AdLibPiece {
+	const span = Agent.startSpan('convertPieceToAdLibPiece')
 	// const oldId = piece._id
 	const newId = Random.id()
 	const newAdLibPiece = literal<AdLibPiece>({
@@ -352,6 +359,8 @@ export function convertPieceToAdLibPiece(piece: PieceInstancePiece): AdLibPiece 
 		)
 		newAdLibPiece.content.timelineObjects = objs
 	}
+
+	if (span) span.end()
 	return newAdLibPiece
 }
 
@@ -360,6 +369,7 @@ export function convertAdLibToPieceInstance(
 	partInstance: PartInstance,
 	queue: boolean
 ): PieceInstance {
+	const span = Agent.startSpan('convertAdLibToPieceInstance')
 	let duration: number | undefined = undefined
 	if (adLibPiece['expectedDuration']) {
 		duration = adLibPiece['expectedDuration']
@@ -425,5 +435,7 @@ export function convertAdLibToPieceInstance(
 		)
 		newPieceInstance.piece.content.timelineObjects = objs
 	}
+
+	if (span) span.end()
 	return newPieceInstance
 }

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -42,6 +42,8 @@ import { ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { reportPartHasStarted } from '../asRunLog'
 import { MethodContext } from '../../../lib/api/methods'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export function takeNextPartInner(
 	context: MethodContext,
@@ -50,6 +52,7 @@ export function takeNextPartInner(
 	let now = getCurrentTime()
 
 	return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
+		const span = Agent.startSpan('takeNextPartInner')
 		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 		if (!dbPlaylist.active) throw new Meteor.Error(501, `RundownPlaylist "${rundownPlaylistId}" is not active!`)
 		if (!dbPlaylist.nextPartInstanceId) throw new Meteor.Error(500, 'nextPartInstanceId is not set!')
@@ -128,13 +131,16 @@ export function takeNextPartInner(
 
 		const { blueprint } = waitForPromise(pBlueprint)
 		if (blueprint.onPreTake) {
+			const span = Agent.startSpan('blueprint.onPreTake')
 			try {
 				waitForPromise(
 					Promise.resolve(
 						blueprint.onPreTake(new PartEventContext(takeRundown, undefined, takePartInstance))
 					).catch(logger.error)
 				)
+				if (span) span.end()
 			} catch (e) {
+				if (span) span.end()
 				logger.error(e)
 			}
 		}
@@ -146,6 +152,7 @@ export function takeNextPartInner(
 			if (showStyle) {
 				const resolvedPieces = getResolvedPieces(cache, showStyle, previousPartInstance)
 
+				const span = Agent.startSpan('blueprint.getEndStateForPart')
 				const context = new RundownContext(takeRundown, undefined)
 				previousPartEndState = blueprint.getEndStateForPart(
 					context,
@@ -154,6 +161,7 @@ export function takeNextPartInner(
 					unprotectObjectArray(resolvedPieces),
 					time
 				)
+				if (span) span.end()
 				logger.info(`Calculated end state in ${getCurrentTime() - time}ms`)
 			}
 		}
@@ -274,6 +282,7 @@ export function takeNextPartInner(
 				// let bp = getBlueprintOfRundown(rundown)
 				if (firstTake) {
 					if (blueprint.onRundownFirstTake) {
+						const span = Agent.startSpan('blueprint.onRundownFirstTake')
 						waitForPromise(
 							Promise.resolve(
 								blueprint.onRundownFirstTake(
@@ -281,20 +290,24 @@ export function takeNextPartInner(
 								)
 							).catch(logger.error)
 						)
+						if (span) span.end()
 					}
 				}
 
 				if (blueprint.onPostTake) {
+					const span = Agent.startSpan('blueprint.onPostTake')
 					waitForPromise(
 						Promise.resolve(
 							blueprint.onPostTake(new PartEventContext(takeRundown, undefined, takePartInstance))
 						).catch(logger.error)
 					)
+					if (span) span.end()
 				}
 			}
 		})
 		waitForPromise(cache.saveAllToDatabase())
 
+		if (span) span.end()
 		return ClientAPI.responseSuccess(undefined)
 	})
 }
@@ -366,6 +379,7 @@ export function afterTake(
 	takePartInstance: PartInstance,
 	timeOffset: number | null = null
 ) {
+	const span = Agent.startSpan('afterTake')
 	// This function should be called at the end of a "take" event (when the Parts have been updated)
 
 	let forceNowTime: number | undefined = undefined
@@ -390,6 +404,7 @@ export function afterTake(
 	}, 40)
 
 	triggerGarbageCollection()
+	if (span) span.end()
 }
 
 function startHold(
@@ -399,6 +414,7 @@ function startHold(
 ) {
 	if (!holdFromPartInstance) throw new Meteor.Error(404, 'previousPart not found!')
 	if (!holdToPartInstance) throw new Meteor.Error(404, 'currentPart not found!')
+	const span = Agent.startSpan('startHold')
 
 	// Make a copy of any item which is flagged as an 'infinite' extension
 	const itemsToCopy = cache.PieceInstances.findFetch({ partInstanceId: holdFromPartInstance._id }).filter(
@@ -444,6 +460,7 @@ function startHold(
 		// This gets deleted once the nextpart is activated, so it doesnt linger for long
 		cache.PieceInstances.upsert(newInstance._id, newInstance)
 	})
+	if (span) span.end()
 }
 
 function completeHold(

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -134,7 +134,7 @@ export function takeNextPartInner(
 			try {
 				waitForPromise(
 					Promise.resolve(
-						blueprint.onPreTake(new PartEventContext(takeRundown, cache, undefined, takePartInstance))
+						blueprint.onPreTake(new PartEventContext(takeRundown, cache, takePartInstance))
 					).catch(logger.error)
 				)
 				if (span) span.end()
@@ -283,9 +283,7 @@ export function takeNextPartInner(
 						const span = Agent.startSpan('blueprint.onRundownFirstTake')
 						waitForPromise(
 							Promise.resolve(
-								blueprint.onRundownFirstTake(
-									new PartEventContext(takeRundown, cache, undefined, takePartInstance)
-								)
+								blueprint.onRundownFirstTake(new PartEventContext(takeRundown, cache, takePartInstance))
 							).catch(logger.error)
 						)
 						if (span) span.end()
@@ -296,7 +294,7 @@ export function takeNextPartInner(
 					const span = Agent.startSpan('blueprint.onPostTake')
 					waitForPromise(
 						Promise.resolve(
-							blueprint.onPostTake(new PartEventContext(takeRundown, cache, undefined, takePartInstance))
+							blueprint.onPostTake(new PartEventContext(takeRundown, cache, takePartInstance))
 						).catch(logger.error)
 					)
 					if (span) span.end()

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -42,7 +42,6 @@ import { ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { reportPartHasStarted } from '../asRunLog'
 import { MethodContext } from '../../../lib/api/methods'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export function takeNextPartInner(

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -64,7 +64,6 @@ import { processAndPrunePieceInstanceTimings, PieceInstanceWithTimings } from '.
 import { createPieceGroupAndCap } from '../../../lib/rundown/pieces'
 import { ShowStyleBase, ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 /**

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -240,7 +240,7 @@ function getTimelineRundown(cache: CacheForRundownPlaylist, studio: Studio): Tim
 
 			if (showStyleBlueprintManifest.onTimelineGenerate && currentPartInstance) {
 				const currentPart = currentPartInstance
-				const context = new PartEventContext(activeRundown, cache, studio, currentPart)
+				const context = new PartEventContext(activeRundown, cache, currentPart)
 				const resolvedPieces = getResolvedPiecesFromFullTimeline(cache, playlist, timelineObjs)
 				try {
 					const tlGenRes = waitForPromise(

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -489,7 +489,7 @@ function restoreFromSnapshot(snapshot: AnySnapshot) {
 	// @ts-ignore is's not really a snapshot here:
 	if (snapshot.externalId && snapshot.segments && snapshot.type === 'mos') {
 		// Special: Not a snapshot, but a datadump of a MOS rundown
-		const studio = Studios.findOne(Meteor.settings.manualSnapshotIngestStudioId || undefined)
+		const studio = Studios.findOne(Meteor.settings.manualSnapshotIngestStudioId || 'studio0')
 		if (studio) {
 			importIngestRundown(studio._id, snapshot)
 			return

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -53,7 +53,6 @@ import { ServerPlayoutAdLibAPI } from './playout/adlib'
 import { BucketsAPI } from './buckets'
 import { BucketAdLib } from '../../lib/collections/BucketAdlibs'
 import { rundownContentAllowWrite } from '../security/rundown'
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 let MINIMUM_TAKE_SPAN = 1000

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -53,6 +53,8 @@ import { ServerPlayoutAdLibAPI } from './playout/adlib'
 import { BucketsAPI } from './buckets'
 import { BucketAdLib } from '../../lib/collections/BucketAdlibs'
 import { rundownContentAllowWrite } from '../security/rundown'
+// @ts-ignore: ts can't find meteor packages
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 let MINIMUM_TAKE_SPAN = 1000
 export function setMinimumTakeSpan(span: number) {
@@ -789,45 +791,68 @@ export function noop(context: MethodContext) {
 	return ClientAPI.responseSuccess(undefined)
 }
 
+export function traceAction<T>(description: string, fn: (...args: any[]) => T, ...args: any[]) {
+	const transaction = Agent.startTransaction(description, 'userAction')
+	return makePromise(() => {
+		const res = fn(...args)
+		if (transaction) transaction.end()
+		return res
+	})
+}
+
 class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 	take(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
-		return makePromise(() => take(this, rundownPlaylistId))
+		return traceAction('userAction.take', take, this, rundownPlaylistId)
 	}
 	setNext(_userEvent: string, rundownPlaylistId: RundownPlaylistId, partId: PartId, timeOffset?: number) {
-		return makePromise(() => setNext(this, rundownPlaylistId, partId, true, timeOffset))
+		return traceAction('userAction.setNext', setNext, this, rundownPlaylistId, partId, true, timeOffset)
 	}
 	setNextSegment(_userEvent: string, rundownPlaylistId: RundownPlaylistId, segmentId: SegmentId) {
-		return makePromise(() => setNextSegment(this, rundownPlaylistId, segmentId))
+		return traceAction('userAction.setNextSegment', setNextSegment, this, rundownPlaylistId, segmentId)
 	}
 	moveNext(_userEvent: string, rundownPlaylistId: RundownPlaylistId, horisontalDelta: number, verticalDelta: number) {
-		return makePromise(() => moveNext(this, rundownPlaylistId, horisontalDelta, verticalDelta, true))
+		return traceAction(
+			'userAction.moveNext',
+			moveNext,
+			this,
+			rundownPlaylistId,
+			horisontalDelta,
+			verticalDelta,
+			true
+		)
 	}
 	prepareForBroadcast(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
-		return makePromise(() => prepareForBroadcast(this, rundownPlaylistId))
+		return traceAction('userAction.prepareForBroadcast', prepareForBroadcast, this, rundownPlaylistId)
 	}
 	resetRundownPlaylist(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
-		return makePromise(() => resetRundownPlaylist(this, rundownPlaylistId))
+		return traceAction('userAction.resetRundownPlaylist', resetRundownPlaylist, this, rundownPlaylistId)
 	}
 	resetAndActivate(_userEvent: string, rundownPlaylistId: RundownPlaylistId, rehearsal?: boolean) {
-		return makePromise(() => resetAndActivate(this, rundownPlaylistId, rehearsal))
+		return traceAction('userAction.resetAndActivate', resetAndActivate, this, rundownPlaylistId, rehearsal)
 	}
 	activate(_userEvent: string, rundownPlaylistId: RundownPlaylistId, rehearsal: boolean) {
-		return makePromise(() => activate(this, rundownPlaylistId, rehearsal))
+		return traceAction('userAction.activate', activate, this, rundownPlaylistId, rehearsal)
 	}
 	deactivate(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
-		return makePromise(() => deactivate(this, rundownPlaylistId))
+		return traceAction('userAction.deactivate', deactivate, this, rundownPlaylistId)
 	}
 	forceResetAndActivate(_userEvent: string, rundownPlaylistId: RundownPlaylistId, rehearsal: boolean) {
-		return makePromise(() => forceResetAndActivate(this, rundownPlaylistId, rehearsal))
+		return traceAction(
+			'userAction.forceResetAndActivate',
+			forceResetAndActivate,
+			this,
+			rundownPlaylistId,
+			rehearsal
+		)
 	}
 	reloadData(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
-		return makePromise(() => reloadRundownPlaylistData(this, rundownPlaylistId))
+		return traceAction('userAction.reloadRundownPlaylistData', reloadRundownPlaylistData, this, rundownPlaylistId)
 	}
 	unsyncRundown(_userEvent: string, rundownId: RundownId) {
-		return makePromise(() => unsyncRundown(this, rundownId))
+		return traceAction('userAction.unsyncRundown', unsyncRundown, this, rundownId)
 	}
 	disableNextPiece(_userEvent: string, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-		return makePromise(() => disableNextPiece(this, rundownPlaylistId, undo))
+		return traceAction('userAction.disableNextPiece', disableNextPiece, this, rundownPlaylistId, undo)
 	}
 	pieceTakeNow(
 		_userEvent: string,
@@ -835,7 +860,14 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		partInstanceId: PartInstanceId,
 		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
 	) {
-		return makePromise(() => pieceTakeNow(this, rundownPlaylistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy))
+		return traceAction(
+			'userAction.pieceTakeNow',
+			pieceTakeNow,
+			this,
+			rundownPlaylistId,
+			partInstanceId,
+			pieceInstanceIdOrPieceIdToCopy
+		)
 	}
 	setInOutPoints(
 		_userEvent: string,
@@ -853,7 +885,7 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		actionId: string,
 		userData: ActionUserData
 	) {
-		return makePromise(() => executeAction(this, rundownPlaylistId, actionId, userData))
+		return traceAction('userAction.executeAction', executeAction, this, rundownPlaylistId, actionId, userData)
 	}
 	segmentAdLibPieceStart(
 		_userEvent: string,
@@ -862,7 +894,15 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		adlibPieceId: PieceId,
 		queue: boolean
 	) {
-		return makePromise(() => segmentAdLibPieceStart(this, rundownPlaylistId, partInstanceId, adlibPieceId, queue))
+		return traceAction(
+			'userAction.segmentAdLibPieceStart',
+			segmentAdLibPieceStart,
+			this,
+			rundownPlaylistId,
+			partInstanceId,
+			adlibPieceId,
+			queue
+		)
 	}
 	sourceLayerOnPartStop(
 		_userEvent: string,
@@ -870,7 +910,14 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		partInstanceId: PartInstanceId,
 		sourceLayerIds: string[]
 	) {
-		return makePromise(() => sourceLayerOnPartStop(this, rundownPlaylistId, partInstanceId, sourceLayerIds))
+		return traceAction(
+			'userAction.sourceLayerOnPartStop',
+			sourceLayerOnPartStop,
+			this,
+			rundownPlaylistId,
+			partInstanceId,
+			sourceLayerIds
+		)
 	}
 	baselineAdLibPieceStart(
 		_userEvent: string,
@@ -879,12 +926,24 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		adlibPieceId: PieceId,
 		queue: boolean
 	) {
-		return makePromise(() =>
-			rundownBaselineAdLibPieceStart(this, rundownPlaylistId, partInstanceId, adlibPieceId, queue)
+		return traceAction(
+			'userAction.			rundownBaselineAdLibPieceStart',
+			rundownBaselineAdLibPieceStart,
+			this,
+			rundownPlaylistId,
+			partInstanceId,
+			adlibPieceId,
+			queue
 		)
 	}
 	sourceLayerStickyPieceStart(_userEvent: string, rundownPlaylistId: RundownPlaylistId, sourceLayerId: string) {
-		return makePromise(() => sourceLayerStickyPieceStart(this, rundownPlaylistId, sourceLayerId))
+		return traceAction(
+			'userAction.sourceLayerStickyPieceStart',
+			sourceLayerStickyPieceStart,
+			this,
+			rundownPlaylistId,
+			sourceLayerId
+		)
 	}
 	bucketAdlibImport(
 		_userEvent: string,
@@ -893,7 +952,15 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		bucketId: BucketId,
 		ingestItem: IngestAdlib
 	) {
-		return makePromise(() => bucketAdlibImport(this, studioId, showStyleVariantId, bucketId, ingestItem))
+		return traceAction(
+			'userAction.bucketAdlibImport',
+			bucketAdlibImport,
+			this,
+			studioId,
+			showStyleVariantId,
+			bucketId,
+			ingestItem
+		)
 	}
 	bucketAdlibStart(
 		_userEvent: string,
@@ -902,31 +969,39 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		bucketAdlibId: PieceId,
 		queue?: boolean
 	) {
-		return makePromise(() => bucketAdlibStart(this, rundownPlaylistId, partInstanceId, bucketAdlibId, queue))
+		return traceAction(
+			'userAction.bucketAdlibStart',
+			bucketAdlibStart,
+			this,
+			rundownPlaylistId,
+			partInstanceId,
+			bucketAdlibId,
+			queue
+		)
 	}
 	activateHold(_userEvent: string, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-		return makePromise(() => activateHold(this, rundownPlaylistId, undo))
+		return traceAction('userAction.activateHold', activateHold, this, rundownPlaylistId, undo)
 	}
 	saveEvaluation(_userEvent: string, evaluation: EvaluationBase) {
 		return makePromise(() => userSaveEvaluation(this, evaluation))
 	}
 	storeRundownSnapshot(_userEvent: string, playlistId: RundownPlaylistId, reason: string) {
-		return makePromise(() => userStoreRundownSnapshot(this, playlistId, reason))
+		return traceAction('userAction.userStoreRundownSnapshot', userStoreRundownSnapshot, this, playlistId, reason)
 	}
 	removeRundownPlaylist(_userEvent: string, playlistId: RundownPlaylistId) {
-		return makePromise(() => removeRundownPlaylist(this, playlistId))
+		return traceAction('userAction.removeRundownPlaylist', removeRundownPlaylist, this, playlistId)
 	}
 	resyncRundownPlaylist(_userEvent: string, playlistId: RundownPlaylistId) {
-		return makePromise(() => resyncRundownPlaylist(this, playlistId))
+		return traceAction('userAction.resyncRundownPlaylist', resyncRundownPlaylist, this, playlistId)
 	}
 	removeRundown(_userEvent: string, rundownId: RundownId) {
-		return makePromise(() => removeRundown(this, rundownId))
+		return traceAction('userAction.removeRundown', removeRundown, this, rundownId)
 	}
 	resyncRundown(_userEvent: string, rundownId: RundownId) {
-		return makePromise(() => resyncRundown(this, rundownId))
+		return traceAction('userAction.resyncRundown', resyncRundown, this, rundownId)
 	}
 	resyncSegment(_userEvent: string, rundownId: RundownId, segmentId: SegmentId) {
-		return makePromise(() => resyncSegment(this, rundownId, segmentId))
+		return traceAction('userAction.resyncSegment', resyncSegment, this, rundownId, segmentId)
 	}
 	recordStop(_userEvent: string, studioId: StudioId) {
 		return makePromise(() => recordStop(this, studioId))
@@ -953,7 +1028,7 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		return makePromise(() => mediaAbortAllWorkflows(this))
 	}
 	regenerateRundownPlaylist(_userEvent: string, playlistId: RundownPlaylistId) {
-		return makePromise(() => regenerateRundownPlaylist(this, playlistId))
+		return traceAction('userAction.regenerateRundownPlaylist', regenerateRundownPlaylist, this, playlistId)
 	}
 	generateRestartToken(_userEvent: string) {
 		return makePromise(() => generateRestartToken(this))
@@ -962,28 +1037,28 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		return makePromise(() => restartCore(this, token))
 	}
 	guiFocused(_userEvent: string, _viewInfo: any[]) {
-		return makePromise(() => noop(this))
+		return traceAction('userAction.noop', noop, this)
 	}
 	guiBlurred(_userEvent: string, _viewInfo: any[]) {
-		return makePromise(() => noop(this))
+		return traceAction('userAction.noop', noop, this)
 	}
 	bucketsRemoveBucket(_userEvent: string, id: BucketId) {
-		return makePromise(() => bucketsRemoveBucket(this, id))
+		return traceAction('userAction.bucketsRemoveBucket', bucketsRemoveBucket, this, id)
 	}
 	bucketsModifyBucket(_userEvent: string, id: BucketId, bucket: Partial<Omit<Bucket, '_id'>>) {
-		return makePromise(() => bucketsModifyBucket(this, id, bucket))
+		return traceAction('userAction.bucketsModifyBucket', bucketsModifyBucket, this, id, bucket)
 	}
 	bucketsEmptyBucket(_userEvent: string, id: BucketId) {
-		return makePromise(() => bucketsEmptyBucket(this, id))
+		return traceAction('userAction.bucketsEmptyBucket', bucketsEmptyBucket, this, id)
 	}
 	bucketsCreateNewBucket(_userEvent: string, name: string, studioId: StudioId, userId: string | null) {
-		return makePromise(() => bucketsCreateNewBucket(this, name, studioId, userId))
+		return traceAction('userAction.bucketsCreateNewBucket', bucketsCreateNewBucket, this, name, studioId, userId)
 	}
 	bucketsRemoveBucketAdLib(_userEvent: string, id: PieceId) {
-		return makePromise(() => bucketsRemoveBucketAdLib(this, id))
+		return traceAction('userAction.bucketsRemoveBucketAdLib', bucketsRemoveBucketAdLib, this, id)
 	}
 	bucketsModifyBucketAdLib(_userEvent: string, id: PieceId, bucketAdlib: Partial<Omit<BucketAdLib, '_id'>>) {
-		return makePromise(() => bucketsModifyBucketAdLib(this, id, bucketAdlib))
+		return traceAction('userAction.bucketsModifyBucketAdLib', bucketsModifyBucketAdLib, this, id, bucketAdlib)
 	}
 }
 registerClassToMeteorMethods(

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -25,7 +25,6 @@ import { ShowStyleVariants, createShowStyleCompound } from '../lib/collections/S
 import { syncFunction } from './codeControl'
 const PackageInfo = require('../package.json')
 const BlueprintIntegrationPackageInfo = require('../node_modules/tv-automation-sofie-blueprints-integration/package.json')
-// @ts-ignore: ts can't find meteor packages
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 
 export { PackageInfo }

--- a/meteor/server/publications/system.ts
+++ b/meteor/server/publications/system.ts
@@ -14,6 +14,7 @@ meteorPublish(PubSub.coreSystem, function(token) {
 				_id: 1,
 				support: 1,
 				systemInfo: 1,
+				apm: 1,
 				name: 1,
 				serviceMessages: 1,
 				blueprintId: 1,

--- a/meteor/server/security/collections.ts
+++ b/meteor/server/security/collections.ts
@@ -53,7 +53,7 @@ CoreSystem.allow({
 	update(userId, doc, fields, modifier) {
 		const access = allowAccessToCoreSystem({ userId: userId })
 		if (!access.update) return logNotAllowed('CoreSystem', access.reason)
-		return allowOnlyFields(doc, fields, ['support', 'systemInfo', 'name'])
+		return allowOnlyFields(doc, fields, ['support', 'systemInfo', 'name', 'apm'])
 	},
 	remove() {
 		return false

--- a/meteor/server/typings/meteor-kschingiz-elastic-apm.d.ts
+++ b/meteor/server/typings/meteor-kschingiz-elastic-apm.d.ts
@@ -1,0 +1,354 @@
+/**
+ * This is mostly copied from https://github.com/elastic/apm-agent-nodejs/blob/master/index.d.ts
+ * As they do not export any of the inner types, adding `disableMeteorInstrumentations` to `AgentConfigOptions` is not trivial without just copying it all
+ */
+declare module 'meteor/kschingiz:meteor-elastic-apm' {
+	/// <reference types="node" />
+
+	import { IncomingMessage, ServerResponse } from 'http'
+
+	export = agent
+
+	declare const agent: Agent
+
+	declare class Agent implements Taggable, StartSpanFn {
+		// Configuration
+		start(options?: AgentConfigOptions): Agent
+		isStarted(): boolean
+		setFramework(options: { name?: string; version?: string; overwrite?: boolean }): void
+		addPatch(modules: string | Array<string>, handler: string | PatchHandler): void
+		removePatch(modules: string | Array<string>, handler: string | PatchHandler): void
+		clearPatches(modules: string | Array<string>): void
+
+		// Data collection hooks
+		middleware: { connect(): Connect.ErrorHandleFunction }
+		lambda(handler: AwsLambda.Handler): AwsLambda.Handler
+		lambda(type: string, handler: AwsLambda.Handler): AwsLambda.Handler
+		handleUncaughtExceptions(fn?: (err: Error) => void): void
+
+		// Errors
+		captureError(err: Error | string | ParameterizedMessageObject, callback?: CaptureErrorCallback): void
+		captureError(
+			err: Error | string | ParameterizedMessageObject,
+			options?: CaptureErrorOptions,
+			callback?: CaptureErrorCallback
+		): void
+
+		// Distributed Tracing
+		currentTraceparent: string | null
+		currentTraceIds: {
+			'trace.id'?: string
+			'transaction.id'?: string
+			'span.id'?: string
+		}
+
+		// Transactions
+		startTransaction(name?: string | null, options?: TransactionOptions): Transaction | null
+		startTransaction(name: string | null, type: string | null, options?: TransactionOptions): Transaction | null
+		startTransaction(
+			name: string | null,
+			type: string | null,
+			subtype: string | null,
+			options?: TransactionOptions
+		): Transaction | null
+		startTransaction(
+			name: string | null,
+			type: string | null,
+			subtype: string | null,
+			action: string | null,
+			options?: TransactionOptions
+		): Transaction | null
+		setTransactionName(name: string): void
+		endTransaction(result?: string | number, endTime?: number): void
+		currentTransaction: Transaction | null
+
+		// Spans
+		startSpan(name?: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, subtype: string | null, options?: SpanOptions): Span | null
+		startSpan(
+			name: string | null,
+			type: string | null,
+			subtype: string | null,
+			action: string | null,
+			options?: SpanOptions
+		): Span | null
+		currentSpan: Span | null
+
+		// Context
+		setLabel(name: string, value: LabelValue): boolean
+		addLabels(labels: Labels): boolean
+		setUserContext(user: UserObject): void
+		setCustomContext(custom: object): void
+
+		// Transport
+		addFilter(fn: FilterFn): void
+		addErrorFilter(fn: FilterFn): void
+		addSpanFilter(fn: FilterFn): void
+		addTransactionFilter(fn: FilterFn): void
+		flush(callback?: Function): void
+		destroy(): void
+
+		// Utils
+		logger: Logger
+
+		// Custom metrics
+		registerMetric(name: string, callback: Function): void
+		registerMetric(name: string, labels: Labels, callback: Function): void
+	}
+
+	declare class GenericSpan implements Taggable {
+		// The following properties and methods are currently not documented as their API isn't considered official:
+		// timestamp, ended, id, traceId, parentId, sampled, duration()
+
+		type: string | null
+		subtype: string | null
+		action: string | null
+		traceparent: string
+
+		setType(type?: string | null, subtype?: string | null, action?: string | null): void
+		setLabel(name: string, value: LabelValue): boolean
+		addLabels(labels: Labels): boolean
+	}
+
+	declare class Transaction extends GenericSpan implements StartSpanFn {
+		// The following properties and methods are currently not documented as their API isn't considered official:
+		// setUserContext(), setCustomContext(), toJSON(), setDefaultName(), setDefaultNameFromRequest()
+
+		name: string
+		result: string | number
+
+		startSpan(name?: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, subtype: string | null, options?: SpanOptions): Span | null
+		startSpan(
+			name: string | null,
+			type: string | null,
+			subtype: string | null,
+			action: string | null,
+			options?: SpanOptions
+		): Span | null
+		ensureParentId(): string
+		end(result?: string | number | null, endTime?: number): void
+	}
+
+	declare class Span extends GenericSpan {
+		// The following properties and methods are currently not documented as their API isn't considered official:
+		// customStackTrace(), setDbContext()
+
+		transaction: Transaction
+		name: string
+
+		end(endTime?: number): void
+	}
+
+	interface AgentConfigOptions {
+		disableMeteorInstrumentations?: string[]
+		abortedErrorThreshold?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		active?: boolean
+		addPatch?: KeyValueConfig
+		apiRequestSize?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		apiRequestTime?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		asyncHooks?: boolean
+		captureBody?: CaptureBody
+		captureErrorLogStackTraces?: CaptureErrorLogStackTraces
+		captureExceptions?: boolean
+		captureHeaders?: boolean
+		captureSpanStackTraces?: boolean
+		containerId?: string
+		disableInstrumentations?: string | string[]
+		environment?: string
+		errorMessageMaxLength?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		errorOnAbortedRequests?: boolean
+		filterHttpHeaders?: boolean
+		frameworkName?: string
+		frameworkVersion?: string
+		globalLabels?: KeyValueConfig
+		hostname?: string
+		ignoreUrls?: Array<string | RegExp>
+		ignoreUserAgents?: Array<string | RegExp>
+		instrument?: boolean
+		instrumentIncomingHTTPRequests?: boolean
+		kubernetesNamespace?: string
+		kubernetesNodeName?: string
+		kubernetesPodName?: string
+		kubernetesPodUID?: string
+		logLevel?: LogLevel
+		logUncaughtExceptions?: boolean
+		logger?: Logger
+		metricsInterval?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		payloadLogFile?: string
+		centralConfig?: boolean
+		secretToken?: string
+		serverCaCertFile?: string
+		serverTimeout?: string // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+		serverUrl?: string
+		serviceName?: string
+		serviceVersion?: string
+		sourceLinesErrorAppFrames?: number
+		sourceLinesErrorLibraryFrames?: number
+		sourceLinesSpanAppFrames?: number
+		sourceLinesSpanLibraryFrames?: number
+		stackTraceLimit?: number
+		transactionMaxSpans?: number
+		transactionSampleRate?: number
+		usePathAsTransactionName?: boolean
+		verifyServerCert?: boolean
+	}
+
+	interface CaptureErrorOptions {
+		request?: IncomingMessage
+		response?: ServerResponse
+		timestamp?: number
+		handled?: boolean
+		user?: UserObject
+		labels?: Labels
+		tags?: Labels
+		custom?: object
+		message?: string
+	}
+
+	interface Labels {
+		[key: string]: LabelValue
+	}
+
+	interface UserObject {
+		id?: string | number
+		username?: string
+		email?: string
+	}
+
+	interface ParameterizedMessageObject {
+		message: string
+		params: Array<any>
+	}
+
+	interface Logger {
+		fatal(msg: string, ...args: any[]): void
+		fatal(obj: {}, msg?: string, ...args: any[]): void
+		error(msg: string, ...args: any[]): void
+		error(obj: {}, msg?: string, ...args: any[]): void
+		warn(msg: string, ...args: any[]): void
+		warn(obj: {}, msg?: string, ...args: any[]): void
+		info(msg: string, ...args: any[]): void
+		info(obj: {}, msg?: string, ...args: any[]): void
+		debug(msg: string, ...args: any[]): void
+		debug(obj: {}, msg?: string, ...args: any[]): void
+		trace(msg: string, ...args: any[]): void
+		trace(obj: {}, msg?: string, ...args: any[]): void
+		[propName: string]: any
+	}
+
+	interface TransactionOptions {
+		startTime?: number
+		childOf?: Transaction | Span | string
+	}
+
+	interface SpanOptions {
+		childOf?: Transaction | Span | string
+	}
+
+	type CaptureBody = 'off' | 'errors' | 'transactions' | 'all'
+	type CaptureErrorLogStackTraces = 'never' | 'messages' | 'always'
+	type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+
+	type CaptureErrorCallback = (err: Error | null, id: string) => void
+	type FilterFn = (payload: Payload) => Payload | boolean | void
+	type LabelValue = string | number | boolean | null | undefined
+	type KeyValueConfig = string | Labels | Array<Array<LabelValue>>
+
+	type Payload = { [propName: string]: any }
+
+	type PatchHandler = (exports: any, agent: Agent, options: PatchOptions) => any
+
+	interface PatchOptions {
+		version: string | undefined
+		enabled: boolean
+	}
+
+	interface Taggable {
+		setLabel(name: string, value: LabelValue): boolean
+		addLabels(labels: Labels): boolean
+	}
+
+	interface StartSpanFn {
+		startSpan(name?: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, options?: SpanOptions): Span | null
+		startSpan(name: string | null, type: string | null, subtype: string | null, options?: SpanOptions): Span | null
+		startSpan(
+			name: string | null,
+			type: string | null,
+			subtype: string | null,
+			action: string | null,
+			options?: SpanOptions
+		): Span | null
+	}
+
+	// Inlined from @types/aws-lambda - start
+	declare namespace AwsLambda {
+		interface CognitoIdentity {
+			cognitoIdentityId: string
+			cognitoIdentityPoolId: string
+		}
+
+		interface ClientContext {
+			client: ClientContextClient
+			custom?: any
+			env: ClientContextEnv
+		}
+
+		interface ClientContextClient {
+			installationId: string
+			appTitle: string
+			appVersionName: string
+			appVersionCode: string
+			appPackageName: string
+		}
+
+		interface ClientContextEnv {
+			platformVersion: string
+			platform: string
+			make: string
+			model: string
+			locale: string
+		}
+
+		type Callback<TResult = any> = (error?: Error | null | string, result?: TResult) => void
+
+		interface Context {
+			// Properties
+			callbackWaitsForEmptyEventLoop: boolean
+			functionName: string
+			functionVersion: string
+			invokedFunctionArn: string
+			memoryLimitInMB: number
+			awsRequestId: string
+			logGroupName: string
+			logStreamName: string
+			identity?: CognitoIdentity
+			clientContext?: ClientContext
+
+			// Functions
+			getRemainingTimeInMillis(): number
+
+			// Functions for compatibility with earlier Node.js Runtime v0.10.42
+			// For more details see http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html#nodejs-prog-model-oldruntime-context-methods
+			done(error?: Error, result?: any): void
+			fail(error: Error | string): void
+			succeed(messageOrObject: any): void
+			succeed(message: string, object: any): void
+		}
+
+		type Handler<TEvent = any, TResult = any> = (
+			event: TEvent,
+			context: Context,
+			callback: Callback<TResult>
+		) => void | Promise<TResult>
+	}
+
+	// Inlined from @types/connect - start
+	declare namespace Connect {
+		type NextFunction = (err?: any) => void
+		type ErrorHandleFunction = (err: any, req: IncomingMessage, res: ServerResponse, next: NextFunction) => void
+	}
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds optional monitoring through Elastic APM if a host is specified through the environment variable "APM_HOST". Optionally the secretToken can be supplied through the "APM_SECRET" env variable.

This also includes settings in the UI for enabling / disabling the monitoring and setting the trace resolution. A trace resolution of 1 will trace all calls but will make the execution significantly slower. A trace resolution of -1 will only report transaction times but none of the other traces. Performance will then be similar to not having any tracing.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
