### PR TITLE
chore(refactor): remove superfluous null checking

### DIFF
--- a/meteor/server/api/blueprints/__tests__/postProcess.test.ts
+++ b/meteor/server/api/blueprints/__tests__/postProcess.test.ts
@@ -101,13 +101,7 @@ describe('Test blueprint post-process', () => {
 			const res = postProcessStudioBaselineObjects(studio, [])
 			expect(res).toHaveLength(0)
 		})
-		testInFiber('null object', () => {
-			const studio = getStudio()
 
-			// Ensure that a null object gets dropped
-			const res = postProcessStudioBaselineObjects(studio, [null as any])
-			expect(res).toHaveLength(0)
-		})
 		testInFiber('some no ids', () => {
 			const studio = getStudio()
 
@@ -222,13 +216,7 @@ describe('Test blueprint post-process', () => {
 			const res = postProcessRundownBaselineItems(context, protectString('some-blueprints'), [])
 			expect(res).toHaveLength(0)
 		})
-		testInFiber('null object', () => {
-			const context = getContext()
 
-			// Ensure that a null object gets dropped
-			const res = postProcessRundownBaselineItems(context, protectString('some-blueprints'), [null as any])
-			expect(res).toHaveLength(0)
-		})
 		testInFiber('some no ids', () => {
 			const context = getContext()
 
@@ -364,13 +352,7 @@ describe('Test blueprint post-process', () => {
 			const res = postProcessAdLibPieces(context, [], protectString('blueprint9'))
 			expect(res).toHaveLength(0)
 		})
-		testInFiber('null piece', () => {
-			const context = getContext()
 
-			// Ensure that a null object gets dropped
-			const res = postProcessAdLibPieces(context, [null as any], protectString('blueprint9'))
-			expect(res).toHaveLength(0)
-		})
 		testInFiber('various pieces', () => {
 			const context = getContext()
 
@@ -410,7 +392,7 @@ describe('Test blueprint post-process', () => {
 					sourceLayerId: 'sl0',
 					outputLayerId: 'ol0',
 					content: {
-						timelineObjects: [null as any],
+						timelineObjects: [],
 					},
 					lifespan: PieceLifespan.WithinPart,
 				},
@@ -498,20 +480,7 @@ describe('Test blueprint post-process', () => {
 			)
 			expect(res).toHaveLength(0)
 		})
-		testInFiber('null piece', () => {
-			const context = getContext()
 
-			// Ensure that a null object gets dropped
-			const res = postProcessPieces(
-				context,
-				[null as any],
-				protectString('blueprint9'),
-				context._rundown._id,
-				protectString('segment5'),
-				protectString('part8')
-			)
-			expect(res).toHaveLength(0)
-		})
 		testInFiber('various pieces', () => {
 			const context = getContext()
 
@@ -544,21 +513,10 @@ describe('Test blueprint post-process', () => {
 					},
 					lifespan: PieceLifespan.WithinPart,
 				},
-				{
-					name: 'test2',
-					externalId: 'eid2',
-					enable: { start: 0 },
-					sourceLayerId: 'sl0',
-					outputLayerId: 'ol0',
-					content: {
-						timelineObjects: [null as any],
-					},
-					lifespan: PieceLifespan.WithinPart,
-				},
 			])
 
 			// mock getHash, to track the returned ids
-			const mockedIds = ['mocked1', 'mocked2', 'mcoked3', 'mocked4']
+			const mockedIds = ['mocked1', 'mocked2', 'mcoked3']
 			const expectedIds = [...mockedIds]
 			jest.spyOn(context, 'getHashId').mockImplementation(() => mockedIds.shift() || '')
 
@@ -590,11 +548,10 @@ describe('Test blueprint post-process', () => {
 			ensureAllKeysDefined(tmpObj, res)
 
 			// Ensure getHashId was called as expected
-			expect(context.getHashId).toHaveBeenCalledTimes(4)
+			expect(context.getHashId).toHaveBeenCalledTimes(3)
 			expect(context.getHashId).toHaveBeenNthCalledWith(1, 'blueprint9_part8_piece_0')
 			expect(context.getHashId).toHaveBeenNthCalledWith(2, 'blueprint9_part8_piece_1')
 			expect(context.getHashId).toHaveBeenNthCalledWith(3, 'blueprint9_part8_piece_2')
-			expect(context.getHashId).toHaveBeenNthCalledWith(4, 'blueprint9_part8_piece_3')
 
 			// Ensure no ids were duplicates
 			const ids = _.map(res, (obj) => obj._id).sort()

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -1,4 +1,3 @@
-import * as _ from 'underscore'
 import { Piece, PieceId } from '../../../lib/collections/Pieces'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { protectString, unprotectString, Omit, literal } from '../../../lib/lib'
@@ -43,7 +42,7 @@ export function postProcessPieces(
 
 	let i = 0
 	let timelineUniqueIds: { [id: string]: true } = {}
-	const processedPieces = _.map(_.compact(pieces), (itemOrig: IBlueprintPiece) => {
+	const processedPieces = pieces.map((itemOrig: IBlueprintPiece) => {
 		let piece: Piece = {
 			...(itemOrig as Omit<IBlueprintPiece, 'continuesRefId'>),
 			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_piece_${i++}`)),
@@ -70,7 +69,7 @@ export function postProcessPieces(
 				)}")`
 			)
 
-		if (piece.content && piece.content.timelineObjects) {
+		if (piece.content?.timelineObjects) {
 			piece.content.timelineObjects = postProcessTimelineObjects(
 				innerContext,
 				piece._id,
@@ -96,7 +95,7 @@ export function postProcessTimelineObjects(
 	prefixAllTimelineObjects: boolean,
 	timelineUniqueIds: { [key: string]: boolean }
 ) {
-	let newObjs = _.map(_.compact(timelineObjects), (o: TimelineObjectCoreExt, i) => {
+	let newObjs = timelineObjects.map((o: TimelineObjectCoreExt, i) => {
 		const obj: TimelineObjRundown = {
 			...o,
 			id: o.id,
@@ -144,12 +143,7 @@ export function postProcessAdLibPieces(
 	let i = 0
 	let timelineUniqueIds: { [id: string]: true } = {}
 
-	const processedPieces: AdLibPiece[] = []
-	for (const itemOrig of adLibPieces) {
-		if (!itemOrig) {
-			continue
-		}
-
+	const processedPieces = adLibPieces.map((itemOrig) => {
 		const piece: AdLibPiece = {
 			...itemOrig,
 			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_adlib_piece_${i++}`)),
@@ -177,8 +171,8 @@ export function postProcessAdLibPieces(
 			)
 		}
 
-		processedPieces.push(piece)
-	}
+		return piece
+	})
 
 	span?.end()
 	return processedPieces
@@ -189,7 +183,7 @@ export function postProcessGlobalAdLibActions(
 	adlibActions: IBlueprintActionManifest[],
 	blueprintId: BlueprintId
 ): RundownBaselineAdLibAction[] {
-	return _.map(adlibActions, (action, i) =>
+	return adlibActions.map((action, i) =>
 		literal<RundownBaselineAdLibAction>({
 			...action,
 			actionId: action.actionId,
@@ -206,7 +200,7 @@ export function postProcessAdLibActions(
 	blueprintId: BlueprintId,
 	partId: PartId
 ): AdLibAction[] {
-	return _.map(adlibActions, (action, i) =>
+	return adlibActions.map((action, i) =>
 		literal<AdLibAction>({
 			...action,
 			actionId: action.actionId,


### PR DESCRIPTION
Removes null checking from blueprints post processing functions where the function signature types does not allow for null items in input arguments.