### PR TITLE
chore: remove old properties from TimelineObjGeneric

### DIFF
--- a/meteor/client/ui/TestTools/Timeline.tsx
+++ b/meteor/client/ui/TestTools/Timeline.tsx
@@ -167,7 +167,6 @@ export const TimelineVisualizerInStudio = translateWithTracker<
 			let timeline = _.compact(
 				_.map(this.props.timeline, (obj) => {
 					let o = _.clone(obj)
-					delete o._id
 
 					if (o.enable.start === 'now') o.enable.start = getCurrentTime() // tmp
 
@@ -232,10 +231,10 @@ export const ComponentTimelineSimulate = withTracker<ITimelineSimulateProps, {},
 			const timeline =
 				(tlComplete &&
 					tlComplete.timeline.sort((a, b) => {
-						if (a._id > b._id) {
+						if (a.id > b.id) {
 							return 1
 						}
-						if (a._id < b._id) {
+						if (a.id < b.id) {
 							return -1
 						}
 						return 0

--- a/meteor/lib/__tests__/lib.test.ts
+++ b/meteor/lib/__tests__/lib.test.ts
@@ -76,7 +76,6 @@ describe('lib/lib', () => {
 	testInFiber('saveIntoDb', () => {
 		const mystudioObjs: Array<TimelineObjGeneric> = [
 			{
-				_id: protectString('abc'),
 				id: 'abc',
 				enable: {
 					start: 0,
@@ -84,11 +83,9 @@ describe('lib/lib', () => {
 				layer: 'L1',
 				content: { deviceType: TSR.DeviceType.ABSTRACT },
 				objectType: TimelineObjType.MANUAL,
-				studioId: protectString('myStudio'),
 				classes: ['abc'], // to be removed
 			},
 			{
-				_id: protectString('abc2'),
 				id: 'abc2',
 				enable: {
 					start: 0,
@@ -96,7 +93,6 @@ describe('lib/lib', () => {
 				layer: 'L1',
 				content: { deviceType: TSR.DeviceType.ABSTRACT },
 				objectType: TimelineObjType.MANUAL,
-				studioId: protectString('myStudio'),
 			},
 		]
 		Timeline.insert({
@@ -106,7 +102,6 @@ describe('lib/lib', () => {
 
 		const mystudio2Objs: Array<TimelineObjGeneric> = [
 			{
-				_id: protectString('abc10'),
 				id: 'abc10',
 				enable: {
 					start: 0,
@@ -114,7 +109,6 @@ describe('lib/lib', () => {
 				layer: 'L1',
 				content: { deviceType: TSR.DeviceType.ABSTRACT },
 				objectType: TimelineObjType.MANUAL,
-				studioId: protectString('myStudio2'),
 			},
 		]
 		Timeline.insert({
@@ -151,7 +145,6 @@ describe('lib/lib', () => {
 					_id: protectString('myStudio'),
 					timeline: [
 						{
-							_id: protectString('abc'),
 							id: 'abc',
 							enable: {
 								start: 0,
@@ -159,11 +152,9 @@ describe('lib/lib', () => {
 							layer: 'L2', // changed property
 							content: { deviceType: TSR.DeviceType.ABSTRACT },
 							objectType: TimelineObjType.MANUAL,
-							studioId: protectString('myStudio'),
 						},
 						{
 							// insert object
-							_id: protectString('abc3'),
 							id: 'abc3',
 							enable: {
 								start: 0,
@@ -171,7 +162,6 @@ describe('lib/lib', () => {
 							layer: 'L1',
 							content: { deviceType: TSR.DeviceType.ABSTRACT },
 							objectType: TimelineObjType.MANUAL,
-							studioId: protectString('myStudio'),
 						}, // remove abc2
 					],
 				},
@@ -257,7 +247,6 @@ describe('lib/lib', () => {
 	})
 	testInFiber('literal', () => {
 		const obj = literal<TimelineObjGeneric>({
-			_id: protectString('abc'),
 			id: 'abc',
 			enable: {
 				start: 0,
@@ -265,10 +254,8 @@ describe('lib/lib', () => {
 			layer: 'L1',
 			content: { deviceType: TSR.DeviceType.ABSTRACT },
 			objectType: TimelineObjType.MANUAL,
-			studioId: protectString('myStudio'),
 		})
 		expect(obj).toEqual({
-			_id: protectString('abc'),
 			id: 'abc',
 			enable: {
 				start: 0,
@@ -276,7 +263,6 @@ describe('lib/lib', () => {
 			layer: 'L1',
 			content: { deviceType: TSR.DeviceType.ABSTRACT },
 			objectType: TimelineObjType.MANUAL,
-			studioId: protectString('myStudio'),
 		})
 		const layer: string | number = obj.layer // just to check typings
 		expect(layer).toBeTruthy()

--- a/meteor/lib/__tests__/timeline.test.ts
+++ b/meteor/lib/__tests__/timeline.test.ts
@@ -8,9 +8,7 @@ describe('lib/timeline', () => {
 	testInFiber('transformTimeline', () => {
 		const timeline: TimelineObjRundown[] = [
 			{
-				_id: protectString('0'),
 				id: '0',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -21,9 +19,7 @@ describe('lib/timeline', () => {
 				layer: 'L1',
 			},
 			{
-				_id: protectString('child0'),
 				id: 'child0',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -35,9 +31,7 @@ describe('lib/timeline', () => {
 				inGroup: 'group0',
 			},
 			{
-				_id: protectString('child1'),
 				id: 'child1',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -49,9 +43,7 @@ describe('lib/timeline', () => {
 				inGroup: 'group0',
 			},
 			{
-				_id: protectString('group0'),
 				id: 'group0',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -63,9 +55,7 @@ describe('lib/timeline', () => {
 				isGroup: true,
 			},
 			{
-				_id: protectString('2'),
 				id: '2',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -84,9 +74,7 @@ describe('lib/timeline', () => {
 				partId: 'myPart0',
 			},
 			{
-				_id: protectString('3'),
 				id: '3',
-				studioId: protectString('studio0'),
 				objectType: TimelineObjType.RUNDOWN,
 				enable: {
 					start: 0,
@@ -145,8 +133,6 @@ describe('lib/timeline', () => {
 			transformTimeline([
 				// @ts-ignore missing: id
 				{
-					_id: protectString('0'),
-					studioId: protectString('studio0'),
 					objectType: TimelineObjType.RUNDOWN,
 					enable: { start: 0 },
 					content: { deviceType: TSR.DeviceType.ABSTRACT },

--- a/meteor/lib/rundown/pieces.ts
+++ b/meteor/lib/rundown/pieces.ts
@@ -24,8 +24,6 @@ export function createPieceGroupAndCap(
 } {
 	const pieceGroup = literal<TimelineObjGroup & TimelineObjRundown & OnGenerateTimelineObj>({
 		id: getPieceGroupId(unprotectString(pieceInstance._id)),
-		_id: protectString(''), // set later
-		studioId: protectString(''), // set later
 		content: {
 			deviceType: TSR.DeviceType.ABSTRACT,
 			type: TimelineContentTypeOther.GROUP,
@@ -51,8 +49,6 @@ export function createPieceGroupAndCap(
 		// TODO - there could already be a piece with a cap of 'now' that we could use as our end time
 		// As the cap is for 'now', rather than try to get tsr to understand `end: 'now'`, we can create a 'now' object to tranlate it
 		nowObj = literal<TimelineObjRundown>({
-			_id: protectString(''), // set later
-			studioId: protectString(''), // set later
 			objectType: TimelineObjType.RUNDOWN,
 			id: `${pieceGroup.id}_cap_now`,
 			enable: {
@@ -82,8 +78,6 @@ export function createPieceGroupAndCap(
 		if (!updatedPieceGroup && pieceInstance.resolvedEndCap !== undefined) {
 			// Create a wrapper group to apply the end cap
 			const pieceEndCapGroup = literal<TimelineObjGroupRundown>({
-				_id: protectString(''), // set later
-				studioId: protectString(''), // set later
 				objectType: TimelineObjType.RUNDOWN,
 				id: `${pieceGroup.id}_cap`,
 				enable: {

--- a/meteor/lib/timeline.ts
+++ b/meteor/lib/timeline.ts
@@ -9,10 +9,10 @@ import { logger } from './logging'
 // playout-gateway:
 export function transformTimeline(timeline: Array<TimelineObjGeneric>): Array<TimelineContentObject> {
 	let transformObject = (obj: TimelineObjGeneric | TimelineObjGroup): TimelineContentObject => {
-		if (!obj.id) throw new Meteor.Error(500, `Timeline object missing id attribute (_id: "${obj._id}") `)
+		if (!obj.id) throw new Meteor.Error(500, `Timeline object missing id attribute ${JSON.stringify(obj)} `)
 
 		let transformedObj: TimelineContentObject = clone(_.omit(obj, ['_id', 'studioId']))
-		transformedObj.id = obj.id || unprotectString(obj._id)
+		transformedObj.id = obj.id
 
 		if (!transformedObj.content) transformedObj.content = {}
 		if (transformedObj.isGroup) {

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -411,9 +411,9 @@ describe('test peripheralDevice general API methods', () => {
 		const updatedStudioTimeline = Timeline.findOne({
 			_id: env.studio._id,
 		})
-		const prevIds = timelineObjs.map((x) => x._id)
+		const prevIds = timelineObjs.map((x) => x.id)
 		const timelineUpdatedObjs =
-			(updatedStudioTimeline && updatedStudioTimeline.timeline.filter((x) => prevIds.indexOf(x._id) >= 0)) || []
+			(updatedStudioTimeline && updatedStudioTimeline.timeline.filter((x) => prevIds.indexOf(x.id) >= 0)) || []
 		console.log('>>>', timelineUpdatedObjs)
 		timelineUpdatedObjs.forEach((tlObj) => {
 			expect(tlObj.enable.setFromNow).toBe(true)

--- a/meteor/server/api/blueprints/__tests__/postProcess.test.ts
+++ b/meteor/server/api/blueprints/__tests__/postProcess.test.ts
@@ -15,7 +15,6 @@ import {
 	IBlueprintPiece,
 	IBlueprintAdLibPiece,
 	TimelineObjectCoreExt,
-	IBlueprintPieceDB,
 	TSR,
 	PieceLifespan,
 } from 'tv-automation-sofie-blueprints-integration'
@@ -284,13 +283,11 @@ describe('Test blueprint post-process', () => {
 
 			// Ensure all required keys are defined
 			const tmpObj = literal<TimelineObjGeneric>({
-				_id: protectString(''),
 				id: '',
 				layer: '',
 				enable: {},
 				content: {} as any,
 				objectType: TimelineObjType.RUNDOWN,
-				studioId: protectString(''),
 			})
 			ensureAllKeysDefined(tmpObj, res)
 		})

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -99,8 +99,6 @@ export function postProcessTimelineObjects(
 		const obj: TimelineObjRundown = {
 			...o,
 			id: o.id,
-			_id: protectString(''), // set later
-			studioId: protectString(''), // set later
 			objectType: TimelineObjType.RUNDOWN,
 		}
 

--- a/meteor/server/api/manualPlayout.ts
+++ b/meteor/server/api/manualPlayout.ts
@@ -1,21 +1,14 @@
 import { registerClassToMeteorMethods } from '../methods'
 import { NewManualPlayoutAPI, ManualPlayoutAPIMethods } from '../../lib/api/manualPlayout'
-import {
-	Timeline,
-	TimelineObjGeneric,
-	getTimelineId,
-	TimelineObjType,
-	TimelineObjId,
-} from '../../lib/collections/Timeline'
+import { TimelineObjGeneric, TimelineObjType } from '../../lib/collections/Timeline'
 import { Studios, StudioId } from '../../lib/collections/Studios'
 import { check } from '../../lib/check'
-import { makePromise, waitForPromise, protectString } from '../../lib/lib'
+import { makePromise, waitForPromise } from '../../lib/lib'
 import { ServerClientAPI } from './client'
 import { MethodContext, MethodContextAPI } from '../../lib/api/methods'
 import { TimelineObjectCoreExt } from 'tv-automation-sofie-blueprints-integration'
 import { StudioContentWriteAccess } from '../security/studio'
-import { CacheForStudio, initCacheForNoRundownPlaylist, CacheForStudioBase } from '../DatabaseCaches'
-import { time, timeline } from 'console'
+import { initCacheForNoRundownPlaylist, CacheForStudioBase } from '../DatabaseCaches'
 
 function insertTimelineObject(
 	context: MethodContext,
@@ -30,15 +23,13 @@ function insertTimelineObject(
 	const timelineObject: TimelineObjGeneric = {
 		...timelineObjectOrg,
 
-		_id: getTimelineId(studioId, timelineObjectOrg.id),
-		studioId: studioId,
 		objectType: TimelineObjType.MANUAL,
 	}
 
 	const studio = Studios.findOne(studioId)
 	const studioTimeline = cache.Timeline.findOne({ _id: studioId })
 	if (studio && studioTimeline) {
-		const indexOfExisting = studioTimeline.timeline.map((x) => x._id).indexOf(timelineObject._id)
+		const indexOfExisting = studioTimeline.timeline.map((x) => x.id).indexOf(timelineObject.id)
 		if (indexOfExisting >= 0) {
 			studioTimeline.timeline[indexOfExisting] = timelineObject
 		} else {
@@ -56,7 +47,7 @@ function removeTimelineObject(context: MethodContext, cache: CacheForStudioBase,
 	const studio = Studios.findOne(studioId)
 	const studioTimeline = cache.Timeline.findOne({ _id: studioId })
 	if (studio && studioTimeline) {
-		studioTimeline.timeline = studioTimeline.timeline.filter((x, index) => x._id !== protectString(id))
+		studioTimeline.timeline = studioTimeline.timeline.filter((x) => x.id !== id)
 		cache.Timeline.update(studioId, studioTimeline)
 	}
 }

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -7,8 +7,6 @@ import { Rundowns } from '../../lib/collections/Rundowns'
 import { getCurrentTime, protectString, makePromise, waitForPromise } from '../../lib/lib'
 import { PeripheralDeviceCommands, PeripheralDeviceCommandId } from '../../lib/collections/PeripheralDeviceCommands'
 import { logger } from '../logging'
-import { Timeline, getTimelineId } from '../../lib/collections/Timeline'
-import { Studios, StudioId } from '../../lib/collections/Studios'
 import { ServerPlayoutAPI } from './playout/playout'
 import { registerClassToMeteorMethods } from '../methods'
 import { IncomingMessage, ServerResponse } from 'http'
@@ -30,8 +28,9 @@ import { triggerWriteAccess, triggerWriteAccessBecauseNoCheckNecessary } from '.
 import { checkAccessAndGetPeripheralDevice } from './ingest/lib'
 import { PickerPOST } from './http'
 import { initCacheForNoRundownPlaylist, initCacheForRundownPlaylist, CacheForRundownPlaylist } from '../DatabaseCaches'
-import { getActiveRundownPlaylistsInStudio } from './playout/studio'
 import { RundownPlaylist } from '../../lib/collections/RundownPlaylists'
+import { getActiveRundownPlaylistsInStudio } from './playout/studio'
+import { StudioId } from '../../lib/collections/Studios'
 
 // import {ServerPeripheralDeviceAPIMOS as MOS} from './peripheralDeviceMos'
 export namespace ServerPeripheralDeviceAPI {
@@ -234,8 +233,7 @@ export namespace ServerPeripheralDeviceAPI {
 
 			logger.info('Timeline: Setting time: "' + o.id + '": ' + o.time)
 
-			const id = getTimelineId(studioId, o.id)
-			const obj = timelineObjs.find((tlo) => tlo._id === id)
+			const obj = timelineObjs.find((tlo) => tlo.id === o.id)
 			if (obj) {
 				obj.enable.start = o.time
 				obj.enable.setFromNow = true

--- a/meteor/server/api/playout/__tests__/__snapshots__/playout.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/playout.test.ts.snap
@@ -6,7 +6,6 @@ Array [
     "_id": "mockStudio4",
     "timeline": Array [
       Object {
-        "_id": "mockStudio4_playlist_randomId9002_status",
         "classes": Array [
           "rundown_active",
         ],
@@ -19,10 +18,8 @@ Array [
         "id": "playlist_randomId9002_status",
         "layer": "rundown_status",
         "objectType": "rundown",
-        "studioId": "mockStudio4",
       },
       Object {
-        "_id": "mockStudio4_part_group_randomId9002_part0_0_randomId9008",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -37,10 +34,8 @@ Array [
         "layer": "",
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio4",
       },
       Object {
-        "_id": "mockStudio4_part_group_firstobject_randomId9002_part0_0_randomId9008",
         "classes": Array [],
         "content": Object {
           "callBack": "partPlaybackStarted",
@@ -59,10 +54,8 @@ Array [
         "inGroup": "part_group_randomId9002_part0_0_randomId9008",
         "layer": "group_first_object",
         "objectType": "rundown",
-        "studioId": "mockStudio4",
       },
       Object {
-        "_id": "mockStudio4_piece_group_randomId9002_part0_0_randomId9008_randomId9002_piece001",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -80,7 +73,6 @@ Array [
         },
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio4",
       },
     ],
   },
@@ -117,7 +109,6 @@ Array [
     "_id": "mockStudio4",
     "timeline": Array [
       Object {
-        "_id": "mockStudio4_baseline_version",
         "content": Object {
           "deviceType": 0,
         },
@@ -130,12 +121,11 @@ Array [
           "versions": Object {
             "blueprintId": "mockBlueprint0",
             "blueprintVersion": "0.0.0",
-            "core": "1.12.0-in-development-R24",
+            "core": "1.12.0-in-development-R25",
             "studio": "asdf",
           },
         },
         "objectType": "rundown",
-        "studioId": "mockStudio4",
       },
     ],
   },

--- a/meteor/server/api/playout/__tests__/__snapshots__/timeline.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/timeline.test.ts.snap
@@ -6,7 +6,6 @@ Array [
     "_id": "mockStudio11",
     "timeline": Array [
       Object {
-        "_id": "mockStudio11_playlist_randomId9002_status",
         "classes": Array [
           "rundown_active",
         ],
@@ -19,10 +18,8 @@ Array [
         "id": "playlist_randomId9002_status",
         "layer": "rundown_status",
         "objectType": "rundown",
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_part_group_randomId9002_part0_0_randomId9007",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -37,10 +34,8 @@ Array [
         "layer": "",
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_part_group_firstobject_randomId9002_part0_0_randomId9007",
         "classes": Array [],
         "content": Object {
           "callBack": "partPlaybackStarted",
@@ -59,10 +54,8 @@ Array [
         "inGroup": "part_group_randomId9002_part0_0_randomId9007",
         "layer": "group_first_object",
         "objectType": "rundown",
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_piece_group_randomId9002_part0_0_randomId9007_randomId9002_piece001",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -80,7 +73,6 @@ Array [
         },
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio11",
       },
     ],
   },
@@ -93,7 +85,6 @@ Array [
     "_id": "mockStudio11",
     "timeline": Array [
       Object {
-        "_id": "mockStudio11_playlist_randomId9002_status",
         "classes": Array [
           "rundown_active",
         ],
@@ -106,10 +97,8 @@ Array [
         "id": "playlist_randomId9002_status",
         "layer": "rundown_status",
         "objectType": "rundown",
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_part_group_randomId9002_part0_0_randomId9007",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -125,10 +114,8 @@ Array [
         "layer": "",
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_part_group_firstobject_randomId9002_part0_0_randomId9007",
         "classes": Array [],
         "content": Object {
           "callBack": "partPlaybackStarted",
@@ -147,10 +134,8 @@ Array [
         "inGroup": "part_group_randomId9002_part0_0_randomId9007",
         "layer": "group_first_object",
         "objectType": "rundown",
-        "studioId": "mockStudio11",
       },
       Object {
-        "_id": "mockStudio11_piece_group_randomId9002_part0_0_randomId9007_randomId9002_piece001",
         "children": Array [],
         "content": Object {
           "deviceType": 0,
@@ -168,7 +153,6 @@ Array [
         },
         "objectType": "rundown",
         "priority": 5,
-        "studioId": "mockStudio11",
       },
     ],
   },
@@ -181,7 +165,6 @@ Array [
     "_id": "mockStudio11",
     "timeline": Array [
       Object {
-        "_id": "mockStudio11_baseline_version",
         "content": Object {
           "deviceType": 0,
         },
@@ -194,12 +177,11 @@ Array [
           "versions": Object {
             "blueprintId": "mockBlueprint7",
             "blueprintVersion": "0.0.0",
-            "core": "1.12.0-in-development-R24",
+            "core": "1.12.0-in-development-R25",
             "studio": "asdf",
           },
         },
         "objectType": "rundown",
-        "studioId": "mockStudio11",
       },
     ],
   },

--- a/meteor/server/api/playout/lookahead.ts
+++ b/meteor/server/api/playout/lookahead.ts
@@ -407,8 +407,6 @@ function findObjectsForPart(
 				allObjs.push(
 					literal<TimelineObjRundown>({
 						...obj,
-						_id: protectString(''), // set later
-						studioId: protectString(''), // set later
 						objectType: TimelineObjType.RUNDOWN,
 					})
 				)
@@ -482,8 +480,6 @@ function findObjectsForPart(
 				res.push(
 					literal<TimelineObjRundown & OnGenerateTimelineObj>({
 						...obj,
-						_id: protectString(''), // set later
-						studioId: protectString(''), // set later
 						objectType: TimelineObjType.RUNDOWN,
 						pieceInstanceId: unprotectString(pieceInstanceId),
 						infinitePieceId: unprotectString(piece._id),

--- a/meteor/server/api/playout/pieces.ts
+++ b/meteor/server/api/playout/pieces.ts
@@ -84,8 +84,6 @@ export function createPieceGroupFirstObject(
 ): TimelineObjPieceAbstract & OnGenerateTimelineObj {
 	const firstObject = literal<TimelineObjPieceAbstract & OnGenerateTimelineObj>({
 		id: getPieceFirstObjectId(unprotectString(pieceInstance.piece._id)),
-		_id: protectString(''), // set later
-		studioId: protectString(''), // set later
 		pieceInstanceId: unprotectString(pieceInstance._id),
 		infinitePieceId: unprotectString(pieceInstance.infinite?.infinitePieceId),
 		objectType: TimelineObjType.RUNDOWN,
@@ -308,8 +306,6 @@ export function convertPieceToAdLibPiece(piece: PieceInstancePiece): AdLibPiece 
 			_.compact(
 				_.map(contentObjects, (obj: TimelineObjectCoreExt) => {
 					return extendMandadory<TimelineObjectCoreExt, TimelineObjGeneric>(obj, {
-						_id: protectString(''), // set later
-						studioId: protectString(''), // set later
 						objectType: TimelineObjType.RUNDOWN,
 					})
 				})
@@ -385,8 +381,6 @@ export function convertAdLibToPieceInstance(
 			_.compact(
 				_.map(contentObjects, (obj) => {
 					return extendMandadory<TimelineObjectCoreExt, TimelineObjGeneric>(obj, {
-						_id: protectString(''), // set later
-						studioId: protectString(''), // set later
 						objectType: TimelineObjType.RUNDOWN,
 					})
 				})

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1235,12 +1235,9 @@ export namespace ServerPlayoutAPI {
 		const activeRundowns = getActiveRundownPlaylistsInStudio(cache, studio._id)
 
 		if (activeRundowns.length === 0) {
-			// const markerId: TimelineObjId = protectString(`${studio._id}_baseline_version`)
 			const studioTimeline = cache.Timeline.findOne(studioId)
 			if (!studioTimeline) return 'noBaseline'
-			const markerObject = studioTimeline.timeline.find(
-				(x) => x._id === protectString(`${studio._id}_baseline_version`)
-			)
+			const markerObject = studioTimeline.timeline.find((x) => x.id === `baseline_version`)
 			if (!markerObject) return 'noBaseline'
 
 			const versionsContent = (markerObject.metaData || {}).versions || {}

--- a/meteor/server/api/testTools.ts
+++ b/meteor/server/api/testTools.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
 import { RecordedFiles, RecordedFile, RecordedFileId } from '../../lib/collections/RecordedFiles'
-import { Studios, Studio, ITestToolsConfig, MappingExt, StudioId } from '../../lib/collections/Studios'
+import { Studios, Studio, ITestToolsConfig, StudioId } from '../../lib/collections/Studios'
 import {
 	getCurrentTime,
 	literal,
@@ -14,8 +14,8 @@ import {
 import { NewTestToolsAPI, TestToolsAPIMethods } from '../../lib/api/testTools'
 import { registerClassToMeteorMethods } from '../methods'
 import moment from 'moment'
-import { TimelineObjRecording, TimelineObjType, setTimelineId } from '../../lib/collections/Timeline'
-import { LookaheadMode, TSR } from 'tv-automation-sofie-blueprints-integration'
+import { TimelineObjRecording, TimelineObjType } from '../../lib/collections/Timeline'
+import { TSR } from 'tv-automation-sofie-blueprints-integration'
 import * as request from 'request'
 import { promisify } from 'util'
 import { check } from '../../lib/check'
@@ -57,11 +57,9 @@ export function generateRecordingTimelineObjs(studio: Studio, recording: Recorde
 		input: getHash(recording._id + layerInput),
 	}
 
-	return setTimelineId([
+	return [
 		literal<TSR.TimelineObjCCGRecord & TimelineObjRecording>({
 			id: IDs.record,
-			_id: protectString(''),
-			studioId: studio._id,
 			objectType: TimelineObjType.RECORDING,
 			enable: {
 				start: recording.startedAt,
@@ -80,8 +78,6 @@ export function generateRecordingTimelineObjs(studio: Studio, recording: Recorde
 		}),
 		literal<TSR.TimelineObjCCGInput & TimelineObjRecording>({
 			id: IDs.input,
-			_id: protectString(''), // set later,
-			studioId: studio._id,
 			objectType: TimelineObjType.RECORDING,
 			enable: { while: 1 },
 			priority: 0,
@@ -94,7 +90,7 @@ export function generateRecordingTimelineObjs(studio: Studio, recording: Recorde
 				deviceFormat: config.recordings.channelFormat,
 			},
 		}),
-	])
+	]
 }
 
 export namespace ServerTestToolsAPI {

--- a/meteor/server/migration/0_25_0.ts
+++ b/meteor/server/migration/0_25_0.ts
@@ -4,14 +4,7 @@ import { renamePropertiesInCollection, setExpectedVersion } from './lib'
 import * as semver from 'semver'
 import { getCoreSystem } from '../../lib/collections/CoreSystem'
 import { getDeprecatedDatabases, dropDeprecatedDatabases } from './deprecatedDatabases/0_25_0'
-import {
-	asyncCollectionInsert,
-	asyncCollectionInsertIgnore,
-	waitForPromiseAll,
-	partial,
-	protectString,
-} from '../../lib/lib'
-
+import { asyncCollectionInsertIgnore, waitForPromiseAll } from '../../lib/lib'
 import { AsRunLog } from '../../lib/collections/AsRunLog'
 import { Evaluations } from '../../lib/collections/Evaluations'
 import { ExpectedMediaItems } from '../../lib/collections/ExpectedMediaItems'
@@ -23,17 +16,16 @@ import { Segments } from '../../lib/collections/Segments'
 import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
 import { ShowStyleVariants } from '../../lib/collections/ShowStyleVariants'
 import { Snapshots } from '../../lib/collections/Snapshots'
-import { Timeline as Timeline120, TimelineObjGeneric, TimelineObjType } from '../../lib/collections/Timeline'
+import { Timeline as Timeline120 } from '../../lib/collections/Timeline'
 import { AdLibPieces } from '../../lib/collections/AdLibPieces'
 import { Pieces } from '../../lib/collections/Pieces'
 import { RundownBaselineObjs } from '../../lib/collections/RundownBaselineObjs'
 import { RundownBaselineAdLibPieces } from '../../lib/collections/RundownBaselineAdLibPieces'
-import { Rundowns, DBRundown } from '../../lib/collections/Rundowns'
+import { Rundowns } from '../../lib/collections/Rundowns'
 import { Parts } from '../../lib/collections/Parts'
 import { Studios } from '../../lib/collections/Studios'
-import { logger } from '../../lib/logging'
 import { PeripheralDeviceAPI } from '../../lib/api/peripheralDevice'
-import { Rundown as Rundown_1_0_0 } from './deprecatedDataTypes/1_0_1'
+import { TimelineObjGeneric as TimelineObjGeneric_1_11_0 } from './deprecatedDataTypes/1_12_0'
 import { TransformedCollection } from '../../lib/typings/meteor'
 
 // 0.25.0 (Release 10) // This is a big refactoring, with a LOT of renamings
@@ -217,7 +209,7 @@ addMigrationSteps('0.25.0', [
 	),
 	renamePropertiesInCollection(
 		'Timeline',
-		(Timeline120 as unknown) as TransformedCollection<TimelineObjGeneric, TimelineObjGeneric>,
+		(Timeline120 as unknown) as TransformedCollection<TimelineObjGeneric_1_11_0, TimelineObjGeneric_1_11_0>,
 		'Timeline',
 		{
 			studioId: 'siId',

--- a/meteor/server/migration/deprecatedDataTypes/1_12_0.ts
+++ b/meteor/server/migration/deprecatedDataTypes/1_12_0.ts
@@ -1,0 +1,22 @@
+import { TimelineObjectCoreExt, TSR } from 'tv-automation-sofie-blueprints-integration'
+import { TimelineObjId, TimelineObjType } from '../../../lib/collections/Timeline'
+import { StudioId } from '../../../lib/collections/Studios'
+
+export interface TimelineObjGeneric extends TimelineObjectCoreExt {
+	/** Unique _id (generally obj.studioId + '_' + obj.id) */
+	_id: TimelineObjId
+	/** Unique within a timeline (ie within a studio) */
+	id: string
+	/** Set when the id of the object is prefixed */
+	originalId?: string
+
+	/** Studio installation Id */
+	studioId: StudioId
+
+	objectType: TimelineObjType
+
+	enable: TSR.Timeline.TimelineEnable & { setFromNow?: boolean }
+
+	/** The id of the group object this object is in  */
+	inGroup?: string
+}

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -13,7 +13,7 @@ import { StudioReadAccess } from '../security/studio'
 
 meteorPublish(PubSub.timeline, function(selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
-	const modifier: FindOptions<TimelineObjGeneric> = {
+	const modifier: FindOptions<TimelineComplete> = {
 		fields: {},
 	}
 	if (StudioReadAccess.studioContent(selector, { userId: this.userId, token })) {


### PR DESCRIPTION
With the move to store `TimelineComplete` in the database, the individual objects don't need a studioId defined, or to have the secondary _id field. _id was kept as a guaranteed system unique copy of id to avoid data collisions if multiple studios were in a single sofie instance. This means that id can be left to be for the timeline and only needs to be unique within a timeline

This removes those two properties as they have no longer have a benefit

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
