### PR TITLE
Fix: call functions with custom timeout

### DIFF
--- a/meteor/client/lib/clientAPI.ts
+++ b/meteor/client/lib/clientAPI.ts
@@ -8,15 +8,22 @@ import { MeteorCall } from '../../lib/api/methods'
 export function callPeripheralDeviceFunction(
 	e: any,
 	deviceId: PeripheralDeviceId,
+	timeoutTime: number | undefined,
 	functionName: string,
 	...params: any[]
 ): Promise<any> {
-	return MeteorCall.client.callPeripheralDeviceFunction(eventContextForLog(e), deviceId, functionName, ...params)
+	return MeteorCall.client.callPeripheralDeviceFunction(
+		eventContextForLog(e),
+		deviceId,
+		timeoutTime,
+		functionName,
+		...params
+	)
 }
 
 export namespace PeripheralDevicesAPI {
 	export function restartDevice(dev: PeripheralDevice, e: Event | React.SyntheticEvent<object>): Promise<any> {
-		return callPeripheralDeviceFunction(e, dev._id, 'killProcess', 1)
+		return callPeripheralDeviceFunction(e, dev._id, undefined, 'killProcess', 1)
 	}
 }
 

--- a/meteor/client/lib/dev.ts
+++ b/meteor/client/lib/dev.ts
@@ -16,6 +16,7 @@ Meteor.startup(() => {
 
 window['Collections'] = Collections
 window['executeFunction'] = PeripheralDeviceAPI.executeFunction
+window['executeFunctionWithCustomTimeout'] = PeripheralDeviceAPI.executeFunctionWithCustomTimeout
 window['getCurrentTime'] = getCurrentTime
 window['Session'] = Session
 

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2353,7 +2353,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				title: t('Restart CasparCG Server'),
 				message: t('Do you want to restart CasparCG Server "{{device}}"?', { device: device.name }),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, 'restartCasparCG')
+					callPeripheralDeviceFunction(event, device._id, undefined, 'restartCasparCG')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -95,6 +95,7 @@ import { AdLibPieceUi } from './Shelf/AdLibPanel'
 import { documentTitle } from '../lib/documentTitle'
 import { PartInstanceId, PartInstance } from '../../lib/collections/PartInstances'
 import { RundownDividerHeader } from './RundownView/RundownDividerHeader'
+import { CASPARCG_RESTART_TIME } from '../../lib/constants'
 
 export const MAGIC_TIME_SCALE_FACTOR = 0.03
 
@@ -2353,7 +2354,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				title: t('Restart CasparCG Server'),
 				message: t('Do you want to restart CasparCG Server "{{device}}"?', { device: device.name }),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, undefined, 'restartCasparCG')
+					callPeripheralDeviceFunction(event, device._id, CASPARCG_RESTART_TIME, 'restartCasparCG')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(

--- a/meteor/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestOAuthFlow.tsx
@@ -7,6 +7,7 @@ import { IngestDeviceSettings } from '../../../../lib/collections/PeripheralDevi
 import { NotificationCenter, Notification, NoticeLevel } from '../../../lib/notifications/notifications'
 import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
 import { fetchFrom } from '../../../lib/lib'
+import { callPeripheralDeviceFunction } from '../../../lib/clientAPI'
 
 interface IConfigManifestOAuthFlowComponentState {}
 interface IConfigManifestOAuthFlowComponentProps {
@@ -103,22 +104,16 @@ export const ConfigManifestOAuthFlowComponent = withTranslation()(
 		onUpdatedAccessToken(authToken: string) {
 			authToken = (authToken + '').trim()
 			if (authToken && authToken.length > 5) {
-				PeripheralDeviceAPI.executeFunction(
-					this.props.device._id,
-					(e) => {
-						if (e) {
-							// nothing
-							console.log(e)
-							NotificationCenter.push(
-								new Notification(undefined, NoticeLevel.WARNING, 'Error when authorizing access token: ' + e, '')
-							)
-						} else {
-							NotificationCenter.push(new Notification(undefined, NoticeLevel.NOTIFICATION, 'Access token saved!', ''))
-						}
-					},
-					'receiveAuthToken',
-					authToken
-				)
+				callPeripheralDeviceFunction(event, this.props.device._id, undefined, 'receiveAuthToken', authToken)
+					.then(() => {
+						NotificationCenter.push(new Notification(undefined, NoticeLevel.NOTIFICATION, 'Access token saved!', ''))
+					})
+					.catch((e) => {
+						console.log(e)
+						NotificationCenter.push(
+							new Notification(undefined, NoticeLevel.WARNING, 'Error when authorizing access token: ' + e, '')
+						)
+					})
 			}
 		}
 		render() {

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -24,6 +24,7 @@ import { StatusResponse } from '../../../lib/api/systemStatus'
 import { doUserAction, UserAction } from '../../lib/userAction'
 import { MeteorCall } from '../../../lib/api/methods'
 import { RESTART_SALT } from '../../../lib/api/userActions'
+import { CASPARCG_RESTART_TIME } from '../../../lib/constants'
 
 interface IDeviceItemProps {
 	// key: string,
@@ -95,7 +96,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 				title: t('Restart CasparCG Server'),
 				message: t('Do you want to restart CasparCG Server?'),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, undefined, 'restartCasparCG')
+					callPeripheralDeviceFunction(event, device._id, CASPARCG_RESTART_TIME, 'restartCasparCG')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -95,7 +95,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 				title: t('Restart CasparCG Server'),
 				message: t('Do you want to restart CasparCG Server?'),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, 'restartCasparCG')
+					callPeripheralDeviceFunction(event, device._id, undefined, 'restartCasparCG')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(
@@ -130,7 +130,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 				title: t('Restart Quantel Gateway'),
 				message: t('Do you want to restart Quantel Gateway?'),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, 'restartQuantel')
+					callPeripheralDeviceFunction(event, device._id, undefined, 'restartQuantel')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(
@@ -162,7 +162,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 				title: t('Format HyperDeck disks'),
 				message: t('Do you want to format the HyperDeck disks? This is a destructive action and cannot be undone.'),
 				onAccept: (event: any) => {
-					callPeripheralDeviceFunction(event, device._id, 'formatHyperdeck')
+					callPeripheralDeviceFunction(event, device._id, undefined, 'formatHyperdeck')
 						.then(() => {
 							NotificationCenter.push(
 								new Notification(

--- a/meteor/lib/api/client.ts
+++ b/meteor/lib/api/client.ts
@@ -7,6 +7,7 @@ export interface NewClientAPI {
 	callPeripheralDeviceFunction(
 		context: string,
 		deviceId: PeripheralDeviceId,
+		timeoutTime: number | undefined,
 		functionName: string,
 		...args: any[]
 	): Promise<any>

--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -436,7 +436,7 @@ export namespace PeripheralDeviceAPI {
 	export function executeFunctionWithCustomTimeout(
 		deviceId: PeripheralDeviceId,
 		cb: (err, result) => void,
-		timeoutTime: number,
+		timeoutTime: number = 3000,
 		functionName: string,
 		...args: any[]
 	) {
@@ -521,7 +521,6 @@ export namespace PeripheralDeviceAPI {
 		functionName: string,
 		...args: any[]
 	) {
-		const timeoutTime = 3000
-		return executeFunctionWithCustomTimeout(deviceId, cb, timeoutTime, functionName, ...args)
+		return executeFunctionWithCustomTimeout(deviceId, cb, undefined, functionName, ...args)
 	}
 }

--- a/meteor/lib/constants.ts
+++ b/meteor/lib/constants.ts
@@ -1,0 +1,2 @@
+/** An appropriate time to wait for the 'restartcasparcg' peripheral-function to execute  */
+export const CASPARCG_RESTART_TIME = 10000

--- a/meteor/server/api/__tests__/client.test.ts
+++ b/meteor/server/api/__tests__/client.test.ts
@@ -58,6 +58,7 @@ describe('ClientAPI', () => {
 						ClientAPIMethods.callPeripheralDeviceFunction,
 						mockContext,
 						mockDeviceId,
+						undefined,
 						mockFunctionName,
 						...mockArgs
 					)
@@ -129,6 +130,7 @@ describe('ClientAPI', () => {
 					ClientAPIMethods.callPeripheralDeviceFunction,
 					mockContext,
 					mockDeviceId,
+					undefined,
 					mockFailingFunctionName,
 					...mockArgs
 				)

--- a/meteor/server/api/client.ts
+++ b/meteor/server/api/client.ts
@@ -117,6 +117,7 @@ export namespace ServerClientAPI {
 		methodContext: MethodContext,
 		context: string,
 		deviceId: PeripheralDeviceId,
+		timeoutTime: number | undefined,
 		functionName: string,
 		...args: any[]
 	): Promise<any> {
@@ -133,12 +134,13 @@ export namespace ServerClientAPI {
 				// Just run and return right away:
 				try {
 					triggerWriteAccessBecauseNoCheckNecessary()
-					PeripheralDeviceAPI.executeFunction(
+					PeripheralDeviceAPI.executeFunctionWithCustomTimeout(
 						deviceId,
 						(err, result) => {
 							if (err) reject(err)
 							else resolve(result)
 						},
+						timeoutTime,
 						functionName,
 						...args
 					)
@@ -166,7 +168,7 @@ export namespace ServerClientAPI {
 				})
 			)
 			try {
-				PeripheralDeviceAPI.executeFunction(
+				PeripheralDeviceAPI.executeFunctionWithCustomTimeout(
 					deviceId,
 					(err, result) => {
 						if (err) {
@@ -196,6 +198,7 @@ export namespace ServerClientAPI {
 						resolve(result)
 						return
 					},
+					timeoutTime,
 					functionName,
 					...args
 				)
@@ -237,7 +240,13 @@ class ServerClientAPIClass extends MethodContextAPI implements NewClientAPI {
 	clientErrorReport(timestamp: Time, errorObject: any, location: string) {
 		return makePromise(() => ServerClientAPI.clientErrorReport(this, timestamp, errorObject, location))
 	}
-	callPeripheralDeviceFunction(context: string, deviceId: PeripheralDeviceId, functionName: string, ...args: any[]) {
+	callPeripheralDeviceFunction(
+		context: string,
+		deviceId: PeripheralDeviceId,
+		timeoutTime: number | undefined,
+		functionName: string,
+		...args: any[]
+	) {
 		return makePromise(() => {
 			const methodContext: MethodContext = this
 			if (!Settings.enableUserAccounts) {
@@ -249,7 +258,14 @@ class ServerClientAPIClass extends MethodContextAPI implements NewClientAPI {
 					methodContext.token = device.token
 				}
 			}
-			return ServerClientAPI.callPeripheralDeviceFunction(methodContext, context, deviceId, functionName, ...args)
+			return ServerClientAPI.callPeripheralDeviceFunction(
+				methodContext,
+				context,
+				deviceId,
+				timeoutTime,
+				functionName,
+				...args
+			)
 		})
 	}
 }

--- a/meteor/server/cronjobs.ts
+++ b/meteor/server/cronjobs.ts
@@ -10,6 +10,7 @@ import { TSR } from 'tv-automation-sofie-blueprints-integration'
 import { AsRunLog } from '../lib/collections/AsRunLog'
 import { UserActionsLog } from '../lib/collections/UserActionsLog'
 import { Snapshots } from '../lib/collections/Snapshots'
+import { CASPARCG_RESTART_TIME } from '../lib/constants'
 
 let lowPrioFcn = (fcn: (...args: any[]) => any, ...args: any[]) => {
 	// Do it at a random time in the future:
@@ -127,7 +128,7 @@ Meteor.startup(() => {
 											resolve()
 										}
 									},
-									10000,
+									CASPARCG_RESTART_TIME,
 									'restartCasparCG'
 								)
 							})


### PR DESCRIPTION
This PR adds timeoutTime to callPeripheralDeviceFunction, so that it's easier to specify custom timeouts.

Along with this, it fixes a timeout issue where when calling 'casparcgRestart'.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
