### PR TITLE
asRunLog in snapshot

### DIFF
--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -783,7 +783,6 @@ export function getSelectedPartInstancesFromCache(
 
 	const selector: MongoQuery<DBPartInstance> = {
 		rundownId: { $in: rundownIds },
-		reset: { $ne: true },
 	}
 
 	const currentPartInstance = playlist.currentPartInstanceId

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -87,6 +87,7 @@ import {
 	RundownBaselineAdLibAction,
 } from '../../lib/collections/RundownBaselineAdLibActions'
 import { migrateConfigToBlueprintConfigOnObject } from '../migration/1_12_0'
+import { AsRunLogEvent, AsRunLog } from '../../lib/collections/AsRunLog'
 
 interface DeprecatedRundownSnapshot {
 	// Old, from the times before rundownPlaylists
@@ -127,6 +128,7 @@ interface RundownPlaylistSnapshot {
 	mediaObjects: Array<MediaObject>
 	expectedMediaItems: Array<ExpectedMediaItem>
 	expectedPlayoutItems: Array<ExpectedPlayoutItem>
+	asRunLog: Array<AsRunLogEvent> // Note: asRunLog is not restored when restoring
 }
 interface SystemSnapshot {
 	version: string
@@ -211,6 +213,7 @@ function createRundownPlaylistSnapshot(
 	const expectedMediaItems = ExpectedMediaItems.find({ partId: { $in: parts.map((i) => i._id) } }).fetch()
 	const expectedPlayoutItems = ExpectedPlayoutItems.find({ rundownId: { $in: rundownIds } }).fetch()
 	const baselineObjs = RundownBaselineObjs.find({ rundownId: { $in: rundownIds } }).fetch()
+	const asRunLog = AsRunLog.find({ rundownId: { $in: rundownIds } }).fetch()
 
 	logger.info(`Snapshot generation done`)
 	return {
@@ -243,6 +246,7 @@ function createRundownPlaylistSnapshot(
 		mediaObjects,
 		expectedMediaItems,
 		expectedPlayoutItems,
+		asRunLog,
 	}
 }
 
@@ -785,6 +789,8 @@ export function restoreFromRundownPlaylistSnapshot(
 		{ rundownId: { $in: rundownIds } },
 		updateItemIds(snapshot.expectedPlayoutItems || [], true)
 	)
+
+	// snapshot.asRunLog is not restored, since that is a log of events in the system
 
 	logger.info(`Restore done`)
 }


### PR DESCRIPTION
This PR adds the `asRunLog` into RundownPlaylistSnapshots, to help with future troubleshooting.

I specifically DONT restore the asRunLog when restoring, since that is a log of what the system has done, so it should not be polluted by restoring snapshots.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
