### PR TITLE
Contribute: Various fixes from TV 2

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1681,6 +1681,7 @@ body.no-overflow {
 
 							&.label-overflow-time {
 								font-weight: 300;
+								padding-right: 10px;
 							}
 
 							> .segment-timeline__piece__label {

--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -262,6 +262,11 @@ export const App = translateWithTracker(() => {
 									<Route exact path="/" component={RundownList} />
 								)}
 								<this.protectedRoute path="/rundowns" component={RundownList} />
+								<this.protectedRoute
+									path="/rundown/:playlistId/shelf"
+									exact
+									component={(props) => <RundownView {...props} onlyShelf={true} />}
+								/>
 								<this.protectedRoute path="/rundown/:playlistId" component={RundownView} />
 								<this.protectedRoute path="/activeRundown/:studioId" component={ActiveRundownView} />
 								<this.protectedRoute path="/prompter/:studioId" component={PrompterView} />

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1568,7 +1568,25 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 							$in: rundownIDs,
 						},
 					})
-					if (this.props.onlyShelf) {
+				}
+			})
+			this.autorun(() => {
+				if (this.props.onlyShelf) {
+					let playlist = RundownPlaylists.findOne(playlistId, {
+						fields: {
+							_id: 1,
+							currentPartInstanceId: 1,
+							nextPartInstanceId: 1,
+							previousPartInstanceId: 1,
+						},
+					})
+					if (playlist) {
+						const rundowns = playlist.getRundowns(undefined, {
+							fields: {
+								_id: 1,
+							},
+						})
+						const rundownIDs = rundowns.map((i) => i._id)
 						this.subscribe(PubSub.pieceInstances, {
 							rundownId: {
 								$in: rundownIDs,

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1518,6 +1518,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					})
 				}
 			})
+
 			this.autorun(() => {
 				let playlist = RundownPlaylists.findOne(playlistId, {
 					fields: {
@@ -1567,6 +1568,34 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 							$in: rundownIDs,
 						},
 					})
+					if (this.props.onlyShelf) {
+						this.subscribe(PubSub.parts, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+						})
+						this.subscribe(PubSub.partInstances, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+							reset: {
+								$ne: true,
+							},
+						})
+						this.subscribe(PubSub.pieces, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+						})
+						this.subscribe(PubSub.pieceInstances, {
+							rundownId: {
+								$in: rundownIDs,
+							},
+							reset: {
+								$ne: true,
+							},
+						})
+					}
 				}
 			})
 			this.autorun(() => {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1574,23 +1574,13 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				if (this.props.onlyShelf) {
 					let playlist = RundownPlaylists.findOne(playlistId, {
 						fields: {
-							_id: 1,
 							currentPartInstanceId: 1,
 							nextPartInstanceId: 1,
 							previousPartInstanceId: 1,
 						},
 					})
 					if (playlist) {
-						const rundowns = playlist.getRundowns(undefined, {
-							fields: {
-								_id: 1,
-							},
-						})
-						const rundownIDs = rundowns.map((i) => i._id)
 						this.subscribe(PubSub.pieceInstances, {
-							rundownId: {
-								$in: rundownIDs,
-							},
 							partInstanceId: {
 								$in: [
 									playlist.currentPartInstanceId,

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1569,27 +1569,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						},
 					})
 					if (this.props.onlyShelf) {
-						this.subscribe(PubSub.parts, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-						})
-						this.subscribe(PubSub.partInstances, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-							reset: {
-								$ne: true,
-							},
-						})
-						this.subscribe(PubSub.pieces, {
-							rundownId: {
-								$in: rundownIDs,
-							},
-						})
 						this.subscribe(PubSub.pieceInstances, {
 							rundownId: {
 								$in: rundownIDs,
+							},
+							partInstanceId: {
+								$in: [
+									playlist.currentPartInstanceId,
+									playlist.nextPartInstanceId,
+									playlist.previousPartInstanceId,
+								].filter((p) => p !== null),
 							},
 							reset: {
 								$ne: true,

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.scss
@@ -115,6 +115,7 @@ $timeline-layer-height: 1em;
 		flex-flow: column nowrap;
 		min-height: 1em;
 		contain: strict style;
+		overflow: hidden;
 
 		.segment-timeline__layer {
 			flex: 1 1;

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -279,7 +279,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 						'keyup',
 						this.props.hotkeyGroup
 					)
-					this.usedHotkeys.push(item.hotkey, this.props.hotkeyGroup)
+					this.usedHotkeys.push(item.hotkey)
 
 					const sourceLayer = this.props.sourceLayerLookup[item.sourceLayerId]
 					if (sourceLayer && sourceLayer.isQueueable) {

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -31,7 +31,7 @@ import { DashboardPieceButtonSplitPreview } from './DashboardPieceButtonSplitPre
 
 export interface IDashboardButtonProps {
 	adLibListItem: IAdLibListItem
-	layer: ISourceLayer
+	layer?: ISourceLayer
 	outputLayer?: IOutputLayer
 	onToggleAdLib: (aSLine: IAdLibListItem, queue: boolean, context: any) => void
 	playlist: RundownPlaylist
@@ -147,7 +147,11 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 					{renderThumbnail ? (
 						<DashboardPieceButtonSplitPreview piece={splitAdLib} />
 					) : (
-						<SplitInputIcon abbreviation={this.props.layer.abbreviation} piece={splitAdLib} hideLabel={true} />
+						<SplitInputIcon
+							abbreviation={this.props.layer ? this.props.layer.abbreviation : undefined}
+							piece={splitAdLib}
+							hideLabel={true}
+						/>
 					)}
 				</React.Fragment>
 			)

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -157,6 +157,7 @@ export function getPlayheadTrackingInfinitesForPart(
 				fromPreviousPart: true,
 				fromPreviousPlayhead: true,
 			}
+			instance.adLibSourceId = p.adLibSourceId
 		}
 
 		return instance

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -118,7 +118,7 @@ export function updateExpectedPlayoutItemsOnPart(
 	cache.deferAfterSave(() => {
 		const intermediaryItems = extractExpectedPlayoutItems(part, [
 			...getAllPiecesFromCache(cache, part),
-			...part.getAllAdLibPieces(),
+			...getAllAdLibPiecesFromCache(cache, part),
 		])
 		const expectedPlayoutItems = wrapExpectedPlayoutItems(rundown, intermediaryItems)
 

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -18,7 +18,7 @@ import {
 import { profiler } from '../profiler'
 
 // /** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
-export const DEFINITELY_ENDED_FUTURE_DURATION = 10 * 1000
+export const DEFINITELY_ENDED_FUTURE_DURATION = 1 * 1000
 
 /**
  * We can only continue adlib onEnd infinites if we go forwards in the rundown. Any distance backwards will clear them.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A variety of fixed are included in this PR:
- Copy adLibSourceId to continuation pieces for an infinite
  - Fixes a bug where continuation pieces of an infinite would not have the adLibSourceId copied to them, which is required for "toggling" and infinite in dashboards.
- chore: use cache for expected playout items for adLibs
  - Previously this would make a direct database call, rather than the cache. This has no performance benefit right now, but is more consistent and may mean that a performance improvement is seen in the future with continued work on the caching system.
- fix: Standalone shelf route
  - The routing for standalone shelf views had been lost at some point, this restores the missing route.
- fix: arrow overlapping with extra time label
  - Small visual fix to the positioning of the overflow time label.
- fix: Crop WithinPart piece instances
  - There was a difference between what the UI was expecting (a unix timestamp) and what the data in the database contained (time relative to the start of the part). This resulted in pieces with WithinPart lifespans not getting cropped correctly when stopped (e.g. by stopping pieces on a sourcelayer).
- Set definitely ended to 1 second
  - With some experimentation at TV 2, we have found that the current definitely ended time (10 seconds) lets pieces live for too long, impacting performance. We have been testing with this value since 02/09 and have not found any issues created by lowering this value.
- fix: Don't push group name to used hotkeys
  - The hotkey group name was being pushed to usedHotkeys in dashboard panels, for every hotkey.
- fix: Dashboard crash
  - It's possible for props.layer to be undefined, so this PR changes it to be optional to enforce checking for the presence of layer.
- fix: Subscribe to all parts, pieces, and instances if in standalone shelf
  - fix: Only fetch piece instances for current, next, and previous part
  - Two commits. Previously, the standalone shelf wouldn't fetch any data, meaning it can't perform actions like stopping pieces and much of the context-aware functionality of the shelf was broken. These two commits mean that the standalone shelf will fetch data from the current, next, and previous parts; which has been enough data so far from testing.
- fix: timed pieces showing outside of their part
  - In cases where you have a part that is set to say 10 seconds, which contain pieces that start after 15 seconds (graphics for example), these graphics would appear outside of the part (often over other parts). This change applies CSS to hide these pieces until the part is played out long enough for them to be about to play out.
- fix: store playlist id in expected playout items
  - This adds playlistId property to ExpectedPlayoutItem because Playout Gateway and TSR need it to filter items that belong to the active rundown playlist

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
