### PR TITLE
fix: ensure older adlibs that never started dont play again later

### DIFF
--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -38,8 +38,6 @@ export class CustomLayerItemRenderer<
 	IProps extends ICustomLayerItemProps,
 	IState extends ISourceLayerItemState
 > extends React.Component<ICustomLayerItemProps & IProps, ISourceLayerItemState & IState> {
-	overflowsTime: boolean
-
 	getItemLabelOffsetLeft(): { [key: string]: string } {
 		if (this.props.getItemLabelOffsetLeft && typeof this.props.getItemLabelOffsetLeft === 'function') {
 			return this.props.getItemLabelOffsetLeft()

--- a/meteor/lib/collections/PieceInstances.ts
+++ b/meteor/lib/collections/PieceInstances.ts
@@ -51,8 +51,8 @@ export interface PieceInstance extends ProtectedStringProperties<Omit<IBlueprint
 
 	/** If this piece has been created play-time using an AdLibPiece, this should be set to it's source piece */
 	adLibSourceId?: PieceId
-	/** If this piece has been insterted during run of rundown (such as adLibs). Df set, this won't be affected by updates from MOS */
-	dynamicallyInserted?: boolean
+	/** If this piece has been insterted during run of rundown (such as adLibs), then this is set to the timestamp it was inserted */
+	dynamicallyInserted?: Time
 
 	/** Only set when this pieceInstance is an infinite. It contains info about the infinite */
 	infinite?: {

--- a/meteor/lib/rundown/__tests__/infinites.test.ts
+++ b/meteor/lib/rundown/__tests__/infinites.test.ts
@@ -3,7 +3,7 @@ import '../../../__mocks__/_extendJest'
 import { testInFiber } from '../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment, DefaultEnvironment } from '../../../__mocks__/helpers/database'
 import { PieceInstance, PieceInstancePiece } from '../../../lib/collections/PieceInstances'
-import { literal, protectString } from '../../../lib/lib'
+import { literal, protectString, getCurrentTime } from '../../../lib/lib'
 import { PieceLifespan } from 'tv-automation-sofie-blueprints-integration'
 import { processAndPrunePieceInstanceTimings } from '../infinites'
 import { Piece } from '../../../lib/collections/Pieces'
@@ -48,7 +48,7 @@ describe('Infinites', () => {
 				status: -1,
 				virtual: clear,
 			}),
-			dynamicallyInserted: clear,
+			dynamicallyInserted: clear ? getCurrentTime() : undefined,
 		})
 	}
 

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -395,7 +395,7 @@ export function processAndPrunePieceInstanceTimings(
 	}
 
 	const groupedPieces = _.groupBy(
-		pieces,
+		pieces.filter((p) => !p.disabled),
 		(p) => exclusiveGroupMap.get(p.piece.sourceLayerId) || p.piece.sourceLayerId
 	)
 	for (const pieces of Object.values(groupedPieces)) {
@@ -455,6 +455,16 @@ function findPieceInstancesOnInfiniteLayers(pieces: PieceInstance[]): PieceInsta
 		if (!best.infinite?.fromPrevious && candidate.infinite?.fromPrevious) {
 			// Prefer the best as it is not from previous
 			return true
+		}
+
+		if (best.piece.enable.start === 'now') {
+			// If we are working for the 'now' time, then we are looking at adlibs
+			// All adlib pieces will have a take time, so prefer the later one
+			const take0 = best.piece.timings?.take[0]
+			const take1 = candidate.piece.timings?.take[0]
+			if (take0 !== undefined && take1 !== undefined) {
+				return take1 > take0
+			}
 		}
 
 		// Fallback to id, as we dont have any other criteria and this will be stable.

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -460,8 +460,8 @@ function findPieceInstancesOnInfiniteLayers(pieces: PieceInstance[]): PieceInsta
 		if (best.piece.enable.start === 'now') {
 			// If we are working for the 'now' time, then we are looking at adlibs
 			// All adlib pieces will have a take time, so prefer the later one
-			const take0 = best.piece.timings?.take[0]
-			const take1 = candidate.piece.timings?.take[0]
+			const take0 = best.dynamicallyInserted
+			const take1 = candidate.dynamicallyInserted
 			if (take0 !== undefined && take1 !== undefined) {
 				return take1 > take0
 			}

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -417,8 +417,6 @@ describe('test peripheralDevice general API methods', () => {
 			expect(tlObj.enable.start).toBeGreaterThan(0)
 		})
 
-		expect(ServerPlayoutAPI.timelineTriggerTimeUpdateCallback).toHaveBeenCalled()
-
 		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
 	})
 

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -308,7 +308,7 @@ describe('Test blueprint api context', () => {
 						_id: pieceId0,
 						rundownId: rundown._id,
 						partInstanceId: partInstances[0]._id,
-						dynamicallyInserted: true,
+						dynamicallyInserted: getCurrentTime(),
 						piece: {
 							_id: getRandomId(),
 							startPartId: partInstances[0].part._id,
@@ -335,7 +335,7 @@ describe('Test blueprint api context', () => {
 						_id: pieceId1,
 						rundownId: rundown._id,
 						partInstanceId: partInstances[0]._id,
-						dynamicallyInserted: true,
+						dynamicallyInserted: getCurrentTime(),
 						piece: {
 							_id: getRandomId(),
 							startPartId: partInstances[0].part._id,
@@ -383,7 +383,7 @@ describe('Test blueprint api context', () => {
 						_id: pieceId0,
 						rundownId: rundown._id,
 						partInstanceId: partInstances[0]._id,
-						dynamicallyInserted: true,
+						dynamicallyInserted: getCurrentTime(),
 						piece: {
 							_id: getRandomId(),
 							startPartId: partInstances[0].part._id,
@@ -403,7 +403,7 @@ describe('Test blueprint api context', () => {
 						_id: pieceId1,
 						rundownId: rundown._id,
 						partInstanceId: partInstances[2]._id,
-						dynamicallyInserted: true,
+						dynamicallyInserted: getCurrentTime(),
 						piece: {
 							_id: getRandomId(),
 							startPartId: partInstances[2].part._id,

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -229,6 +229,15 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			part === 'current',
 			true
 		)[0]
+		piece.timings = {
+			take: [getCurrentTime()],
+			startedPlayback: [],
+			next: [],
+			stoppedPlayback: [],
+			playOffset: [],
+			takeDone: [],
+			takeOut: [],
+		}
 		const newPieceInstance = wrapPieceToInstance(piece, partInstance._id)
 
 		// Do the work

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -250,7 +250,7 @@ export namespace ServerPeripheralDeviceAPI {
 								},
 							})
 
-							const takeTime = pieceInstance.piece.timings?.take[0]
+							const takeTime = pieceInstance.dynamicallyInserted
 							if (pieceInstance.dynamicallyInserted && takeTime) {
 								lastTakeTime = lastTakeTime === undefined ? takeTime : Math.max(lastTakeTime, takeTime)
 							}
@@ -263,11 +263,11 @@ export namespace ServerPeripheralDeviceAPI {
 				// We updated some pieceInstance from now, so lets ensure any earlier adlibs do not still have a now
 				const remainingNowPieces = cache.PieceInstances.findFetch({
 					partInstanceId: activePlaylist.currentPartInstanceId,
-					dynamicallyInserted: true,
+					dynamicallyInserted: { $exists: true },
 					disabled: { $ne: true },
 				})
 				for (const piece of remainingNowPieces) {
-					const pieceTakeTime = piece.piece.timings?.take[0]
+					const pieceTakeTime = piece.dynamicallyInserted
 					if (pieceTakeTime && pieceTakeTime <= lastTakeTime && piece.piece.enable.start === 'now') {
 						// Disable and hide the instance
 						cache.PieceInstances.update(piece._id, {

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -32,6 +32,7 @@ import { checkAccessAndGetPeripheralDevice } from './ingest/lib'
 import { PickerPOST } from './http'
 import { initCacheForNoRundownPlaylist, initCacheForStudio, initCacheForRundownPlaylist } from '../DatabaseCaches'
 import { RundownPlaylists } from '../../lib/collections/RundownPlaylists'
+import { PieceInstanceId } from '../../lib/collections/PieceInstances'
 
 // import {ServerPeripheralDeviceAPIMOS as MOS} from './peripheralDeviceMos'
 export namespace ServerPeripheralDeviceAPI {
@@ -170,6 +171,11 @@ export namespace ServerPeripheralDeviceAPI {
 
 		return peripheralDevice
 	}
+
+	/**
+	 * Called from Playout-gateway when the trigger-time of a timeline object has updated
+	 * ( typically when using the "now"-feature )
+	 */
 	export const timelineTriggerTime = syncFunction(function timelineTriggerTime(
 		context: MethodContext,
 		deviceId: PeripheralDeviceId,
@@ -199,9 +205,8 @@ export namespace ServerPeripheralDeviceAPI {
 			const cache = activePlaylist
 				? waitForPromise(initCacheForRundownPlaylist(activePlaylist))
 				: waitForPromise(initCacheForNoRundownPlaylist(studioId))
-			const allowedRundownsIds = activePlaylist
-				? _.map(cache.Rundowns.findFetch({ playlistId: activePlaylist._id }), (r) => r._id)
-				: []
+
+			let lastTakeTime: number | undefined
 
 			_.each(results, (o) => {
 				check(o.id, String)
@@ -231,15 +236,57 @@ export namespace ServerPeripheralDeviceAPI {
 					obj.enable.start = o.time
 					obj.enable.setFromNow = true
 
-					ServerPlayoutAPI.timelineTriggerTimeUpdateCallback(context, cache, allowedRundownsIds, obj, o.time)
+					if (obj.metaData?.pieceId) {
+						logger.debug('Update PieceInstance: ', {
+							pieceId: obj.metaData.pieceId,
+							time: new Date(o.time).toTimeString(),
+						})
+
+						const pieceInstance = cache.PieceInstances.findOne(obj.metaData.pieceId)
+						if (pieceInstance) {
+							cache.PieceInstances.update(pieceInstance._id, {
+								$set: {
+									'piece.enable.start': o.time,
+								},
+							})
+
+							const takeTime = pieceInstance.piece.timings?.take[0]
+							if (pieceInstance.dynamicallyInserted && takeTime) {
+								lastTakeTime = lastTakeTime === undefined ? takeTime : Math.max(lastTakeTime, takeTime)
+							}
+						}
+					}
 				}
 			})
+
+			if (lastTakeTime !== undefined && activePlaylist?.currentPartInstanceId) {
+				// We updated some pieceInstance from now, so lets ensure any earlier adlibs do not still have a now
+				const remainingNowPieces = cache.PieceInstances.findFetch({
+					partInstanceId: activePlaylist.currentPartInstanceId,
+					dynamicallyInserted: true,
+					disabled: { $ne: true },
+				})
+				for (const piece of remainingNowPieces) {
+					const pieceTakeTime = piece.piece.timings?.take[0]
+					if (pieceTakeTime && pieceTakeTime <= lastTakeTime && piece.piece.enable.start === 'now') {
+						// Disable and hide the instance
+						cache.PieceInstances.update(piece._id, {
+							$set: {
+								disabled: true,
+								hidden: true,
+							},
+						})
+					}
+				}
+			}
+
 			// After we've updated the timeline, we must call afterUpdateTimeline!
 			afterUpdateTimeline(cache, studioId)
 			waitForPromise(cache.saveAllToDatabase())
 		}
 	},
-	'timelineTriggerTime$0,$1') // kz 'timelineTriggerTime$1' maybe?
+	'timelineTriggerTime$1')
+
 	export function partPlaybackStarted(
 		context: MethodContext,
 		deviceId: PeripheralDeviceId,

--- a/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
@@ -49,7 +49,7 @@ Array [
   Object {
     "_id": "randomId9002_part0_0_randomId9007_randomId9012",
     "adLibSourceId": "randomId9002_globalAdLib0",
-    "dynamicallyInserted": true,
+    "dynamicallyInserted": 1000,
     "infinite": Object {
       "infinitePieceId": "randomId9012",
     },
@@ -132,7 +132,7 @@ Array [
   Object {
     "_id": "randomId9002_part0_0_randomId9007_randomId9012",
     "adLibSourceId": "randomId9002_globalAdLib0",
-    "dynamicallyInserted": true,
+    "dynamicallyInserted": 1000,
     "infinite": Object {
       "infinitePieceId": "randomId9012",
     },
@@ -166,7 +166,7 @@ Array [
   Object {
     "_id": "randomId9002_part0_0_randomId9007_randomId9014",
     "adLibSourceId": "randomId9002_adLib000",
-    "dynamicallyInserted": true,
+    "dynamicallyInserted": 3000,
     "partInstanceId": "randomId9002_part0_0_randomId9007",
     "piece": Object {
       "_id": "randomId9014",

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -347,7 +347,7 @@ export namespace ServerPlayoutAdLibAPI {
 		if (originalOnly) {
 			// Ignore adlibs if using original only
 			query.dynamicallyInserted = {
-				$ne: true,
+				$exists: false,
 			}
 		}
 
@@ -417,7 +417,7 @@ export namespace ServerPlayoutAdLibAPI {
 		// Ensure it is labelled as dynamic
 		newPieceInstance.partInstanceId = existingPartInstance._id
 		newPieceInstance.piece.startPartId = existingPartInstance.part._id
-		newPieceInstance.dynamicallyInserted = true
+		newPieceInstance.dynamicallyInserted = getCurrentTime()
 
 		// exclusiveGroup is handled at runtime by processAndPrunePieceInstanceTimings
 
@@ -501,7 +501,7 @@ export namespace ServerPlayoutAdLibAPI {
 								currentPartInstance.rundownId,
 								currentPartInstance._id
 							),
-							dynamicallyInserted: true,
+							dynamicallyInserted: getCurrentTime(),
 							infinite: {
 								infinitePieceId: pieceId,
 							},

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -98,7 +98,7 @@ export function createPieceGroupFirstObject(
 			callBackData: {
 				rundownPlaylistId: playlistId,
 				pieceInstanceId: pieceInstance._id,
-				dynamicallyInserted: pieceInstance.dynamicallyInserted,
+				dynamicallyInserted: pieceInstance.dynamicallyInserted !== undefined,
 			},
 			callBackStopped: 'piecePlaybackStopped', // Will cause a callback to be called, when the object stops playing:
 		},
@@ -342,7 +342,7 @@ export function convertAdLibToPieceInstance(
 		rundownId: partInstance.rundownId,
 		partInstanceId: partInstance._id,
 		adLibSourceId: adLibPiece._id,
-		dynamicallyInserted: !queue,
+		dynamicallyInserted: queue ? undefined : getCurrentTime(),
 		piece: literal<PieceInstancePiece>({
 			...(_.omit(
 				adLibPiece,

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1193,60 +1193,7 @@ export namespace ServerPlayoutAPI {
 			waitForPromise(cache.saveAllToDatabase())
 		})
 	}
-	/**
-	 * Called from Playout-gateway when the trigger-time of a timeline object has updated
-	 * ( typically when using the "now"-feature )
-	 */
 
-	export function timelineTriggerTimeUpdateCallback(
-		context: MethodContext,
-		cache: CacheForRundownPlaylist,
-		activeRundownIds: RundownId[],
-		timelineObj: TimelineObjGeneric,
-		time: number
-	) {
-		check(timelineObj, Object)
-		check(time, Number)
-
-		triggerWriteAccessBecauseNoCheckNecessary() // tmp
-
-		if (activeRundownIds && activeRundownIds.length > 0 && timelineObj.metaData && timelineObj.metaData.pieceId) {
-			logger.debug('Update PieceInstance: ', {
-				pieceId: timelineObj.metaData.pieceId,
-				time: new Date(time).toTimeString(),
-			})
-
-			cache.PieceInstances.update(
-				{
-					_id: timelineObj.metaData.pieceId,
-					rundownId: { $in: activeRundownIds },
-				},
-				{
-					$set: {
-						'piece.enable.start': time,
-					},
-				}
-			)
-
-			const pieceInstance = cache.PieceInstances.findOne({
-				_id: timelineObj.metaData.pieceId,
-				rundownId: { $in: activeRundownIds },
-			})
-			if (pieceInstance) {
-				cache.PieceInstances.update(
-					{
-						_id: pieceInstance._id,
-						rundownId: { $in: activeRundownIds },
-					},
-					{
-						$set: {
-							'piece.enable.start': time,
-						},
-					}
-				)
-			}
-		}
-	}
 	export function updateStudioBaseline(context: MethodContext, studioId: StudioId) {
 		// TODO - should there be a studio lock for activate/deactivate/this?
 		StudioContentWriteAccess.baseline(context, studioId)

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -360,7 +360,7 @@ function copyOverflowingPieces(
 						_id: getRandomId(),
 						rundownId: instance.rundownId,
 						partInstanceId: nextPartInstance._id,
-						dynamicallyInserted: true,
+						dynamicallyInserted: getCurrentTime(),
 						piece: {
 							...omit(instance.piece, 'startedPlayback', 'overflows'),
 							_id: getRandomId(),
@@ -447,7 +447,7 @@ function startHold(
 			_id: protectString<PieceInstanceId>(instance._id + '_hold'),
 			rundownId: instance.rundownId,
 			partInstanceId: holdToPartInstance._id,
-			dynamicallyInserted: true,
+			dynamicallyInserted: getCurrentTime(),
 			piece: {
 				...clone(instance.piece),
 				_id: protectString<PieceId>(instance.piece._id + '_hold'),


### PR DESCRIPTION
What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This ensures that when adlibs are executed in rapid succession, we ensure that any adlibs that didnt get de-nowified (due to not having a chance to be played) get disabled, so they dont try to play later

* **What is the current behavior?** (You can also link to an open issue here)

When we run an adlib if another gets run soon after, the first may not get played out. But it gets left with a `start: 'now'` so at the next updateTimeline it may start playing

* **What is the new behavior (if this is a feature change)?**

When we get the timelineTriggerTime callback from playout gateway, any adlibs inserted before the one being de-nowified get disabled.

Also, the prune pieces logic was not ignoring disabled pieces

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
