### PR TITLE
Fix: APM Slowdown

### DIFF
--- a/meteor/server/DatabaseCache.ts
+++ b/meteor/server/DatabaseCache.ts
@@ -19,7 +19,7 @@ import {
 import * as _ from 'underscore'
 import { TransformedCollection, MongoModifier, FindOptions, MongoQuery } from '../lib/typings/meteor'
 import { BulkWriteOperation } from 'mongodb'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from './api/profiler'
 
 export function isDbCacheReadCollection(o: any): o is DbCacheReadCollection<any, any> {
 	return !!(o && typeof o === 'object' && o.fillWithDataFromDatabase)
@@ -80,7 +80,7 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 		selector?: MongoQuery<DBInterface> | DBInterface['_id'] | SelectorFunction<DBInterface>,
 		options?: FindOptions<DBInterface>
 	): Class[] {
-		const span = Agent.startSpan(`DBCache.findFetch.${this.name}`)
+		const span = profiler.startSpan(`DBCache.findFetch.${this.name}`)
 		this._initialize()
 
 		selector = selector || {}
@@ -167,7 +167,7 @@ export class DbCacheWriteCollection<
 	DBInterface extends { _id: ProtectedString<any> }
 > extends DbCacheReadCollection<Class, DBInterface> {
 	insert(doc: DBInterface): DBInterface['_id'] {
-		const span = Agent.startSpan(`DBCache.insert.${this.name}`)
+		const span = profiler.startSpan(`DBCache.insert.${this.name}`)
 		this._initialize()
 
 		const existing = doc._id && this.documents[unprotectString(doc._id)]
@@ -183,7 +183,7 @@ export class DbCacheWriteCollection<
 		return doc._id
 	}
 	remove(selector: MongoQuery<DBInterface> | DBInterface['_id'] | SelectorFunction<DBInterface>): number {
-		const span = Agent.startSpan(`DBCache.remove.${this.name}`)
+		const span = profiler.startSpan(`DBCache.remove.${this.name}`)
 		this._initialize()
 
 		let removed = 0
@@ -209,7 +209,7 @@ export class DbCacheWriteCollection<
 		selector: MongoQuery<DBInterface> | DBInterface['_id'] | SelectorFunction<DBInterface>,
 		modifier: ((doc: DBInterface) => DBInterface) | MongoModifier<DBInterface>
 	): number {
-		const span = Agent.startSpan(`DBCache.update.${this.name}`)
+		const span = profiler.startSpan(`DBCache.update.${this.name}`)
 		this._initialize()
 
 		const selectorInModify: MongoQuery<DBInterface> = _.isFunction(selector)
@@ -248,7 +248,7 @@ export class DbCacheWriteCollection<
 
 	/** Returns true if a doc was replace, false if inserted */
 	replace(doc: DBInterface): boolean {
-		const span = Agent.startSpan(`DBCache.replace.${this.name}`)
+		const span = profiler.startSpan(`DBCache.replace.${this.name}`)
 		this._initialize()
 
 		if (!doc._id) throw new Meteor.Error(500, `Error: The (immutable) field '_id' must be defined: "${doc._id}"`)
@@ -276,7 +276,7 @@ export class DbCacheWriteCollection<
 		numberAffected?: number
 		insertedId?: DBInterface['_id']
 	} {
-		const span = Agent.startSpan(`DBCache.upsert.${this.name}`)
+		const span = profiler.startSpan(`DBCache.upsert.${this.name}`)
 		this._initialize()
 
 		if (isProtectedString(selector)) {
@@ -303,7 +303,7 @@ export class DbCacheWriteCollection<
 		}
 	}
 	async updateDatabaseWithData() {
-		const span = Agent.startSpan(`DBCache.updateDatabaseWithData.${this.name}`)
+		const span = profiler.startSpan(`DBCache.updateDatabaseWithData.${this.name}`)
 		const changes: {
 			insert: number
 			update: number
@@ -404,7 +404,7 @@ export function saveIntoCache<DocClass extends DBInterface, DBInterface extends 
 	newData: Array<DBInterface>,
 	options?: SaveIntoDbOptions<DocClass, DBInterface>
 ): Changes {
-	const span = Agent.startSpan(`DBCache.saveIntoCache.${collection.name}`)
+	const span = profiler.startSpan(`DBCache.saveIntoCache.${collection.name}`)
 	const preparedChanges = prepareSaveIntoCache(collection, filter, newData, options)
 
 	if (span)

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -31,7 +31,7 @@ import { AdLibAction, AdLibActions } from '../lib/collections/AdLibActions'
 import { RundownBaselineAdLibAction, RundownBaselineAdLibActions } from '../lib/collections/RundownBaselineAdLibActions'
 import { isInTestWrite } from './security/lib/securityVerify'
 import { ActivationCache, getActivationCache } from './ActivationCache'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from './api/profiler'
 
 type DeferredFunction<Cache> = (cache: Cache) => void
 
@@ -70,7 +70,7 @@ export class Cache {
 		})
 	}
 	async saveAllToDatabase() {
-		const span = Agent.startSpan('Cache.saveAllToDatabase')
+		const span = profiler.startSpan('Cache.saveAllToDatabase')
 		const startTime = getCurrentTime()
 		this._abortActiveTimeout()
 
@@ -234,7 +234,7 @@ async function fillCacheForRundownPlaylistWithData(
 	playlist: RundownPlaylist,
 	initializeImmediately: boolean
 ) {
-	const span = Agent.startSpan('Cache.fillCacheForRundownPlaylistWithData')
+	const span = profiler.startSpan('Cache.fillCacheForRundownPlaylistWithData')
 	const ps: Promise<any>[] = []
 	cache.Rundowns.prepareInit({ playlistId: playlist._id }, true)
 

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -30,7 +30,7 @@ import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/
 import { PartInstance, PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../lib/collections/PieceInstances'
 import { CacheForRundownPlaylist, initCacheForRundownPlaylist } from '../DatabaseCaches'
-import { profiler } from './api/profiler'
+import { profiler } from './profiler'
 import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
 
 const EVENT_WAIT_TIME = 500

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -30,7 +30,7 @@ import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/
 import { PartInstance, PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../lib/collections/PieceInstances'
 import { CacheForRundownPlaylist, initCacheForRundownPlaylist } from '../DatabaseCaches'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from './api/profiler'
 import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
 
 const EVENT_WAIT_TIME = 500
@@ -173,7 +173,7 @@ export function reportRundownDataHasChanged(
 
 export function reportPartHasStarted(cache: CacheForRundownPlaylist, partInstance: PartInstance, timestamp: Time) {
 	if (partInstance) {
-		const span = Agent.startSpan('reportPartHasStarted')
+		const span = profiler.startSpan('reportPartHasStarted')
 		cache.PartInstances.update(partInstance._id, {
 			$set: {
 				'part.startedPlayback': true,

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -23,7 +23,7 @@ import { getActiveRundownPlaylistsInStudio } from './studio'
 import { RundownPlaylists, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PartInstances } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 export function activateRundownPlaylist(
 	cache: CacheForRundownPlaylist,
@@ -113,7 +113,7 @@ export function deactivateRundownPlaylistInner(
 	cache: CacheForRundownPlaylist,
 	rundownPlaylist: RundownPlaylist
 ): Rundown | undefined {
-	const span = Agent.startSpan('deactivateRundownPlaylistInner')
+	const span = profiler.startSpan('deactivateRundownPlaylistInner')
 	logger.info(`Deactivating rundown playlist "${rundownPlaylist._id}"`)
 
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, rundownPlaylist)

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -37,7 +37,7 @@ import { MongoQuery } from '../../../lib/typings/meteor'
 import { syncPlayheadInfinitesForNextPartInstance, DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { ShowStyleBases, ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 export namespace ServerPlayoutAdLibAPI {
 	export function pieceTakeNow(
@@ -238,7 +238,7 @@ export namespace ServerPlayoutAdLibAPI {
 		currentPartInstance: PartInstance,
 		adLibPiece: AdLibPiece | BucketAdLib
 	) {
-		const span = Agent.startSpan('innerStartOrQueueAdLibPiece')
+		const span = profiler.startSpan('innerStartOrQueueAdLibPiece')
 		if (queue || adLibPiece.toBeQueued) {
 			const newPartInstance = new PartInstance({
 				_id: getRandomId(),
@@ -326,7 +326,7 @@ export namespace ServerPlayoutAdLibAPI {
 		originalOnly: boolean,
 		customQuery?: MongoQuery<PieceInstance>
 	) {
-		const span = Agent.startSpan('innerFindLastPieceOnLayer')
+		const span = profiler.startSpan('innerFindLastPieceOnLayer')
 		const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
 
 		const query = {
@@ -365,7 +365,7 @@ export namespace ServerPlayoutAdLibAPI {
 		newPartInstance: PartInstance,
 		newPieceInstances: PieceInstance[]
 	) {
-		const span = Agent.startSpan('innerStartQueuedAdLib')
+		const span = profiler.startSpan('innerStartQueuedAdLib')
 		logger.info('adlibQueueInsertPartInstance')
 
 		// check if there's already a queued part after this:
@@ -420,7 +420,7 @@ export namespace ServerPlayoutAdLibAPI {
 		existingPartInstance: PartInstance,
 		newPieceInstance: PieceInstance
 	) {
-		const span = Agent.startSpan('innerStartAdLibPiece')
+		const span = profiler.startSpan('innerStartAdLibPiece')
 		// Ensure it is labelled as dynamic
 		newPieceInstance.partInstanceId = existingPartInstance._id
 		newPieceInstance.piece.startPartId = existingPartInstance.part._id
@@ -439,7 +439,7 @@ export namespace ServerPlayoutAdLibAPI {
 		filter: (pieceInstance: PieceInstance) => boolean,
 		timeOffset: number | undefined
 	) {
-		const span = Agent.startSpan('innerStopPieces')
+		const span = profiler.startSpan('innerStopPieces')
 		const stoppedInstances: PieceInstanceId[] = []
 
 		const lastStartedPlayback = currentPartInstance.part.getLastStartedPlayback()

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -15,7 +15,7 @@ import {
 	buildPiecesStartingInThisPartQuery,
 	buildPastInfinitePiecesForThisPartQuery,
 } from '../../../lib/rundown/infinites'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 // /** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
 export const DEFINITELY_ENDED_FUTURE_DURATION = 10 * 1000
@@ -30,7 +30,7 @@ function canContinueAdlibOnEndInfinites(
 	part: DBPart
 ): boolean {
 	if (previousPartInstance && playlist) {
-		const span = Agent.startSpan('canContinueAdlibOnEndInfinites')
+		const span = profiler.startSpan('canContinueAdlibOnEndInfinites')
 		// TODO - if we don't have an index for previousPartInstance, what should we do?
 
 		const expectedNextPart = selectNextPart(playlist, previousPartInstance, orderedParts)
@@ -62,7 +62,7 @@ function canContinueAdlibOnEndInfinites(
 }
 
 function getIdsBeforeThisPart(cache: CacheForRundownPlaylist, nextPart: DBPart) {
-	const span = Agent.startSpan('getIdsBeforeThisPart')
+	const span = profiler.startSpan('getIdsBeforeThisPart')
 	// Note: This makes the assumption that nextPart is a part found in this cache
 	const partsBeforeThisInSegment = cache.Parts.findFetch({
 		segmentId: nextPart.segmentId,
@@ -87,7 +87,7 @@ export async function fetchPiecesThatMayBeActiveForPart(
 	cache: CacheForRundownPlaylist,
 	part: DBPart
 ): Promise<Piece[]> {
-	const span = Agent.startSpan('fetchPiecesThatMayBeActiveForPart')
+	const span = profiler.startSpan('fetchPiecesThatMayBeActiveForPart')
 	const pPiecesStartingInPart = asyncCollectionFindFetch(Pieces, buildPiecesStartingInThisPartQuery(part))
 
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, part)
@@ -106,7 +106,7 @@ export function syncPlayheadInfinitesForNextPartInstance(
 	cache: CacheForRundownPlaylist,
 	playlist: RundownPlaylist
 ): void {
-	const span = Agent.startSpan('syncPlayheadInfinitesForNextPartInstance')
+	const span = profiler.startSpan('syncPlayheadInfinitesForNextPartInstance')
 	const { nextPartInstance, currentPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
 	if (nextPartInstance && currentPartInstance) {
 		const infinites = getPlayheadTrackingInfinitesForPart(cache, playlist, currentPartInstance, nextPartInstance)
@@ -129,7 +129,7 @@ function getPlayheadTrackingInfinitesForPart(
 	playingPartInstance: PartInstance,
 	nextPartInstance: PartInstance
 ): PieceInstance[] {
-	const span = Agent.startSpan('getPlayheadTrackingInfinitesForPart')
+	const span = profiler.startSpan('getPlayheadTrackingInfinitesForPart')
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, nextPartInstance.part)
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)
@@ -165,7 +165,7 @@ export function getPieceInstancesForPart(
 	newInstanceId: PartInstanceId,
 	isTemporary: boolean
 ): PieceInstance[] {
-	const span = Agent.startSpan('getPieceInstancesForPart')
+	const span = profiler.startSpan('getPieceInstancesForPart')
 	const { partsBeforeThisInSegment, segmentsBeforeThisInRundown } = getIdsBeforeThisPart(cache, part)
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -30,9 +30,9 @@ import { MethodContext } from '../../../lib/api/methods'
 import { MongoQuery } from '../../../lib/typings/meteor'
 import { RundownBaselineAdLibActions } from '../../../lib/collections/RundownBaselineAdLibActions'
 import { isAnySyncFunctionsRunning } from '../../codeControl'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 import { Pieces } from '../../../lib/collections/Pieces'
 import { RundownBaselineObjs } from '../../../lib/collections/RundownBaselineObjs'
+import { profiler } from '../profiler'
 
 /**
  * Reset the rundown:
@@ -287,7 +287,7 @@ export function selectNextPart(
 	previousPartInstance: PartInstance | null,
 	parts: Part[]
 ): SelectNextPartResult | undefined {
-	const span = Agent.startSpan('selectNextPart')
+	const span = profiler.startSpan('selectNextPart')
 	const findFirstPlayablePart = (
 		offset: number,
 		condition?: (part: Part) => boolean
@@ -342,7 +342,7 @@ export function setNextPart(
 	setManually?: boolean,
 	nextTimeOffset?: number | undefined
 ) {
-	const span = Agent.startSpan('setNextPart')
+	const span = profiler.startSpan('setNextPart')
 	const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(
 		cache,
@@ -513,7 +513,7 @@ export function setNextSegment(
 	rundownPlaylist: RundownPlaylist,
 	nextSegment: Segment | null
 ) {
-	const span = Agent.startSpan('setNextSegment')
+	const span = profiler.startSpan('setNextSegment')
 	const acceptableRundowns = getRundownIDsFromCache(cache, rundownPlaylist)
 	if (nextSegment) {
 		if (acceptableRundowns.indexOf(nextSegment.rundownId) === -1) {

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -21,7 +21,7 @@ import {
 import { PartInstanceId, PartInstance } from '../../../lib/collections/PartInstances'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { sortPiecesByStart } from './pieces'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 const LOOKAHEAD_OBJ_PRIORITY = 0.1
 
@@ -53,7 +53,7 @@ function getOrderedPartsAfterPlayhead(
 	if (partCount <= 0) {
 		return []
 	}
-	const span = Agent.startSpan('getOrderedPartsAfterPlayhead')
+	const span = profiler.startSpan('getOrderedPartsAfterPlayhead')
 
 	const orderedParts = getAllOrderedPartsFromCache(cache, playlist)
 	const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
@@ -116,7 +116,7 @@ export async function getLookeaheadObjects(
 	studio: Studio,
 	playlist: RundownPlaylist
 ): Promise<Array<TimelineObjGeneric>> {
-	const span = Agent.startSpan('getLookeaheadObjects')
+	const span = profiler.startSpan('getLookeaheadObjects')
 	const mappingsToConsider = Object.entries(studio.mappings ?? {}).filter(
 		([id, map]) => map.lookahead !== LookaheadMode.NONE
 	)
@@ -296,7 +296,7 @@ function findLookaheadForlayer(
 	lookaheadTargetObjects: number,
 	lookaheadMaxSearchDistance: number
 ): LookaheadResult {
-	const span = Agent.startSpan('findLookaheadForlayer')
+	const span = profiler.startSpan('findLookaheadForlayer')
 	const res: LookaheadResult = {
 		timed: [],
 		future: [],
@@ -384,7 +384,7 @@ function findObjectsForPart(
 	if (!partInfo || partInfo.pieces.length === 0) {
 		return []
 	}
-	const span = Agent.startSpan('findObjectsForPart')
+	const span = profiler.startSpan('findObjectsForPart')
 
 	let allObjs: TimelineObjRundown[] = []
 	for (const piece of partInfo.pieces) {

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -40,7 +40,7 @@ import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { processAndPrunePieceInstanceTimings } from '../../../lib/rundown/infinites'
 import { createPieceGroupAndCap } from '../../../lib/rundown/pieces'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 function comparePieceStart<T extends PieceInstancePiece>(a: T, b: T, nowInPart: number): 0 | 1 | -1 {
 	const aStart = a.enable.start === 'now' ? nowInPart : a.enable.start
@@ -200,7 +200,7 @@ export function getResolvedPieces(
 	showStyleBase: ShowStyleBase,
 	partInstance: PartInstance
 ): ResolvedPieceInstance[] {
-	const span = Agent.startSpan('getResolvedPieces')
+	const span = profiler.startSpan('getResolvedPieces')
 	const pieceInstances = cache.PieceInstances.findFetch({ partInstanceId: partInstance._id })
 
 	const pieceInststanceMap = normalizeArray(pieceInstances, '_id')
@@ -241,7 +241,7 @@ export function getResolvedPiecesFromFullTimeline(
 	playlist: RundownPlaylist,
 	allObjs: TimelineObjGeneric[]
 ): { pieces: ResolvedPieceInstance[]; time: number } {
-	const span = Agent.startSpan('getResolvedPiecesFromFullTimeline')
+	const span = profiler.startSpan('getResolvedPiecesFromFullTimeline')
 	const objs = clone(
 		allObjs.filter((o) => o.isGroup && ((o as any).isPartGroup || (o.metaData && o.metaData.pieceId)))
 	)
@@ -291,7 +291,7 @@ export function getResolvedPiecesFromFullTimeline(
 }
 
 export function convertPieceToAdLibPiece(piece: PieceInstancePiece): AdLibPiece {
-	const span = Agent.startSpan('convertPieceToAdLibPiece')
+	const span = profiler.startSpan('convertPieceToAdLibPiece')
 	// const oldId = piece._id
 	const newId = Random.id()
 	const newAdLibPiece = literal<AdLibPiece>({
@@ -328,7 +328,7 @@ export function convertAdLibToPieceInstance(
 	partInstance: PartInstance,
 	queue: boolean
 ): PieceInstance {
-	const span = Agent.startSpan('convertAdLibToPieceInstance')
+	const span = profiler.startSpan('convertAdLibToPieceInstance')
 	let duration: number | undefined = undefined
 	if (adLibPiece['expectedDuration']) {
 		duration = adLibPiece['expectedDuration']

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -42,7 +42,7 @@ import { ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { reportPartHasStarted } from '../asRunLog'
 import { MethodContext } from '../../../lib/api/methods'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 export function takeNextPartInner(
 	context: MethodContext,
@@ -66,7 +66,7 @@ export function takeNextPartInnerSync(
 	now: number,
 	existingCache?: CacheForRundownPlaylist
 ) {
-	const span = Agent.startSpan('takeNextPartInner')
+	const span = profiler.startSpan('takeNextPartInner')
 	const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 	if (!dbPlaylist.active) throw new Meteor.Error(501, `RundownPlaylist "${rundownPlaylistId}" is not active!`)
 	if (!dbPlaylist.nextPartInstanceId) throw new Meteor.Error(500, 'nextPartInstanceId is not set!')
@@ -142,7 +142,7 @@ export function takeNextPartInnerSync(
 
 	const { blueprint } = waitForPromise(pBlueprint)
 	if (blueprint.onPreTake) {
-		const span = Agent.startSpan('blueprint.onPreTake')
+		const span = profiler.startSpan('blueprint.onPreTake')
 		try {
 			waitForPromise(
 				Promise.resolve(blueprint.onPreTake(new PartEventContext(takeRundown, cache, takePartInstance))).catch(
@@ -163,7 +163,7 @@ export function takeNextPartInnerSync(
 		if (showStyle) {
 			const resolvedPieces = getResolvedPieces(cache, showStyle, previousPartInstance)
 
-			const span = Agent.startSpan('blueprint.getEndStateForPart')
+			const span = profiler.startSpan('blueprint.getEndStateForPart')
 			const context = new RundownContext(takeRundown, cache, undefined)
 			previousPartEndState = blueprint.getEndStateForPart(
 				context,
@@ -292,7 +292,7 @@ export function takeNextPartInnerSync(
 			// let bp = getBlueprintOfRundown(rundown)
 			if (firstTake) {
 				if (blueprint.onRundownFirstTake) {
-					const span = Agent.startSpan('blueprint.onRundownFirstTake')
+					const span = profiler.startSpan('blueprint.onRundownFirstTake')
 					waitForPromise(
 						Promise.resolve(
 							blueprint.onRundownFirstTake(new PartEventContext(takeRundown, cache, takePartInstance))
@@ -303,7 +303,7 @@ export function takeNextPartInnerSync(
 			}
 
 			if (blueprint.onPostTake) {
-				const span = Agent.startSpan('blueprint.onPostTake')
+				const span = profiler.startSpan('blueprint.onPostTake')
 				waitForPromise(
 					Promise.resolve(
 						blueprint.onPostTake(new PartEventContext(takeRundown, cache, takePartInstance))
@@ -386,7 +386,7 @@ export function afterTake(
 	takePartInstance: PartInstance,
 	timeOffset: number | null = null
 ) {
-	const span = Agent.startSpan('afterTake')
+	const span = profiler.startSpan('afterTake')
 	// This function should be called at the end of a "take" event (when the Parts have been updated)
 
 	let forceNowTime: number | undefined = undefined
@@ -421,7 +421,7 @@ function startHold(
 ) {
 	if (!holdFromPartInstance) throw new Meteor.Error(404, 'previousPart not found!')
 	if (!holdToPartInstance) throw new Meteor.Error(404, 'currentPart not found!')
-	const span = Agent.startSpan('startHold')
+	const span = profiler.startSpan('startHold')
 
 	// Make a copy of any item which is flagged as an 'infinite' extension
 	const itemsToCopy = cache.PieceInstances.findFetch({ partInstanceId: holdFromPartInstance._id }).filter(

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -64,7 +64,7 @@ import { processAndPrunePieceInstanceTimings, PieceInstanceWithTimings } from '.
 import { createPieceGroupAndCap } from '../../../lib/rundown/pieces'
 import { ShowStyleBase, ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from '../profiler'
 
 /**
  * Updates the Timeline to reflect the state in the Rundown, Segments, Parts etc...
@@ -74,7 +74,7 @@ import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 // export const updateTimeline: (cache: CacheForRundownPlaylist, studioId: StudioId, forceNowToTime?: Time) => void
 // = syncFunctionIgnore(function updateTimeline (cache: CacheForRundownPlaylist, studioId: StudioId, forceNowToTime?: Time) {
 export function updateTimeline(cache: CacheForRundownPlaylist, studioId: StudioId, forceNowToTime?: Time) {
-	const span = Agent.startSpan('updateTimeline')
+	const span = profiler.startSpan('updateTimeline')
 	logger.debug('updateTimeline running...')
 	const studio = cache.activationCache.getStudio()
 	const activePlaylist = getActiveRundownPlaylist(cache, studioId)
@@ -141,7 +141,7 @@ export function afterUpdateTimeline(
 	studioId: StudioId,
 	timelineObjs?: Array<TimelineObjGeneric>
 ) {
-	const span = Agent.startSpan('afterUpdateTimeline')
+	const span = profiler.startSpan('afterUpdateTimeline')
 	// logger.info('afterUpdateTimeline')
 	if (!timelineObjs) {
 		timelineObjs = cache.Timeline.findFetch({
@@ -191,7 +191,7 @@ export function getActiveRundownPlaylist(cache: CacheForStudioBase, studioId: St
  * Returns timeline objects related to rundowns in a studio
  */
 function getTimelineRundown(cache: CacheForRundownPlaylist, studio: Studio): TimelineObjRundown[] {
-	const span = Agent.startSpan('getTimelineRundown')
+	const span = profiler.startSpan('getTimelineRundown')
 	try {
 		let timelineObjs: Array<TimelineObjGeneric & OnGenerateTimelineObj> = []
 
@@ -362,7 +362,7 @@ function getTimelineRecording(
  * @param timelineObjs Array of timeline objects
  */
 function processTimelineObjects(studio: Studio, timelineObjs: Array<TimelineObjGeneric>): void {
-	const span = Agent.startSpan('processTimelineObjects')
+	const span = profiler.startSpan('processTimelineObjects')
 	// first, split out any grouped objects, to make the timeline shallow:
 	let fixObjectChildren = (o: TimelineObjGeneric): void => {
 		// Unravel children objects and put them on the (flat) timelineObjs array
@@ -417,7 +417,7 @@ function buildTimelineObjsForRundown(
 	baselineItems: RundownBaselineObj[],
 	activePlaylist: RundownPlaylist
 ): (TimelineObjRundown & OnGenerateTimelineObj)[] {
-	const span = Agent.startSpan('buildTimelineObjsForRundown')
+	const span = profiler.startSpan('buildTimelineObjsForRundown')
 	let timelineObjs: Array<TimelineObjRundown & OnGenerateTimelineObj> = []
 	let currentPartGroup: TimelineObjRundown | undefined
 	let previousPartGroup: TimelineObjRundown | undefined
@@ -834,7 +834,7 @@ function transformPartIntoTimeline(
 	holdState?: RundownHoldState,
 	showHoldExcept?: boolean
 ): Array<TimelineObjRundown & OnGenerateTimelineObj> {
-	const span = Agent.startSpan('transformPartIntoTimeline')
+	const span = profiler.startSpan('transformPartIntoTimeline')
 	let timelineObjs: Array<TimelineObjRundown & OnGenerateTimelineObj> = []
 
 	const isHold = holdState === RundownHoldState.ACTIVE

--- a/meteor/server/api/profiler.ts
+++ b/meteor/server/api/profiler.ts
@@ -1,5 +1,4 @@
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
-import { Settings } from '../../lib/Settings'
 
 class Profiler {
 	private active: boolean = false

--- a/meteor/server/api/profiler.ts
+++ b/meteor/server/api/profiler.ts
@@ -10,7 +10,7 @@ class Profiler {
 
 	startTransaction(description: string, name: string) {
 		if (!this.active) return
-		Agent.startTransaction(description, name)
+		return Agent.startTransaction(description, name)
 	}
 
 	setActive(active: boolean) {

--- a/meteor/server/api/profiler.ts
+++ b/meteor/server/api/profiler.ts
@@ -1,0 +1,24 @@
+import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { Settings } from '../../lib/Settings'
+
+class Profiler {
+	private active: boolean = false
+
+	startSpan(_name: string) {
+		if (!this.active) return
+		return Agent.startSpan(_name)
+	}
+
+	startTransaction(description: string, name: string) {
+		if (!this.active) return
+		Agent.startTransaction(description, name)
+	}
+
+	setActive(active: boolean) {
+		this.active = active
+	}
+}
+
+const profiler = new Profiler()
+
+export { profiler }

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -53,7 +53,7 @@ import { ServerPlayoutAdLibAPI } from './playout/adlib'
 import { BucketsAPI } from './buckets'
 import { BucketAdLib } from '../../lib/collections/BucketAdlibs'
 import { rundownContentAllowWrite } from '../security/rundown'
-import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from './profiler'
 
 let MINIMUM_TAKE_SPAN = 1000
 export function setMinimumTakeSpan(span: number) {
@@ -791,7 +791,7 @@ export function noop(context: MethodContext) {
 }
 
 export function traceAction<T>(description: string, fn: (...args: any[]) => T, ...args: any[]) {
-	const transaction = Agent.startTransaction(description, 'userAction')
+	const transaction = profiler.startTransaction(description, 'userAction')
 	return makePromise(() => {
 		const res = fn(...args)
 		if (transaction) transaction.end()

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -539,7 +539,7 @@ function startInstrumenting() {
 			transactionSampleRate: system.apm.transactionSampleRate,
 			disableMeteorInstrumentations: ['methods', 'http-out', 'session', 'async', 'metrics'],
 		})
-		profiler.setActive(system.apm.enabled || true)
+		profiler.setActive(system.apm.enabled || false)
 	} else {
 		logger.info(`APM agent inactive`)
 		Agent.start({

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -539,7 +539,7 @@ function startInstrumenting() {
 			transactionSampleRate: system.apm.transactionSampleRate,
 			disableMeteorInstrumentations: ['methods', 'http-out', 'session', 'async', 'metrics'],
 		})
-		profiler.setActive(true)
+		profiler.setActive(system.apm.enabled || true)
 	} else {
 		logger.info(`APM agent inactive`)
 		Agent.start({

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -26,6 +26,7 @@ import { syncFunction } from './codeControl'
 const PackageInfo = require('../package.json')
 const BlueprintIntegrationPackageInfo = require('../node_modules/tv-automation-sofie-blueprints-integration/package.json')
 import Agent from 'meteor/kschingiz:meteor-elastic-apm'
+import { profiler } from './api/profiler'
 
 export { PackageInfo }
 
@@ -538,6 +539,7 @@ function startInstrumenting() {
 			transactionSampleRate: system.apm.transactionSampleRate,
 			disableMeteorInstrumentations: ['methods', 'http-out', 'session', 'async', 'metrics'],
 		})
+		profiler.setActive(true)
 	} else {
 		logger.info(`APM agent inactive`)
 		Agent.start({


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This wraps any calls to the APM Agent such that we will only make calls to `Agent` if APM is currently enabled on the system. This is because we have seen evidence of these Agent calls taking a lot of time, even if APM is not connected - particularly in places like `savePreparedChangesIntoCache` where we spend time looping over a lot of object.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
