### PR TITLE
feat: Add method to remove MediaObjects with specific collectionId

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -236,6 +236,7 @@ export interface NewPeripheralDeviceAPI {
 		id: string,
 		doc: MediaObject | null
 	): Promise<void>
+	clearMediaObjectCollection(deviceId: PeripheralDeviceId, deviceToken: string, collectionId: string): Promise<void>
 
 	getMediaWorkFlowRevisions(deviceId: PeripheralDeviceId, deviceToken: string): Promise<MediaWorkFlowRevision[]>
 	getMediaWorkFlowStepRevisions(
@@ -321,6 +322,7 @@ export enum PeripheralDeviceAPIMethods {
 
 	'getMediaObjectRevisions' = 'peripheralDevice.mediaScanner.getMediaObjectRevisions',
 	'updateMediaObject' = 'peripheralDevice.mediaScanner.updateMediaObject',
+	'clearMediaObjectCollection' = 'peripheralDevice.mediaScanner.clearMediaObjectCollection',
 
 	'getMediaWorkFlowRevisions' = 'peripheralDevice.mediaManager.getMediaWorkFlowRevisions',
 	'updateMediaWorkFlow' = 'peripheralDevice.mediaManager.updateMediaWorkFlow',

--- a/meteor/server/api/integration/media-scanner.ts
+++ b/meteor/server/api/integration/media-scanner.ts
@@ -64,4 +64,11 @@ export namespace MediaScannerIntegration {
 			throw new Meteor.Error(400, 'missing doc argument')
 		}
 	}
+	export function clearMediaObjectCollection(deviceId: PeripheralDeviceId, token: string, collectionId: string) {
+		let peripheralDevice = PeripheralDeviceSecurity.getPeripheralDevice(deviceId, token, this)
+
+		const studioId = getStudioIdFromDevice(peripheralDevice)
+
+		MediaObjects.remove({ collectionId, studioId })
+	}
 }

--- a/meteor/server/api/integration/media-scanner.ts
+++ b/meteor/server/api/integration/media-scanner.ts
@@ -65,7 +65,7 @@ export namespace MediaScannerIntegration {
 		}
 	}
 	export function clearMediaObjectCollection(deviceId: PeripheralDeviceId, token: string, collectionId: string) {
-		let peripheralDevice = PeripheralDeviceSecurity.getPeripheralDevice(deviceId, token, this)
+		let peripheralDevice = checkAccessAndGetPeripheralDevice(deviceId, token, this)
 
 		const studioId = getStudioIdFromDevice(peripheralDevice)
 

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -783,6 +783,11 @@ class ServerPeripheralDeviceAPIClass implements NewPeripheralDeviceAPI {
 			MediaScannerIntegration.updateMediaObject(deviceId, deviceToken, collectionId, id, doc)
 		)
 	}
+	clearMediaObjectCollection(deviceId: PeripheralDeviceId, deviceToken: string, collectionId: string) {
+		return makePromise(() =>
+			MediaScannerIntegration.clearMediaObjectCollection(deviceId, deviceToken, collectionId)
+		)
+	}
 	// ------- Media Manager --------------
 	getMediaWorkFlowRevisions(deviceId: PeripheralDeviceId, deviceToken: string) {
 		return makePromise(() => MediaManagerIntegration.getMediaWorkFlowRevisions(deviceId, deviceToken))


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR adds a `clearMediaObjectCollection` method to the `PeripheralDeviceAPI`. This method allows removing documents from the MediaObjects collection, where the given `collectionId` and the `studioId` of the device match.


* **What is the current behavior?**
There is no way to empty the MediaObjects collection other than removing each document explicitly.


* **What is the new behavior (if this is a feature change)?**
The `clearMediaObjectCollection` removes all Media Objects where the given `collectionId` and the `studioId` of the requesting device match.


* **Other information**:
This can be used e.g. by the Playout Gateway to manage MediaObjects used for reporting statuses of Viz elements.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
