### PR TITLE
Fix/readonly caches

### DIFF
--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -57,6 +57,7 @@ export class Cache {
 				const futureError = new Meteor.Error(500, `saveAllToDatabase never called`)
 				this._activeTimeout = Meteor.setTimeout(() => {
 					logger.error(futureError)
+					logger.error(futureError.stack)
 				}, 2000)
 			}
 		}

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -29,7 +29,12 @@ import { AsRunEventContext } from './blueprints/context'
 import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
 import { PartInstance, PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance, PieceInstanceId } from '../../lib/collections/PieceInstances'
-import { CacheForRundownPlaylist, initCacheForRundownPlaylist } from '../DatabaseCaches'
+import {
+	CacheForRundownPlaylist,
+	initCacheForRundownPlaylist,
+	convertReadOnlyCacheForRundownPlaylist,
+	initReadOnlyCacheForRundownPlaylist,
+} from '../DatabaseCaches'
 import { profiler } from './profiler'
 import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
 
@@ -85,7 +90,8 @@ function handleAsRunEvent(event: AsRunLogEvent): void {
 				const { blueprint } = loadShowStyleBlueprint(showStyleBase)
 
 				if (blueprint.onAsRunEvent) {
-					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
+					const cache = waitForPromise(initReadOnlyCacheForRundownPlaylist(playlist))
+
 					const context = new AsRunEventContext(rundown, cache, event)
 
 					Promise.resolve(blueprint.onAsRunEvent(context))

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -62,7 +62,7 @@ import { Blueprints } from '../../../../lib/collections/Blueprints'
 import { ExternalMessageQueue } from '../../../../lib/collections/ExternalMessageQueue'
 import { extendIngestRundownCore } from '../../ingest/lib'
 import { loadStudioBlueprint, loadShowStyleBlueprint } from '../cache'
-import { CacheForRundownPlaylist } from '../../../DatabaseCaches'
+import { CacheForRundownPlaylist, ReadOnlyCacheForRundownPlaylist } from '../../../DatabaseCaches'
 
 /** Common */
 
@@ -223,7 +223,7 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 
 	constructor(
 		studio: Studio,
-		private readonly cache: CacheForRundownPlaylist | undefined,
+		private readonly cache: ReadOnlyCacheForRundownPlaylist | undefined,
 		readonly _rundown: Rundown | undefined,
 		readonly showStyleBaseId: ShowStyleBaseId,
 		readonly showStyleVariantId: ShowStyleVariantId,
@@ -329,7 +329,7 @@ export class RundownContext extends ShowStyleContext implements IRundownContext,
 	readonly _rundown: Rundown
 	readonly playlistId: RundownPlaylistId
 
-	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, notesContext: NotesContext | undefined) {
+	constructor(rundown: Rundown, cache: ReadOnlyCacheForRundownPlaylist, notesContext: NotesContext | undefined) {
 		super(
 			cache.activationCache.getStudio(),
 			cache,
@@ -387,7 +387,7 @@ export class PartEventContext extends RundownContext implements IPartEventContex
 export class AsRunEventContext extends RundownContext implements IAsRunEventContext {
 	public readonly asRunEvent: Readonly<IBlueprintAsRunLogEvent>
 
-	constructor(rundown: Rundown, cache: CacheForRundownPlaylist, asRunEvent: AsRunLogEvent) {
+	constructor(rundown: Rundown, cache: ReadOnlyCacheForRundownPlaylist, asRunEvent: AsRunLogEvent) {
 		super(
 			rundown,
 			cache,

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -213,12 +213,14 @@ export namespace ServerPeripheralDeviceAPI {
 					// Take ownership of the playlist in the db, so that we can mutate the timeline and piece instances
 					const cache = waitForPromise(initCacheForRundownPlaylist(activePlaylist, undefined, false))
 					timelineTriggerTimeInner(cache, studioId, results, activePlaylist)
+					waitForPromise(cache.saveAllToDatabase())
 				})
 			} else {
 				// TODO - technically this could still be a race condition, but the chances of it colliding with another cache write
 				// are slim and need larger changes to avoid. Also, using a `start: 'now'` in a studio baseline would be weird
 				const cache = waitForPromise(initCacheForNoRundownPlaylist(studioId))
 				timelineTriggerTimeInner(cache, studioId, results, undefined)
+				waitForPromise(cache.saveAllToDatabase())
 			}
 		}
 	},
@@ -303,9 +305,6 @@ export namespace ServerPeripheralDeviceAPI {
 				true
 			)
 		}
-
-		// After we've updated the timeline, we must call afterUpdateTimeline!
-		waitForPromise(cache.saveAllToDatabase())
 	}
 	export function partPlaybackStarted(
 		context: MethodContext,


### PR DESCRIPTION
This is an attempt to fix an issue I found in https://github.com/nrkno/tv-automation-server-core/blob/fix/readonly-caches/meteor/server/api/asRunLog.ts#L93 where we set up a cache, but never call `cache.saveAllToDatabase()`.

The simplest solution here would be to simply call `cache.saveAllToDatabase()`, but we might not want to do that without putting it in a `syncFunction`.

This PR instead adds a ReadOnly-version of the Cache (since the AsRunLog-context only uses it for reading stuff), which doesn't need to have `cache.saveAllToDatabase()`.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
