### PR TITLE
fix: pieces leaking into Timeline 

### DIFF
--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -891,12 +891,12 @@ function transformPartIntoTimeline(
 			}
 		}
 
-		// create a piece group for the pieces and then place all of them there
-		const { pieceGroup, capObjs } = createPieceGroupAndCap(pieceInstance, partGroup, pieceEnable)
-		timelineObjs.push(pieceGroup)
-		timelineObjs.push(...capObjs)
-
 		if (!pieceInstance.piece.virtual && pieceInstance.piece.content?.timelineObjects && !hasDefinitelyEnded) {
+			// create a piece group for the pieces and then place all of them there
+			const { pieceGroup, capObjs } = createPieceGroupAndCap(pieceInstance, partGroup, pieceEnable)
+			timelineObjs.push(pieceGroup)
+			timelineObjs.push(...capObjs)
+
 			timelineObjs.push(createPieceGroupFirstObject(playlistId, pieceInstance, pieceGroup, firstObjClasses))
 
 			for (const o of pieceInstance.piece.content.timelineObjects) {


### PR DESCRIPTION
This PR fixes an issue where Pieces that was defenitelyEnded() still added piece_group object into Timeline.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
