### PR TITLE
Feat/tally tags

### DIFF
--- a/meteor/client/styles/shelf/adLibRegionPanel.scss
+++ b/meteor/client/styles/shelf/adLibRegionPanel.scss
@@ -47,12 +47,12 @@
 			}
 		}
 
+		&.on-air {
+			border: 3px solid var(--general-live-color) !important;
+		}
+
 		&.next {
 			border: 3px solid var(--general-next-color);
-		}
-		
-		&.on-air {
-			border: 3px solid var(--general-live-color);
 		}
 	}
 }

--- a/meteor/client/styles/shelf/adLibRegionPanel.scss
+++ b/meteor/client/styles/shelf/adLibRegionPanel.scss
@@ -47,12 +47,12 @@
 			}
 		}
 
-		&.on-air {
-			border: 3px solid var(--general-live-color);
-		}
-
 		&.next {
 			border: 3px solid var(--general-next-color);
+		}
+		
+		&.on-air {
+			border: 3px solid var(--general-live-color);
 		}
 	}
 }

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1531,6 +1531,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					})
 				}
 			})
+
 			this.autorun(() => {
 				let playlist = RundownPlaylists.findOne(playlistId, {
 					fields: {
@@ -1580,6 +1581,34 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 							$in: rundownIDs,
 						},
 					})
+					if (this.props.onlyShelf) {
+						this.subscribe(PubSub.parts, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+						})
+						this.subscribe(PubSub.partInstances, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+							reset: {
+								$ne: true,
+							},
+						})
+						this.subscribe(PubSub.pieces, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+						})
+						this.subscribe(PubSub.pieceInstances, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+							reset: {
+								$ne: true,
+							},
+						})
+					}
 				}
 			})
 			this.autorun(() => {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1582,27 +1582,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						},
 					})
 					if (this.props.onlyShelf) {
-						this.subscribe(PubSub.parts, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-						})
-						this.subscribe(PubSub.partInstances, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-							reset: {
-								$ne: true,
-							},
-						})
-						this.subscribe(PubSub.pieces, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-						})
 						this.subscribe(PubSub.pieceInstances, {
 							rundownId: {
 								$in: rundownIDs,
+							},
+							partInstanceId: {
+								$in: [
+									playlist.currentPartInstanceId,
+									playlist.nextPartInstanceId,
+									playlist.previousPartInstanceId,
+								].filter((p) => p !== null),
 							},
 							reset: {
 								$ne: true,

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -51,7 +51,7 @@ import {
 } from '../../../lib/collections/PartInstances'
 import { MeteorCall } from '../../../lib/api/methods'
 import { SegmentUi, PieceUi } from '../SegmentTimeline/SegmentTimelineContainer'
-import { AdLibActions, AdLibActionCommon, AdLibAction } from '../../../lib/collections/AdLibActions'
+import { AdLibActions, AdLibAction } from '../../../lib/collections/AdLibActions'
 import { RundownUtils } from '../../lib/rundown'
 import { ShelfTabs } from './Shelf'
 import {
@@ -470,6 +470,37 @@ export interface IAdLibPanelTrackedProps {
 	rundownBaselineAdLibs: Array<AdLibPieceUi>
 }
 
+function actionToAdLibPieceUi(action: AdLibAction | RundownBaselineAdLibAction): AdLibPieceUi {
+	let sourceLayerId = ''
+	let outputLayerId = ''
+	let content: Omit<SomeContent, 'timelineObject'> | undefined = undefined
+	const isContent = RundownUtils.isAdlibActionContent(action.display)
+	if (isContent) {
+		sourceLayerId = (action.display as IBlueprintActionManifestDisplayContent).sourceLayerId
+		outputLayerId = (action.display as IBlueprintActionManifestDisplayContent).outputLayerId
+		content = (action.display as IBlueprintActionManifestDisplayContent).content
+	}
+
+	return literal<AdLibPieceUi>({
+		_id: protectString(`function_${action._id}`),
+		name: action.display.label,
+		status: RundownAPI.PieceStatusCode.UNKNOWN,
+		isAction: true,
+		expectedDuration: 0,
+		disabled: false,
+		externalId: unprotectString(action._id),
+		rundownId: action.rundownId,
+		sourceLayerId,
+		outputLayerId,
+		_rank: action.display._rank || 0,
+		content: content,
+		adlibAction: action,
+		tags: action.display.tags,
+		onAirTags: action.display.onAirTags,
+		setNextTags: action.display.setNextTags,
+	})
+}
+
 export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanelTrackedProps {
 	const { t } = props
 
@@ -610,35 +641,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 			)
 				.fetch()
 				.map((action) => {
-					let sourceLayerId = ''
-					let outputLayerId = ''
-					let content: Omit<SomeContent, 'timelineObject'> | undefined = undefined
-					const isContent = RundownUtils.isAdlibActionContent(action.display)
-					if (isContent) {
-						sourceLayerId = (action.display as IBlueprintActionManifestDisplayContent).sourceLayerId
-						outputLayerId = (action.display as IBlueprintActionManifestDisplayContent).outputLayerId
-						content = (action.display as IBlueprintActionManifestDisplayContent).content
-					}
-
-					return [
-						action.partId,
-						literal<AdLibPieceUi>({
-							_id: protectString(`function_${action._id}`),
-							name: action.display.label,
-							status: RundownAPI.PieceStatusCode.UNKNOWN,
-							isAction: true,
-							expectedDuration: 0,
-							lifespan: PieceLifespan.WithinPart,
-							externalId: unprotectString(action._id),
-							rundownId: action.rundownId,
-							sourceLayerId,
-							outputLayerId,
-							_rank: action.display._rank || 0,
-							content: content,
-							adlibAction: action,
-							tags: action.display.tags,
-						}),
-					]
+					return [action.partId, actionToAdLibPieceUi(action)]
 				}),
 		'adLibActions',
 		rundownIds,
@@ -759,35 +762,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): IAdLibPanel
 								}
 							)
 								.fetch()
-								.map((action) => {
-									let sourceLayerId = ''
-									let outputLayerId = ''
-									let content: Omit<SomeContent, 'timelineObject'> | undefined = undefined
-									const isContent = RundownUtils.isAdlibActionContent(action.display)
-									if (isContent) {
-										sourceLayerId = (action.display as IBlueprintActionManifestDisplayContent).sourceLayerId
-										outputLayerId = (action.display as IBlueprintActionManifestDisplayContent).outputLayerId
-										content = (action.display as IBlueprintActionManifestDisplayContent).content
-									}
-
-									return literal<AdLibPieceUi>({
-										_id: protectString(`function_${action._id}`),
-										name: action.display.label,
-										status: RundownAPI.PieceStatusCode.UNKNOWN,
-										isAction: true,
-										isGlobal: true,
-										expectedDuration: 0,
-										lifespan: PieceLifespan.WithinPart,
-										externalId: unprotectString(action._id),
-										rundownId: action.rundownId,
-										sourceLayerId,
-										outputLayerId,
-										_rank: action.display._rank || 0,
-										content: content,
-										adlibAction: action,
-										tags: action.display.tags,
-									})
-								}),
+								.map((action) => actionToAdLibPieceUi(action)),
 						'globalAdLibActions',
 						rundownIds
 					)

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -487,7 +487,6 @@ function actionToAdLibPieceUi(action: AdLibAction | RundownBaselineAdLibAction):
 		status: RundownAPI.PieceStatusCode.UNKNOWN,
 		isAction: true,
 		expectedDuration: 0,
-		disabled: false,
 		externalId: unprotectString(action._id),
 		rundownId: action.rundownId,
 		sourceLayerId,
@@ -498,6 +497,7 @@ function actionToAdLibPieceUi(action: AdLibAction | RundownBaselineAdLibAction):
 		tags: action.display.tags,
 		currentPieceTags: action.display.currentPieceTags,
 		nextPieceTags: action.display.nextPieceTags,
+		lifespan: PieceLifespan.WithinPart, // value doesn't matter
 	})
 }
 

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -496,8 +496,8 @@ function actionToAdLibPieceUi(action: AdLibAction | RundownBaselineAdLibAction):
 		content: content,
 		adlibAction: action,
 		tags: action.display.tags,
-		onAirTags: action.display.onAirTags,
-		setNextTags: action.display.setNextTags,
+		currentPieceTags: action.display.currentPieceTags,
+		nextPieceTags: action.display.nextPieceTags,
 	})
 }
 

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -12,6 +12,8 @@ import {
 	IDashboardPanelTrackedProps,
 	getUnfinishedPieceInstancesGrouped,
 	getNextPieceInstancesGrouped,
+	isAdLibOnAir,
+	isAdLibNext,
 } from './DashboardPanel'
 import ClassNames from 'classnames'
 import { AdLibPieceUi, IAdLibPanelProps, IAdLibPanelTrackedProps, fetchAndFilter, matchFilter } from './AdLibPanel'
@@ -21,7 +23,7 @@ import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications'
 import { unprotectString } from '../../../lib/lib'
 import { PartInstanceId } from '../../../lib/collections/PartInstances'
-import { PieceInstances, PieceInstance } from '../../../lib/collections/PieceInstances'
+import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { MeteorCall } from '../../../lib/api/methods'
 
 interface IState {}
@@ -44,23 +46,11 @@ export class AdLibRegionPanelInner extends MeteorReactComponent<
 	}
 
 	isAdLibOnAir(adLib: AdLibPieceUi) {
-		if (
-			this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
-			this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0
-		) {
-			return true
-		}
-		return false
+		return isAdLibOnAir(this.props.unfinishedAdLibIds, this.props.unfinishedTags, adLib)
 	}
 
 	isAdLibNext(adLib: AdLibPieceUi) {
-		if (
-			this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
-			this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0
-		) {
-			return true
-		}
-		return false
+		return isAdLibNext(this.props.nextAdLibIds, this.props.nextTags, adLib)
 	}
 
 	onToggleSticky = (sourceLayerId: string, e: any) => {
@@ -192,18 +182,16 @@ export const AdLibRegionPanel = translateWithTracker<
 >(
 	(props: Translated<IAdLibPanelProps & IAdLibRegionPanelProps>) => {
 		const studio = props.playlist.getStudio()
-		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
 			props.playlist.currentPartInstanceId
 		)
-		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
-			props.playlist.nextPartInstanceId
-		)
+		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
 		return Object.assign({}, fetchAndFilter(props), {
 			studio: studio,
-			unfinishedPieceInstancesByAdlibId,
-			unfinishedPieceInstancesByTag,
-			nextPieceInstancesByAdlibId,
-			nextPieceInstancesByAdlibTag,
+			unfinishedAdLibIds,
+			unfinishedTags,
+			nextAdLibIds,
+			nextTags,
 		})
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -50,7 +50,7 @@ export class AdLibRegionPanelInner extends MeteorReactComponent<
 	}
 
 	isAdLibNext(adLib: AdLibPieceUi) {
-		return isAdLibNext(this.props.nextAdLibIds, this.props.nextTags, adLib)
+		return isAdLibNext(this.props.nextAdLibIds, this.props.unfinishedTags, this.props.nextTags, adLib)
 	}
 
 	onToggleSticky = (sourceLayerId: string, e: any) => {

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -28,13 +28,13 @@ import {
 	IDashboardPanelTrackedProps,
 	getUnfinishedPieceInstancesGrouped,
 	getNextPieceInstancesGrouped,
+	isAdLibOnAir,
 } from './DashboardPanel'
 import { BucketAdLib, BucketAdLibs } from '../../../lib/collections/BucketAdlibs'
 import { Bucket, BucketId } from '../../../lib/collections/Buckets'
 import { Events as MOSEvents } from '../../lib/data/mos/plugin-support'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
-import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { DragDropItemTypes } from '../DragDropItemTypes'
 import { PieceId } from '../../../lib/collections/Pieces'
 import { BucketPieceButton } from './BucketPieceButton'
@@ -42,6 +42,7 @@ import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import update from 'immutability-helper'
 import { ShowStyleVariantId } from '../../../lib/collections/ShowStyleVariants'
 import { PartInstances, PartInstance } from '../../../lib/collections/PartInstances'
+import { AdLibPieceUi } from './AdLibPanel'
 
 const bucketSource = {
 	beginDrag(props: IBucketPanelProps, monitor: DragSourceMonitor, component: any) {
@@ -211,12 +212,10 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 				showStyleVariantId = rundown.showStyleVariantId
 			}
 		}
-		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
 			props.playlist.currentPartInstanceId
 		)
-		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
-			props.playlist.nextPartInstanceId
-		)
+		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
 		return literal<IBucketPanelTrackedProps>({
 			adLibPieces: BucketAdLibs.find(
 				{
@@ -230,11 +229,11 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 				}
 			).fetch(),
 			studio: props.playlist.getStudio(),
-			unfinishedPieceInstancesByAdlibId,
-			unfinishedPieceInstancesByTag,
+			unfinishedAdLibIds,
+			unfinishedTags,
 			showStyleVariantId,
-			nextPieceInstancesByAdlibId,
-			nextPieceInstancesByAdlibTag,
+			nextAdLibIds,
+			nextTags,
 		})
 	},
 	(data, props: IBucketPanelProps, nextProps: IBucketPanelProps) => {
@@ -339,14 +338,8 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 					window.removeEventListener(MOSEvents.dragleave, this.onDragLeave)
 				}
 
-				isAdLibOnAir(adLib: IAdLibListItem) {
-					if (
-						this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
-						this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0
-					) {
-						return true
-					}
-					return false
+				isAdLibOnAir(adLibPiece: AdLibPieceUi) {
+					return isAdLibOnAir(this.props.unfinishedAdLibIds, this.props.unfinishedTags, adLibPiece)
 				}
 
 				onDragEnter = () => {
@@ -408,7 +401,10 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						return
 					}
 					if (this.props.playlist && this.props.playlist.currentPartInstanceId) {
-						if (!this.isAdLibOnAir(piece) || !(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
+						if (
+							!this.isAdLibOnAir((piece as any) as AdLibPieceUi) ||
+							!(sourceLayer && sourceLayer.clearKeyboardHotkey)
+						) {
 							const currentPartInstanceId = this.props.playlist.currentPartInstanceId
 
 							doUserAction(t, e, UserAction.START_BUCKET_ADLIB, (e) =>
@@ -624,7 +620,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 														outputLayer={this.state.outputLayers[adlib.outputLayerId]}
 														onToggleAdLib={this.onToggleAdLib}
 														playlist={this.props.playlist}
-														isOnAir={this.isAdLibOnAir((adlib as any) as IAdLibListItem)}
+														isOnAir={this.isAdLibOnAir((adlib as any) as AdLibPieceUi)}
 														mediaPreviewUrl={
 															this.props.studio
 																? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || ''

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -165,19 +165,34 @@ export class DashboardPanelInner extends MeteorReactComponent<
 					startedPlayback: {
 						$exists: true,
 					},
-					adLibSourceId: {
-						$exists: true,
-					},
-					$or: [
+					$and: [
 						{
-							stoppedPlayback: {
-								$eq: 0,
-							},
+							$or: [
+								{
+									adLibSourceId: {
+										$exists: true,
+									},
+								},
+								{
+									'piece.tags': {
+										$exists: true,
+									},
+								},
+							],
 						},
 						{
-							stoppedPlayback: {
-								$exists: false,
-							},
+							$or: [
+								{
+									stoppedPlayback: {
+										$eq: 0,
+									},
+								},
+								{
+									stoppedPlayback: {
+										$exists: false,
+									},
+								},
+							],
 						},
 					],
 				})
@@ -575,20 +590,33 @@ export function getUnfinishedPieceInstancesReactive(currentPartInstanceId: PartI
 						},
 					],
 				},
-			],
-			adLibSourceId: {
-				$exists: true,
-			},
-			$or: [
 				{
-					userDuration: {
-						$exists: false,
-					},
+					$or: [
+						{
+							adLibSourceId: {
+								$exists: true,
+							},
+						},
+						{
+							'piece.tags': {
+								$exists: true,
+							},
+						},
+					],
 				},
 				{
-					'userDuration.end': {
-						$exists: false,
-					},
+					$or: [
+						{
+							userDuration: {
+								$exists: false,
+							},
+						},
+						{
+							'userDuration.end': {
+								$exists: false,
+							},
+						},
+					],
 				},
 			],
 		}).fetch()
@@ -658,8 +686,8 @@ export function getUnfinishedPieceInstancesGrouped(
 	const unfinishedPieceInstances = getUnfinishedPieceInstancesReactive(currentPartInstanceId)
 
 	const unfinishedAdLibIds: PieceId[] = unfinishedPieceInstances
-		.filter((piece) => !!piece.piece.adLibSourceId)
-		.map((piece) => piece.piece.adLibSourceId!)
+		.filter((piece) => !!piece.adLibSourceId)
+		.map((piece) => piece.adLibSourceId!)
 	const unfinishedTags: string[] = unfinishedPieceInstances
 		.filter((piece) => !!piece.piece.tags)
 		.map((piece) => piece.piece.tags!)
@@ -677,8 +705,8 @@ export function getNextPieceInstancesGrouped(
 	const nextPieceInstances = getNextPiecesReactive(nextPartInstanceId)
 
 	const nextAdLibIds: PieceId[] = nextPieceInstances
-		.filter((piece) => !!piece.piece.adLibSourceId)
-		.map((piece) => piece.piece.adLibSourceId!)
+		.filter((piece) => !!piece.adLibSourceId)
+		.map((piece) => piece.adLibSourceId!)
 	const nextTags: string[] = nextPieceInstances
 		.filter((piece) => !!piece.piece.tags)
 		.map((piece) => piece.piece.tags!)

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -657,14 +657,13 @@ export function getUnfinishedPieceInstancesGrouped(
 ): Pick<IDashboardPanelTrackedProps, 'unfinishedAdLibIds' | 'unfinishedTags'> {
 	const unfinishedPieceInstances = getUnfinishedPieceInstancesReactive(currentPartInstanceId)
 
-	const unfinishedAdLibIds: PieceId[] = [
-		...new Set(
-			unfinishedPieceInstances.filter((piece) => !!piece.piece.adLibSourceId).map((piece) => piece.piece.adLibSourceId!)
-		),
-	]
-	const unfinishedTags: string[] = [
-		...new Set(...unfinishedPieceInstances.filter((piece) => !!piece.piece.tags).map((piece) => piece.piece.tags!)),
-	]
+	const unfinishedAdLibIds: PieceId[] = unfinishedPieceInstances
+		.filter((piece) => !!piece.piece.adLibSourceId)
+		.map((piece) => piece.piece.adLibSourceId!)
+	const unfinishedTags: string[] = unfinishedPieceInstances
+		.filter((piece) => !!piece.piece.tags)
+		.map((piece) => piece.piece.tags!)
+		.reduce((a, b) => a.concat(b), [])
 
 	return {
 		unfinishedAdLibIds,
@@ -725,21 +724,17 @@ export const DashboardPanel = translateWithTracker<
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps>) => {
-		const {
-			unfinishedAdLibIds: unfinishedPieceInstancesByAdlibId,
-			unfinishedTags: unfinishedPieceInstancesByTag,
-		} = getUnfinishedPieceInstancesGrouped(props.playlist.currentPartInstanceId)
-		const {
-			nextAdLibIds: nextPieceInstancesByAdlibId,
-			nextTags: nextPieceInstancesByAdlibTag,
-		} = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
+			props.playlist.currentPartInstanceId
+		)
+		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			unfinishedAdLibIds: unfinishedPieceInstancesByAdlibId,
-			unfinishedTags: unfinishedPieceInstancesByTag,
-			nextAdLibIds: nextPieceInstancesByAdlibId,
-			nextTags: nextPieceInstancesByAdlibTag,
+			unfinishedAdLibIds,
+			unfinishedTags,
+			nextAdLibIds,
+			nextTags,
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -676,14 +676,13 @@ export function getNextPieceInstancesGrouped(
 ): Pick<IDashboardPanelTrackedProps, 'nextAdLibIds' | 'nextTags'> & { nextPieceInstances: PieceInstance[] } {
 	const nextPieceInstances = getNextPiecesReactive(nextPartInstanceId)
 
-	const nextAdLibIds: PieceId[] = [
-		...new Set(
-			nextPieceInstances.filter((piece) => !!piece.piece.adLibSourceId).map((piece) => piece.piece.adLibSourceId!)
-		),
-	]
-	const nextTags: string[] = [
-		...new Set(...nextPieceInstances.filter((piece) => !!piece.piece.tags).map((piece) => piece.piece.tags!)),
-	]
+	const nextAdLibIds: PieceId[] = nextPieceInstances
+		.filter((piece) => !!piece.piece.adLibSourceId)
+		.map((piece) => piece.piece.adLibSourceId!)
+	const nextTags: string[] = nextPieceInstances
+		.filter((piece) => !!piece.piece.tags)
+		.map((piece) => piece.piece.tags!)
+		.reduce((a, b) => a.concat(b), [])
 
 	return { nextAdLibIds, nextTags, nextPieceInstances }
 }

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -64,18 +64,10 @@ export interface IDashboardPanelProps {
 
 export interface IDashboardPanelTrackedProps {
 	studio?: Studio
-	unfinishedPieceInstancesByAdlibId: {
-		[adlibId: string]: PieceInstance[]
-	}
-	unfinishedPieceInstancesByTag: {
-		[tag: string]: PieceInstance[]
-	}
-	nextPieceInstancesByAdlibId: {
-		[adlibid: string]: PieceInstance[]
-	}
-	nextPieceInstancesByAdlibTag: {
-		[tag: string]: PieceInstance[]
-	}
+	unfinishedAdLibIds: PieceId[]
+	unfinishedTags: string[]
+	nextAdLibIds: PieceId[]
+	nextTags: string[]
 }
 
 interface DashboardPositionableElement {
@@ -211,27 +203,11 @@ export class DashboardPanelInner extends MeteorReactComponent<
 	}
 
 	isAdLibOnAir(adLib: AdLibPieceUi) {
-		if (
-			(this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
-				this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0) ||
-			(adLib.onAirTags &&
-				adLib.onAirTags.every((tag) => Object.keys(this.props.unfinishedPieceInstancesByTag).includes(tag)))
-		) {
-			return true
-		}
-		return false
+		return isAdLibOnAir(this.props.unfinishedAdLibIds, this.props.unfinishedTags, adLib)
 	}
 
 	isAdLibNext(adLib: AdLibPieceUi) {
-		if (
-			(this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
-				this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0) ||
-			(adLib.setNextTags &&
-				adLib.setNextTags.every((tag) => Object.keys(this.props.nextPieceInstancesByAdlibTag).includes(tag)))
-		) {
-			return true
-		}
-		return false
+		return isAdLibNext(this.props.nextAdLibIds, this.props.nextTags, adLib)
 	}
 
 	refreshKeyboardHotkeys() {
@@ -678,56 +654,67 @@ export function getNextPiecesReactive(nextPartInstanceId: PartInstanceId | null)
 
 export function getUnfinishedPieceInstancesGrouped(
 	currentPartInstanceId: PartInstanceId | null
-): Pick<IDashboardPanelTrackedProps, 'unfinishedPieceInstancesByAdlibId' | 'unfinishedPieceInstancesByTag'> {
-	const unfinishedPieces = getUnfinishedPieceInstancesReactive(currentPartInstanceId)
+): Pick<IDashboardPanelTrackedProps, 'unfinishedAdLibIds' | 'unfinishedTags'> {
+	const unfinishedPieceInstances = getUnfinishedPieceInstancesReactive(currentPartInstanceId)
 
-	const unfinishedPieceInstancesByAdlibId: { [adlibId: string]: PieceInstance[] } = {}
-	_.each(
-		_.groupBy(unfinishedPieces, (piece) => piece.piece.adLibSourceId),
-		(grp, id) => (unfinishedPieceInstancesByAdlibId[id] = _.map(grp, (instance) => instance))
-	)
-	const unfinishedPieceInstancesByTag: { [tag: string]: PieceInstance[] } = {}
-	unfinishedPieces
-		.filter((piece) => !!piece.piece.tags)
-		.forEach((piece) => {
-			piece.piece.tags!.forEach((tag) => {
-				if (unfinishedPieceInstancesByTag[tag] === undefined) {
-					unfinishedPieceInstancesByTag[tag] = []
-				}
-				unfinishedPieceInstancesByTag[tag].push(piece)
-			})
-		})
+	const unfinishedAdLibIds: PieceId[] = [
+		...new Set(
+			unfinishedPieceInstances.filter((piece) => !!piece.piece.adLibSourceId).map((piece) => piece.piece.adLibSourceId!)
+		),
+	]
+	const unfinishedTags: string[] = [
+		...new Set(...unfinishedPieceInstances.filter((piece) => !!piece.piece.tags).map((piece) => piece.piece.tags!)),
+	]
 
 	return {
-		unfinishedPieceInstancesByAdlibId,
-		unfinishedPieceInstancesByTag,
+		unfinishedAdLibIds,
+		unfinishedTags,
 	}
 }
 
 export function getNextPieceInstancesGrouped(
 	nextPartInstanceId: PartInstanceId | null
-): Pick<IDashboardPanelTrackedProps, 'nextPieceInstancesByAdlibId' | 'nextPieceInstancesByAdlibTag'> {
+): Pick<IDashboardPanelTrackedProps, 'nextAdLibIds' | 'nextTags'> & { nextPieceInstances: PieceInstance[] } {
 	const nextPieceInstances = getNextPiecesReactive(nextPartInstanceId)
 
-	const nextPieceInstancesByAdlibId: { [adlib: string]: PieceInstance[] } = {}
-	_.each(
-		_.groupBy(nextPieceInstances, (piece) => piece.piece.adLibSourceId),
-		(grp, id) => (nextPieceInstancesByAdlibId[id] = _.map(grp, (instance) => instance))
-	)
+	const nextAdLibIds: PieceId[] = [
+		...new Set(
+			nextPieceInstances.filter((piece) => !!piece.piece.adLibSourceId).map((piece) => piece.piece.adLibSourceId!)
+		),
+	]
+	const nextTags: string[] = [
+		...new Set(...nextPieceInstances.filter((piece) => !!piece.piece.tags).map((piece) => piece.piece.tags!)),
+	]
 
-	const nextPieceInstancesByAdlibTag: { [tag: string]: PieceInstance[] } = {}
-	nextPieceInstances
-		.filter((piece) => !!piece.piece.tags)
-		.forEach((piece) => {
-			piece.piece.tags!.forEach((tag) => {
-				if (nextPieceInstancesByAdlibTag[tag] === undefined) {
-					nextPieceInstancesByAdlibTag[tag] = []
-				}
-				nextPieceInstancesByAdlibTag[tag].push(piece)
-			})
-		})
+	return { nextAdLibIds, nextTags, nextPieceInstances }
+}
 
-	return { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag }
+export function isAdLibOnAir(
+	unfinishedAdLibIds: IDashboardPanelTrackedProps['unfinishedAdLibIds'],
+	unfinishedTags: IDashboardPanelTrackedProps['unfinishedTags'],
+	adLib: AdLibPieceUi
+) {
+	if (
+		unfinishedAdLibIds.includes(adLib._id) ||
+		(adLib.onAirTags && adLib.onAirTags.every((tag) => unfinishedTags.includes(tag)))
+	) {
+		return true
+	}
+	return false
+}
+
+export function isAdLibNext(
+	nextAdLibIds: IDashboardPanelTrackedProps['nextAdLibIds'],
+	nextTags: IDashboardPanelTrackedProps['nextTags'],
+	adLib: AdLibPieceUi
+) {
+	if (
+		nextAdLibIds.includes(adLib._id) ||
+		(adLib.setNextTags && adLib.setNextTags.every((tag) => nextTags.includes(tag)))
+	) {
+		return true
+	}
+	return false
 }
 
 export const DashboardPanel = translateWithTracker<
@@ -736,19 +723,21 @@ export const DashboardPanel = translateWithTracker<
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps>) => {
-		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
-			props.playlist.currentPartInstanceId
-		)
-		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
-			props.playlist.nextPartInstanceId
-		)
+		const {
+			unfinishedAdLibIds: unfinishedPieceInstancesByAdlibId,
+			unfinishedTags: unfinishedPieceInstancesByTag,
+		} = getUnfinishedPieceInstancesGrouped(props.playlist.currentPartInstanceId)
+		const {
+			nextAdLibIds: nextPieceInstancesByAdlibId,
+			nextTags: nextPieceInstancesByAdlibTag,
+		} = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			unfinishedPieceInstancesByAdlibId,
-			unfinishedPieceInstancesByTag,
-			nextPieceInstancesByAdlibId,
-			nextPieceInstancesByAdlibTag,
+			unfinishedAdLibIds: unfinishedPieceInstancesByAdlibId,
+			unfinishedTags: unfinishedPieceInstancesByTag,
+			nextAdLibIds: nextPieceInstancesByAdlibId,
+			nextTags: nextPieceInstancesByAdlibTag,
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -662,7 +662,7 @@ export function getNextPiecesReactive(nextPartInstanceId: PartInstanceId | null)
 				{
 					$or: [
 						{
-							'piece.adLibSourceId': {
+							adLibSourceId: {
 								$exists: true,
 							},
 						},

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -40,8 +40,8 @@ import { invalidateAt } from '../../lib/invalidatingTime'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../../lib/collections/PieceInstances'
 import { MeteorCall } from '../../../lib/api/methods'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
-import { getNextPiecesReactive } from './AdLibRegionPanel'
 import { PartInstanceId } from '../../../lib/collections/PartInstances'
+import { pieceSetInOutPoints } from '../../../server/api/userActions'
 
 interface IState {
 	outputLayers: {
@@ -64,11 +64,17 @@ export interface IDashboardPanelProps {
 
 export interface IDashboardPanelTrackedProps {
 	studio?: Studio
-	unfinishedPieceInstances: {
+	unfinishedPieceInstancesByAdlibId: {
 		[adlibId: string]: PieceInstance[]
 	}
-	nextPieces: {
-		[key: string]: PieceInstance[]
+	unfinishedPieceInstancesByTag: {
+		[tag: string]: PieceInstance[]
+	}
+	nextPieceInstancesByAdlibId: {
+		[adlibid: string]: PieceInstance[]
+	}
+	nextPieceInstancesByAdlibTag: {
+		[tag: string]: PieceInstance[]
 	}
 }
 
@@ -206,8 +212,10 @@ export class DashboardPanelInner extends MeteorReactComponent<
 
 	isAdLibOnAir(adLib: AdLibPieceUi) {
 		if (
-			this.props.unfinishedPieceInstances[unprotectString(adLib._id)] &&
-			this.props.unfinishedPieceInstances[unprotectString(adLib._id)].length > 0
+			(this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
+				this.props.unfinishedPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0) ||
+			(adLib.onAirTags &&
+				adLib.onAirTags.every((tag) => Object.keys(this.props.unfinishedPieceInstancesByTag).includes(tag)))
 		) {
 			return true
 		}
@@ -216,8 +224,10 @@ export class DashboardPanelInner extends MeteorReactComponent<
 
 	isAdLibNext(adLib: AdLibPieceUi) {
 		if (
-			this.props.nextPieces[unprotectString(adLib._id)] &&
-			this.props.nextPieces[unprotectString(adLib._id)].length > 0
+			(this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)] &&
+				this.props.nextPieceInstancesByAdlibId[unprotectString(adLib._id)].length > 0) ||
+			(adLib.setNextTags &&
+				adLib.setNextTags.every((tag) => Object.keys(this.props.nextPieceInstancesByAdlibTag).includes(tag)))
 		) {
 			return true
 		}
@@ -631,14 +641,93 @@ export function getUnfinishedPieceInstancesReactive(currentPartInstanceId: PartI
 		if (Number.isFinite(nearestEnd)) invalidateAt(nearestEnd)
 	}
 
-	// Convert to array of ids as that is all that is needed
-	const unfinishedPieceInstances: { [adlibId: string]: PieceInstance[] } = {}
+	return prospectivePieces
+}
+
+export function getNextPiecesReactive(nextPartInstanceId: PartInstanceId | null): PieceInstance[] {
+	let prospectivePieceInstances: PieceInstance[] = []
+	if (nextPartInstanceId) {
+		prospectivePieceInstances = PieceInstances.find({
+			partInstanceId: nextPartInstanceId,
+			$and: [
+				{
+					piece: {
+						$exists: true,
+					},
+				},
+				{
+					$or: [
+						{
+							'piece.adLibSourceId': {
+								$exists: true,
+							},
+						},
+						{
+							'piece.tags': {
+								$exists: true,
+							},
+						},
+					],
+				},
+			],
+		}).fetch()
+	}
+
+	return prospectivePieceInstances
+}
+
+export function getUnfinishedPieceInstancesGrouped(
+	currentPartInstanceId: PartInstanceId | null
+): Pick<IDashboardPanelTrackedProps, 'unfinishedPieceInstancesByAdlibId' | 'unfinishedPieceInstancesByTag'> {
+	const unfinishedPieces = getUnfinishedPieceInstancesReactive(currentPartInstanceId)
+
+	const unfinishedPieceInstancesByAdlibId: { [adlibId: string]: PieceInstance[] } = {}
 	_.each(
-		_.groupBy(prospectivePieces, (piece) => piece.adLibSourceId),
-		(grp, id) => (unfinishedPieceInstances[id] = _.map(grp, (instance) => instance))
+		_.groupBy(unfinishedPieces, (piece) => piece.piece.adLibSourceId),
+		(grp, id) => (unfinishedPieceInstancesByAdlibId[id] = _.map(grp, (instance) => instance))
+	)
+	const unfinishedPieceInstancesByTag: { [tag: string]: PieceInstance[] } = {}
+	unfinishedPieces
+		.filter((piece) => !!piece.piece.tags)
+		.forEach((piece) => {
+			piece.piece.tags!.forEach((tag) => {
+				if (unfinishedPieceInstancesByTag[tag] === undefined) {
+					unfinishedPieceInstancesByTag[tag] = []
+				}
+				unfinishedPieceInstancesByTag[tag].push(piece)
+			})
+		})
+
+	return {
+		unfinishedPieceInstancesByAdlibId,
+		unfinishedPieceInstancesByTag,
+	}
+}
+
+export function getNextPieceInstancesGrouped(
+	nextPartInstanceId: PartInstanceId | null
+): Pick<IDashboardPanelTrackedProps, 'nextPieceInstancesByAdlibId' | 'nextPieceInstancesByAdlibTag'> {
+	const nextPieceInstances = getNextPiecesReactive(nextPartInstanceId)
+
+	const nextPieceInstancesByAdlibId: { [adlib: string]: PieceInstance[] } = {}
+	_.each(
+		_.groupBy(nextPieceInstances, (piece) => piece.piece.adLibSourceId),
+		(grp, id) => (nextPieceInstancesByAdlibId[id] = _.map(grp, (instance) => instance))
 	)
 
-	return unfinishedPieceInstances
+	const nextPieceInstancesByAdlibTag: { [tag: string]: PieceInstance[] } = {}
+	nextPieceInstances
+		.filter((piece) => !!piece.piece.tags)
+		.forEach((piece) => {
+			piece.piece.tags!.forEach((tag) => {
+				if (nextPieceInstancesByAdlibTag[tag] === undefined) {
+					nextPieceInstancesByAdlibTag[tag] = []
+				}
+				nextPieceInstancesByAdlibTag[tag].push(piece)
+			})
+		})
+
+	return { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag }
 }
 
 export const DashboardPanel = translateWithTracker<
@@ -647,11 +736,19 @@ export const DashboardPanel = translateWithTracker<
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps>) => {
+		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
+			props.playlist.currentPartInstanceId
+		)
+		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
+			props.playlist.nextPartInstanceId
+		)
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			unfinishedPieceInstances: getUnfinishedPieceInstancesReactive(props.playlist.currentPartInstanceId),
-			nextPieces: getNextPiecesReactive(props.playlist.nextPartInstanceId),
+			unfinishedPieceInstancesByAdlibId,
+			unfinishedPieceInstancesByTag,
+			nextPieceInstancesByAdlibId,
+			nextPieceInstancesByAdlibTag,
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -207,7 +207,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 	}
 
 	isAdLibNext(adLib: AdLibPieceUi) {
-		return isAdLibNext(this.props.nextAdLibIds, this.props.nextTags, adLib)
+		return isAdLibNext(this.props.nextAdLibIds, this.props.unfinishedTags, this.props.nextTags, adLib)
 	}
 
 	refreshKeyboardHotkeys() {
@@ -705,11 +705,13 @@ export function isAdLibOnAir(
 
 export function isAdLibNext(
 	nextAdLibIds: IDashboardPanelTrackedProps['nextAdLibIds'],
+	unfinishedTags: IDashboardPanelTrackedProps['unfinishedTags'],
 	nextTags: IDashboardPanelTrackedProps['nextTags'],
 	adLib: AdLibPieceUi
 ) {
 	if (
 		nextAdLibIds.includes(adLib._id) ||
+		(adLib.setNextTags && adLib.setNextTags.every((tag) => unfinishedTags.includes(tag))) ||
 		(adLib.setNextTags && adLib.setNextTags.every((tag) => nextTags.includes(tag)))
 	) {
 		return true

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -722,7 +722,7 @@ export function isAdLibOnAir(
 ) {
 	if (
 		unfinishedAdLibIds.includes(adLib._id) ||
-		(adLib.onAirTags && adLib.onAirTags.every((tag) => unfinishedTags.includes(tag)))
+		(adLib.currentPieceTags && adLib.currentPieceTags.every((tag) => unfinishedTags.includes(tag)))
 	) {
 		return true
 	}
@@ -737,8 +737,8 @@ export function isAdLibNext(
 ) {
 	if (
 		nextAdLibIds.includes(adLib._id) ||
-		(adLib.setNextTags && adLib.setNextTags.every((tag) => unfinishedTags.includes(tag))) ||
-		(adLib.setNextTags && adLib.setNextTags.every((tag) => nextTags.includes(tag)))
+		(adLib.nextPieceTags && adLib.nextPieceTags.every((tag) => unfinishedTags.includes(tag))) ||
+		(adLib.nextPieceTags && adLib.nextPieceTags.every((tag) => nextTags.includes(tag)))
 	) {
 		return true
 	}

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -42,19 +42,17 @@ export const TimelineDashboardPanel = translateWithTracker<
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps & IDashboardPanelProps>) => {
-		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
 			props.playlist.currentPartInstanceId
 		)
-		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
-			props.playlist.nextPartInstanceId
-		)
+		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist.nextPartInstanceId)
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			unfinishedPieceInstancesByAdlibId,
-			unfinishedPieceInstancesByTag,
-			nextPieceInstancesByAdlibId,
-			nextPieceInstancesByAdlibTag,
+			unfinishedAdLibIds,
+			unfinishedTags,
+			nextAdLibIds,
+			nextTags,
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -20,13 +20,12 @@ import { Studio } from '../../../lib/collections/Studios'
 import {
 	DashboardPanelInner,
 	dashboardElementPosition,
-	getUnfinishedPieceInstancesReactive,
 	IDashboardPanelTrackedProps,
 	IDashboardPanelProps,
+	getUnfinishedPieceInstancesGrouped,
+	getNextPieceInstancesGrouped,
 } from './DashboardPanel'
-import { PieceInstanceId, PieceInstance } from '../../../lib/collections/PieceInstances'
-import { unprotectString, protectString } from '../../../lib/lib'
-import { getNextPiecesReactive } from './AdLibRegionPanel'
+import { unprotectString } from '../../../lib/lib'
 interface IState {
 	outputLayers: {
 		[key: string]: IOutputLayer
@@ -43,11 +42,19 @@ export const TimelineDashboardPanel = translateWithTracker<
 	IAdLibPanelTrackedProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps & IDashboardPanelProps>) => {
+		const { unfinishedPieceInstancesByAdlibId, unfinishedPieceInstancesByTag } = getUnfinishedPieceInstancesGrouped(
+			props.playlist.currentPartInstanceId
+		)
+		const { nextPieceInstancesByAdlibId, nextPieceInstancesByAdlibTag } = getNextPieceInstancesGrouped(
+			props.playlist.nextPartInstanceId
+		)
 		return {
 			...fetchAndFilter(props),
 			studio: props.playlist.getStudio(),
-			unfinishedPieceInstances: getUnfinishedPieceInstancesReactive(props.playlist.currentPartInstanceId),
-			nextPieces: getNextPiecesReactive(props.playlist.nextPartInstanceId),
+			unfinishedPieceInstancesByAdlibId,
+			unfinishedPieceInstancesByTag,
+			nextPieceInstancesByAdlibId,
+			nextPieceInstancesByAdlibTag,
 		}
 	},
 	(data, props: IAdLibPanelProps, nextProps: IAdLibPanelProps) => {

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -10190,7 +10190,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -758,7 +758,7 @@ describe('Test blueprint api context', () => {
 					expect(innerStartQueuedAdLibMock).toHaveBeenCalledTimes(0)
 
 					partInstance.part.autoNext = true
-					partInstance.part.expectedDuration = 4000
+					partInstance.part.expectedDuration = 700
 					partInstance.timings = {
 						startedPlayback: getCurrentTime(),
 						stoppedPlayback: undefined,
@@ -768,7 +768,7 @@ describe('Test blueprint api context', () => {
 						takeOut: undefined,
 						next: undefined,
 					}
-					expect(isTooCloseToAutonext(partInstance, false)).toBeTruthy()
+					expect(isTooCloseToAutonext(partInstance, true)).toBeTruthy()
 					expect(() => context.queuePart({} as any, [{}] as any)).toThrowError(
 						'Too close to an autonext to queue a part'
 					)

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -323,7 +323,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			throw new Error('Cannot queue part when next part has already been modified')
 		}
 
-		if (isTooCloseToAutonext(currentPartInstance, false)) {
+		if (isTooCloseToAutonext(currentPartInstance, true)) {
 			throw new Error('Too close to an autonext to queue a part')
 		}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds tags to pieces that can be used by adLibs and adLib actions to signal when they should be considered to be on air or set as next.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, only the `adLibSourceId` is used to determine whether an adLib is in the next / current part and should considered to be on on-air. This does not necessarily work for adLib actions where they could be creating multiple pieces or may create "data storage" pieces that do not currently have an effect on the show, but will if another condition is met. The same is true if, for example, one adLib creates a piece that contains timeline objects that need to be enabled by another piece. This PR hopes to establish an indicator of this relationship.


* **What is the new behavior (if this is a feature change)?**
The above behaviour using `adLibSourceId` will continue to work as expected, however, if a piece with an `adLibSourceId` matching an adLibs ID is not found, Sofie will then look at the properties `onAirTags` and `setNextTags` on the adLib / adLibAction.

These tags are expected to be found on pieces either in the current or next parts. For example, if an adLib has the `onAirTags` property set to `["CAM_1", "CAM_LIVE"]` it will expect to find those tags distributed across the currently active pieces. It doesn't matter whether the tags are on a single piece or on multiple, as long as they are found within the active pieces.

The `setNextTags` have similar behaviour, except that they first check the next part and then check the currently active pieces. This allows an action which creates a "data storage" piece to be highlighted as set as next, "selected", (e.g. the next DVE layout to use) even though it is in the current part.


* **Other information**:
Requires https://github.com/nrkno/tv-automation-sofie-blueprints-integration/pull/74

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
