### PR TITLE
Feat/restructure blueprint logging

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -11,8 +11,6 @@ import {
 	SourceLayerType,
 	StudioBlueprintManifest,
 	BlueprintManifestType,
-	IStudioContext,
-	IStudioConfigContext,
 	IBlueprintShowStyleBase,
 	IngestRundown,
 	BlueprintManifestBase,
@@ -22,7 +20,6 @@ import {
 	BlueprintResultRundown,
 	BlueprintResultSegment,
 	IngestSegment,
-	SegmentContext,
 	IBlueprintAdLibPiece,
 	IBlueprintRundown,
 	IBlueprintSegment,
@@ -275,11 +272,11 @@ export function setupMockStudioBlueprint(showStyleBaseId: ShowStyleBaseId): Blue
 
 				studioConfigManifest: [],
 				studioMigrations: [],
-				getBaseline: (context: IStudioContext): TSR.TSRTimelineObjBase[] => {
+				getBaseline: (context: unknown): TSR.TSRTimelineObjBase[] => {
 					return []
 				},
 				getShowStyleId: (
-					context: IStudioConfigContext,
+					context: unknown,
 					showStyles: Array<IBlueprintShowStyleBase>,
 					ingestRundown: IngestRundown
 				): string | null => {
@@ -321,7 +318,7 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 				showStyleConfigManifest: [],
 				showStyleMigrations: [],
 				getShowStyleVariantId: (
-					context: IStudioConfigContext,
+					context: unknown,
 					showStyleVariants: Array<IBlueprintShowStyleVariant>,
 					ingestRundown: IngestRundown
 				): string | null => {
@@ -341,7 +338,7 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 						baseline: [],
 					}
 				},
-				getSegment: (context: SegmentContext, ingestSegment: IngestSegment): BlueprintResultSegment => {
+				getSegment: (context: unknown, ingestSegment: IngestSegment): BlueprintResultSegment => {
 					const segment: IBlueprintSegment = {
 						name: ingestSegment.name ? ingestSegment.name : ingestSegment.externalId,
 						metaData: ingestSegment.payload,

--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -16,7 +16,7 @@ import {
 	BlueprintManifestBase,
 	ShowStyleBlueprintManifest,
 	IBlueprintShowStyleVariant,
-	ShowStyleContext,
+	IShowStyleContext,
 	BlueprintResultRundown,
 	BlueprintResultSegment,
 	IngestSegment,
@@ -324,7 +324,7 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 				): string | null => {
 					return SHOW_STYLE_VARIANT_ID
 				},
-				getRundown: (context: ShowStyleContext, ingestRundown: IngestRundown): BlueprintResultRundown => {
+				getRundown: (context: IShowStyleContext, ingestRundown: IngestRundown): BlueprintResultRundown => {
 					const rundown: IBlueprintRundown = {
 						externalId: ingestRundown.externalId,
 						name: ingestRundown.name,

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -17462,9 +17462,9 @@
 			}
 		},
 		"tv-automation-sofie-blueprints-integration": {
-			"version": "3.0.0-nightly-feat-localisation-20200925-131650-a7a0fd91.0",
-			"resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-3.0.0-nightly-feat-localisation-20200925-131650-a7a0fd91.0.tgz",
-			"integrity": "sha512-EtjPu0dY7C0CkngNN+Y1Pp9MHtO5CIAAg9zkMW84u46p7Mul27s6t6y8yyGIiYPH805AUADCsxDjK6/Vu4W0gA==",
+			"version": "3.0.0-nightly-feat-restructure-logging-20200925-131814-2f27114c.0",
+			"resolved": "https://registry.npmjs.org/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-3.0.0-nightly-feat-restructure-logging-20200925-131814-2f27114c.0.tgz",
+			"integrity": "sha512-HapGf5m+H5aeLRTi/4Gl21lq8FwXcVE6hkxtwJ6g7AHWNoFz32/azZBCPigy9QFEBBLtNwOqS/FwJhcSNbOQjA==",
 			"requires": {
 				"moment": "2.22.2",
 				"timeline-state-resolver-types": "5.0.0-nightly-release24-20200914-120931-3357b9dc.0",

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -17096,7 +17096,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -95,7 +95,7 @@
     "soap": "^0.31.0",
     "superfly-timeline": "^8.1.1",
     "timecode": "0.0.4",
-    "tv-automation-sofie-blueprints-integration": "3.0.0-nightly-feat-localisation-20200925-131650-a7a0fd91.0",
+    "tv-automation-sofie-blueprints-integration": "3.0.0-nightly-feat-restructure-logging-20200925-131814-2f27114c.0",
     "underscore": "^1.11.0",
     "utility-types": "^3.10.0",
     "velocity-animate": "^1.5.2",

--- a/meteor/server/api/asRunLog.ts
+++ b/meteor/server/api/asRunLog.ts
@@ -92,7 +92,15 @@ function handleAsRunEvent(event: AsRunLogEvent): void {
 				if (blueprint.onAsRunEvent) {
 					const cache = waitForPromise(initReadOnlyCacheForRundownPlaylist(playlist))
 
-					const context = new AsRunEventContext(rundown, cache, event)
+					const context = new AsRunEventContext(
+						{
+							name: rundown.name,
+							identifier: `rundownId=${rundown._id},eventId=${event._id}`,
+						},
+						rundown,
+						cache,
+						event
+					)
 
 					Promise.resolve(blueprint.onAsRunEvent(context))
 						.then((messages: Array<IBlueprintExternalMessageQueueObj>) => {

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -7,7 +7,7 @@ import {
 import { protectString, unprotectString, waitForPromise, getRandomId, getCurrentTime } from '../../../../lib/lib'
 import { Studio, Studios } from '../../../../lib/collections/Studios'
 import { IBlueprintPart, IBlueprintPiece, PieceLifespan } from 'tv-automation-sofie-blueprints-integration'
-import { NotesContext, ActionExecutionContext, ActionPartChange } from '../context'
+import { ActionExecutionContext, ActionPartChange } from '../context'
 import { Rundown, Rundowns } from '../../../../lib/collections/Rundowns'
 import { PartInstance, PartInstanceId, PartInstances } from '../../../../lib/collections/PartInstances'
 import {
@@ -107,14 +107,21 @@ describe('Test blueprint api context', () => {
 		const rundownIds = getRundownIDsFromCache(cache, playlist)
 		waitForPromise(cache.PieceInstances.fillWithDataFromDatabase({ rundownId: { $in: rundownIds } }))
 
-		const notesContext = new NotesContext('fakeContext', `fakeContext`, true)
-		const context = new ActionExecutionContext(cache, notesContext, studio, playlist, rundown)
+		const context = new ActionExecutionContext(
+			{
+				name: 'fakeContext',
+				identifier: 'action',
+			},
+			cache,
+			studio,
+			playlist,
+			rundown
+		)
 		expect(context.getStudio()).toBeTruthy()
 
 		return {
 			playlist,
 			rundown,
-			notesContext,
 			context,
 		}
 	}

--- a/meteor/server/api/blueprints/__tests__/context.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context.test.ts
@@ -429,48 +429,6 @@ describe('Test blueprint api context', () => {
 				getShowStyleConfigRef.mockRestore()
 			}
 		})
-
-		// class FakeNotesContext implements INotesContext {
-		// 	error: (message: string) => void = jest.fn()
-		// 	warning: (message: string) => void = jest.fn()
-		// 	getHashId: (originString: string, originIsNotUnique?: boolean | undefined) => string = jest.fn(
-		// 		() => 'hashed'
-		// 	)
-		// 	unhashId: (hash: string) => string = jest.fn(() => 'unhash')
-		// }
-
-		// testInFiber('notes', () => {
-		// 	const studio = mockStudio()
-		// 	const context = getContext(studio)
-
-		// 	// Fake the notes context
-		// 	const fakeNotes = new FakeNotesContext()
-		// 		// Apply mocked notesContext:
-		// 	;(context as any).notesContext = fakeNotes
-
-		// 	context.error('this is an {{error}}', { error: 'embarrasing situation' }, 'extid1')
-
-		// 	expect(fakeNotes.error).toHaveBeenCalledTimes(1)
-		// 	expect(fakeNotes.error).toHaveBeenCalledWith(
-		// 		'this is an {{error}}',
-		// 		{ error: 'embarrasing situation' },
-		// 		'extid1'
-		// 	)
-
-		// 	context.warning('this is an warning', {}, 'extid1')
-		// 	expect(fakeNotes.warning).toHaveBeenCalledTimes(1)
-		// 	expect(fakeNotes.warning).toHaveBeenCalledWith('this is an warning', {}, 'extid1')
-
-		// 	const hash = context.getHashId('str 1', false)
-		// 	expect(hash).toEqual('hashed')
-		// 	expect(fakeNotes.getHashId).toHaveBeenCalledTimes(1)
-		// 	expect(fakeNotes.getHashId).toHaveBeenCalledWith('str 1', false)
-
-		// 	const unhash = context.unhashId('str 1')
-		// 	expect(unhash).toEqual('unhash')
-		// 	expect(fakeNotes.unhashId).toHaveBeenCalledTimes(1)
-		// 	expect(fakeNotes.unhashId).toHaveBeenCalledWith('str 1')
-		// })
 	})
 
 	describe('SegmentUserContext', () => {

--- a/meteor/server/api/blueprints/__tests__/postProcess.test.ts
+++ b/meteor/server/api/blueprints/__tests__/postProcess.test.ts
@@ -82,14 +82,14 @@ describe('Test blueprint post-process', () => {
 		)
 
 		// Make sure we arent an IUserNotesContext, as that means new work to handle those notes
-		expect(((context as unknown) as IUserNotesContext).userError).toBeUndefined()
+		expect(((context as unknown) as IUserNotesContext).notifyUserError).toBeUndefined()
 		return context
 	}
 	function getStudioContext(studio: Studio) {
 		const context = new StudioContext({ name: studio.name, identifier: `studioId=${studio._id}` }, studio)
 
 		// Make sure we arent an IUserNotesContext, as that means new work to handle those notes
-		expect(((context as unknown) as IUserNotesContext).userError).toBeUndefined()
+		expect(((context as unknown) as IUserNotesContext).notifyUserError).toBeUndefined()
 		return context
 	}
 

--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -13,6 +13,7 @@ import { Meteor } from 'meteor/meteor'
 import { getShowStyleCompound, ShowStyleVariantId, ShowStyleCompound } from '../../../lib/collections/ShowStyleVariants'
 import { protectString, objectPathGet, objectPathSet } from '../../../lib/lib'
 import { logger } from '../../../lib/logging'
+import { CommonContext } from './context'
 
 /**
  * This whole ConfigRef logic will need revisiting for a multi-studio context, to ensure that there are strict boundaries across who can give to access to what.
@@ -85,7 +86,11 @@ export function preprocessStudioConfig(studio: Studio, blueprint?: StudioBluepri
 	res['SofieHostURL'] = studio.settings.sofieUrl
 
 	if (blueprint && blueprint.preprocessConfig) {
-		res = blueprint.preprocessConfig(res)
+		const context = new CommonContext({
+			name: `preprocessStudioConfig`,
+			identifier: `studioId=${studio._id}`,
+		})
+		res = blueprint.preprocessConfig(context, res)
 	}
 	return res
 }
@@ -98,7 +103,11 @@ export function preprocessShowStyleConfig(showStyle: ShowStyleCompound, blueprin
 		res = showStyle.blueprintConfig
 	}
 	if (blueprint && blueprint.preprocessConfig) {
-		res = blueprint.preprocessConfig(res)
+		const context = new CommonContext({
+			name: `preprocessShowStyleConfig`,
+			identifier: `showStyleBaseId=${showStyle._id},showStyleVariantId=${showStyle.showStyleVariantId}`,
+		})
+		res = blueprint.preprocessConfig(context, res)
 	}
 	return res
 }

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -123,6 +123,8 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 		this.rundownPlaylist = rundownPlaylist
 		this.rundown = rundown
 		this.takeAfterExecute = false
+
+		this.blackHoleNotes = contextInfo.blackHoleUserNotes ?? false
 	}
 
 	notifyUserError(message: string, params?: { [key: string]: any }, trackingId?: string): void {

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -13,8 +13,8 @@ import {
 import { Part } from '../../../../lib/collections/Parts'
 import { logger } from '../../../../lib/logging'
 import {
-	EventContext as IEventContext,
-	ActionExecutionContext as IActionExecutionContext,
+	IEventContext,
+	IActionExecutionContext,
 	IBlueprintPartInstance,
 	IBlueprintPieceInstance,
 	IBlueprintPiece,
@@ -125,7 +125,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 		this.takeAfterExecute = false
 	}
 
-	userError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		if (this.blackHoleNotes) {
 			this.logError(message)
 		} else {
@@ -139,7 +139,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 			})
 		}
 	}
-	userWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		if (this.blackHoleNotes) {
 			this.logWarning(message)
 		} else {

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -73,11 +73,14 @@ export interface UserContextInfo extends ContextInfo {
 
 export class CommonContext implements ICommonContext {
 	private readonly _contextIdentifier: string
+	private readonly _contextName: string
+
 	private hashI = 0
 	private hashed: { [hash: string]: string } = {}
 
 	constructor(info: ContextInfo) {
 		this._contextIdentifier = info.identifier
+		this._contextName = info.name
 	}
 	getHashId(str: string, isNotUnique?: boolean) {
 		if (!str) str = 'hash' + this.hashI++
@@ -95,20 +98,16 @@ export class CommonContext implements ICommonContext {
 	}
 
 	logDebug(message: string): void {
-		// TODO - prefix with _contextIdentifier?
-		logger.debug(message)
+		logger.debug(`"${this._contextName}": "${message}"\n(${this._contextIdentifier})`)
 	}
 	logInfo(message: string): void {
-		// TODO - prefix with _contextIdentifier?
-		logger.info(message)
+		logger.info(`"${this._contextName}": "${message}"\n(${this._contextIdentifier})`)
 	}
 	logWarning(message: string): void {
-		// TODO - prefix with _contextIdentifier?
-		logger.warn(message)
+		logger.warn(`"${this._contextName}": "${message}"\n(${this._contextIdentifier})`)
 	}
 	logError(message: string): void {
-		// TODO - prefix with _contextIdentifier?
-		logger.error(message)
+		logger.error(`"${this._contextName}": "${message}"\n(${this._contextIdentifier})`)
 	}
 }
 

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -19,15 +19,15 @@ import { logger } from '../../../../lib/logging'
 import {
 	ICommonContext,
 	IUserNotesContext,
-	ShowStyleContext as IShowStyleContext,
-	RundownContext as IRundownContext,
-	SegmentUserContext as ISegmentUserContext,
-	EventContext as IEventContext,
-	AsRunEventContext as IAsRunEventContext,
-	PartEventContext as IPartEventContext,
-	TimelineEventContext as ITimelineEventContext,
-	StudioContext as IStudioContext,
-	StudioUserContext as IStudioUserContext,
+	IShowStyleContext,
+	IRundownContext,
+	ISegmentUserContext,
+	IEventContext,
+	IAsRunEventContext,
+	IPartEventContext,
+	ITimelineEventContext,
+	IStudioContext,
+	IStudioUserContext,
 	BlueprintMappings,
 	IBlueprintSegmentDB,
 	IngestPart,
@@ -38,7 +38,6 @@ import {
 	IBlueprintAsRunLogEvent,
 	IBlueprintExternalMessageQueueObj,
 	ExtendedIngestRundown,
-	ShowStyleBlueprintManifest,
 } from 'tv-automation-sofie-blueprints-integration'
 import { Studio, StudioId, Studios } from '../../../../lib/collections/Studios'
 import { ConfigRef, preprocessStudioConfig, findMissingConfigs, preprocessShowStyleConfig } from '../config'
@@ -187,7 +186,7 @@ export class StudioUserContext extends StudioContext implements IStudioUserConte
 		this.blackHoleNotes = contextInfo.blackHoleUserNotes ?? false
 	}
 
-	userError(message: string, params?: { [key: string]: any }): void {
+	notifyUserError(message: string, params?: { [key: string]: any }): void {
 		if (this.blackHoleNotes) {
 			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -200,7 +199,7 @@ export class StudioUserContext extends StudioContext implements IStudioUserConte
 			})
 		}
 	}
-	userWarning(message: string, params?: { [key: string]: any }): void {
+	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
 		if (this.blackHoleNotes) {
 			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -311,7 +310,7 @@ export class ShowStyleUserContext extends ShowStyleContext implements IUserNotes
 		super(contextInfo, studio, cache, _rundown, showStyleBaseId, showStyleVariantId)
 	}
 
-	userError(message: string, params?: { [key: string]: any }): void {
+	notifyUserError(message: string, params?: { [key: string]: any }): void {
 		if (this.blackHoleNotes) {
 			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -324,7 +323,7 @@ export class ShowStyleUserContext extends ShowStyleContext implements IUserNotes
 			})
 		}
 	}
-	userWarning(message: string, params?: { [key: string]: any }): void {
+	notifyUserWarning(message: string, params?: { [key: string]: any }): void {
 		if (this.blackHoleNotes) {
 			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -388,7 +387,7 @@ export class SegmentUserContext extends RundownContext implements ISegmentUserCo
 		super(contextInfo, rundown, cache)
 	}
 
-	userError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		this.notes.push({
 			type: NoteType.ERROR,
 			message: {
@@ -398,7 +397,7 @@ export class SegmentUserContext extends RundownContext implements ISegmentUserCo
 			trackingId: trackingId,
 		})
 	}
-	userWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		this.notes.push({
 			type: NoteType.WARNING,
 			message: {
@@ -473,7 +472,7 @@ export class TimelineEventContext extends RundownContext implements ITimelineEve
 		return getCurrentTime()
 	}
 
-	userError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserError(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		if (this.blackHoleNotes) {
 			this.logError(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -487,7 +486,7 @@ export class TimelineEventContext extends RundownContext implements ITimelineEve
 			})
 		}
 	}
-	userWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
+	notifyUserWarning(message: string, params?: { [key: string]: any }, trackingId?: string): void {
 		if (this.blackHoleNotes) {
 			this.logWarning(`UserNotes: "${message}", ${JSON.stringify(params)}`)
 		} else {
@@ -512,12 +511,7 @@ export class AsRunEventContext extends RundownContext implements IAsRunEventCont
 		cache: ReadOnlyCacheForRundownPlaylist,
 		asRunEvent: AsRunLogEvent
 	) {
-		super(
-			contextInfo,
-			rundown,
-			cache
-			// new NotesContext(rundown.name, `rundownId=${rundown._id},asRunEventId=${asRunEvent._id}`, false)
-		)
+		super(contextInfo, rundown, cache)
 		this.asRunEvent = unprotectObject(asRunEvent)
 	}
 

--- a/meteor/server/api/ingest/bucketAdlibs.ts
+++ b/meteor/server/api/ingest/bucketAdlibs.ts
@@ -3,8 +3,8 @@ import { IngestAdlib } from 'tv-automation-sofie-blueprints-integration'
 import { ShowStyleCompound } from '../../../lib/collections/ShowStyleVariants'
 import { Studio } from '../../../lib/collections/Studios'
 import { loadShowStyleBlueprint } from '../blueprints/cache'
-import { ShowStyleContext, NotesContext } from '../blueprints/context'
-import { postProcessAdLibPieces, postProcessBucketAdLib } from '../blueprints/postProcess'
+import { ShowStyleUserContext } from '../blueprints/context'
+import { postProcessBucketAdLib } from '../blueprints/postProcess'
 import { RundownImportVersions } from '../../../lib/collections/Rundowns'
 import { PackageInfo } from '../../coreSystem'
 import { BucketAdLibs } from '../../../lib/collections/BucketAdlibs'
@@ -14,8 +14,6 @@ import {
 	cleanUpExpectedMediaItemForBucketAdLibPiece,
 	updateExpectedMediaItemForBucketAdLibPiece,
 } from '../expectedMediaItems'
-import { waitForPromise, unprotectString } from '../../../lib/lib'
-import { initCacheForRundownPlaylist } from '../../DatabaseCaches'
 
 export function updateBucketAdlibFromIngestData(
 	showStyle: ShowStyleCompound,
@@ -25,21 +23,25 @@ export function updateBucketAdlibFromIngestData(
 ): PieceId | null {
 	const { blueprint, blueprintId } = loadShowStyleBlueprint(showStyle)
 
-	const blueprintIds: Set<string> = new Set<string>()
-	if (blueprintId) {
-		blueprintIds.add(unprotectString(blueprintId))
-	}
-	if (studio.blueprintId) {
-		blueprintIds.add(unprotectString(studio.blueprintId))
-	}
+	// const blueprintIds: Set<string> = new Set<string>()
+	// if (blueprintId) {
+	// 	blueprintIds.add(unprotectString(blueprintId))
+	// }
+	// if (studio.blueprintId) {
+	// 	blueprintIds.add(unprotectString(studio.blueprintId))
+	// }
 
-	const context = new ShowStyleContext(
+	const context = new ShowStyleUserContext(
+		{
+			name: `Bucket Ad-Lib`,
+			identifier: `studioId=${studio._id},showStyleBaseId=${showStyle._id},showStyleVariantId=${showStyle.showStyleVariantId}`,
+			blackHoleUserNotes: true, // TODO-CONTEXT
+		},
 		studio,
 		undefined,
 		undefined,
 		showStyle._id,
-		showStyle.showStyleVariantId,
-		new NotesContext('Bucket Ad-Lib', 'bucket-adlib', false, Array.from(blueprintIds))
+		showStyle.showStyleVariantId
 	)
 	if (!blueprint.getAdlibItem) throw new Meteor.Error(501, "This blueprint doesn't support ingest AdLibs")
 	const rawAdlib = blueprint.getAdlibItem(context, ingestData)

--- a/meteor/server/api/ingest/bucketAdlibs.ts
+++ b/meteor/server/api/ingest/bucketAdlibs.ts
@@ -27,7 +27,7 @@ export function updateBucketAdlibFromIngestData(
 		{
 			name: `Bucket Ad-Lib`,
 			identifier: `studioId=${studio._id},showStyleBaseId=${showStyle._id},showStyleVariantId=${showStyle.showStyleVariantId}`,
-			blackHoleUserNotes: true, // TODO-CONTEXT
+			tempSendUserNotesIntoBlackHole: true, // TODO-CONTEXT
 		},
 		studio,
 		undefined,

--- a/meteor/server/api/ingest/bucketAdlibs.ts
+++ b/meteor/server/api/ingest/bucketAdlibs.ts
@@ -23,14 +23,6 @@ export function updateBucketAdlibFromIngestData(
 ): PieceId | null {
 	const { blueprint, blueprintId } = loadShowStyleBlueprint(showStyle)
 
-	// const blueprintIds: Set<string> = new Set<string>()
-	// if (blueprintId) {
-	// 	blueprintIds.add(unprotectString(blueprintId))
-	// }
-	// if (studio.blueprintId) {
-	// 	blueprintIds.add(unprotectString(studio.blueprintId))
-	// }
-
 	const context = new ShowStyleUserContext(
 		{
 			name: `Bucket Ad-Lib`,

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -456,7 +456,7 @@ function updateRundownFromIngestData(
 		{
 			name: 'selectShowStyleVariant',
 			identifier: `studioId=${studio._id},rundownId=${existingDbRundown?._id},ingestRundownId=${ingestRundown.externalId}`,
-			blackHoleUserNotes: true,
+			tempSendUserNotesIntoBlackHole: true,
 		},
 		studio
 	)
@@ -615,7 +615,7 @@ function updateRundownFromIngestData(
 		{
 			name: 'getRundownPlaylistInfo',
 			identifier: `studioId=${studio._id},rundownId=${existingDbRundown?._id},ingestRundownId=${ingestRundown.externalId}`,
-			blackHoleUserNotes: true,
+			tempSendUserNotesIntoBlackHole: true,
 		},
 		studio
 	)
@@ -1450,11 +1450,11 @@ function generateSegmentContents(
 	const blueprintRes = blueprint.getSegment(context, ingestSegment)
 
 	// Ensure all parts have a valid externalId set on them
-	const knownPartIds = blueprintRes.parts.map((p) => p.part.externalId)
+	const knownPartExternalIds = blueprintRes.parts.map((p) => p.part.externalId)
 
 	const segmentNotes: SegmentNote[] = []
 	for (const note of context.notes) {
-		if (!note.trackingId || knownPartIds.indexOf(note.trackingId) === -1) {
+		if (!note.partExternalId || knownPartExternalIds.indexOf(note.partExternalId) === -1) {
 			segmentNotes.push(
 				literal<SegmentNote>({
 					type: note.type,
@@ -1492,7 +1492,7 @@ function generateSegmentContents(
 		const notes: PartNote[] = []
 
 		for (const note of context.notes) {
-			if (note.trackingId === blueprintPart.part.externalId) {
+			if (note.partExternalId === blueprintPart.part.externalId) {
 				notes.push(
 					literal<PartNote>({
 						type: note.type,

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -8,7 +8,7 @@ import { PeripheralDevices, PeripheralDevice } from '../../../lib/collections/Pe
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { getCurrentTime, getRandomId, waitForPromise } from '../../../lib/lib'
 import { loadShowStyleBlueprint } from '../blueprints/cache'
-import { RundownContext } from '../blueprints/context'
+import { RundownContext, RundownEventContext } from '../blueprints/context'
 import {
 	setNextPart,
 	onPartHasStoppedPlaying,
@@ -83,8 +83,10 @@ export function activateRundownPlaylist(
 
 	cache.defer((cache) => {
 		if (!rundown) return // if the proper rundown hasn't been found, there's little point doing anything else
-		const { blueprint } = loadShowStyleBlueprint(waitForPromise(cache.activationCache.getShowStyleBase(rundown)))
-		const context = new RundownContext(rundown, cache, undefined)
+		const { blueprint, blueprintId } = loadShowStyleBlueprint(
+			waitForPromise(cache.activationCache.getShowStyleBase(rundown))
+		)
+		const context = new RundownEventContext(blueprintId, rundown, cache)
 		context.wipeCache()
 		if (blueprint.onRundownActivate) {
 			Promise.resolve(blueprint.onRundownActivate(context)).catch(logger.error)
@@ -98,13 +100,13 @@ export function deactivateRundownPlaylist(cache: CacheForRundownPlaylist, rundow
 
 	cache.defer((cache) => {
 		if (rundown) {
-			const { blueprint } = loadShowStyleBlueprint(
+			const { blueprint, blueprintId } = loadShowStyleBlueprint(
 				waitForPromise(cache.activationCache.getShowStyleBase(rundown))
 			)
 			if (blueprint.onRundownDeActivate) {
-				Promise.resolve(blueprint.onRundownDeActivate(new RundownContext(rundown, cache, undefined))).catch(
-					logger.error
-				)
+				Promise.resolve(
+					blueprint.onRundownDeActivate(new RundownEventContext(blueprintId, rundown, cache))
+				).catch(logger.error)
 			}
 		}
 	})

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -30,7 +30,6 @@ import {
 import { Blueprints } from '../../../lib/collections/Blueprints'
 import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { loadShowStyleBlueprint } from '../blueprints/cache'
-import { NotesContext } from '../blueprints/context/context'
 import { ActionExecutionContext, ActionPartChange } from '../blueprints/context/adlibActions'
 import { IngestActions } from '../ingest/actions'
 import { updateTimeline } from './timeline'
@@ -1209,23 +1208,27 @@ export namespace ServerPlayoutAPI {
 				if (!rundown)
 					throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
 
-				const blueprintIds: Set<string> = new Set<string>()
-				if (studio.blueprintId) {
-					blueprintIds.add(unprotectString(studio.blueprintId))
-				}
-				if (rundown.getShowStyleBase()?.blueprintId) {
-					blueprintIds.add(unprotectString(rundown.getShowStyleBase().blueprintId))
-				}
+				// const blueprintIds: Set<string> = new Set<string>()
+				// if (studio.blueprintId) {
+				// 	blueprintIds.add(unprotectString(studio.blueprintId))
+				// }
+				// if (rundown.getShowStyleBase()?.blueprintId) {
+				// 	blueprintIds.add(unprotectString(rundown.getShowStyleBase().blueprintId))
+				// }
 
-				const notesContext = new NotesContext(
-					`${rundown.name}(${playlist.name})`,
-					`playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
-						currentPartInstance._id
-					},execution=${getRandomId()}`,
-					false,
-					Array.from(blueprintIds)
+				const actionContext = new ActionExecutionContext(
+					{
+						name: `${rundown.name}(${playlist.name})`,
+						identifier: `playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
+							currentPartInstance._id
+						},execution=${getRandomId()}`,
+						blackHoleUserNotes: true, // TODO-CONTEXT store these notes
+					},
+					cache,
+					studio,
+					playlist,
+					rundown
 				)
-				const actionContext = new ActionExecutionContext(cache, notesContext, studio, playlist, rundown)
 
 				// If any action cannot be done due to timings, that needs to be rejected by the context
 				func(actionContext, cache, rundown, currentPartInstance)

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1214,7 +1214,7 @@ export namespace ServerPlayoutAPI {
 						identifier: `playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
 							currentPartInstance._id
 						},execution=${getRandomId()}`,
-						blackHoleUserNotes: true, // TODO-CONTEXT store these notes
+						tempSendUserNotesIntoBlackHole: true, // TODO-CONTEXT store these notes
 					},
 					cache,
 					studio,

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1208,14 +1208,6 @@ export namespace ServerPlayoutAPI {
 				if (!rundown)
 					throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
 
-				// const blueprintIds: Set<string> = new Set<string>()
-				// if (studio.blueprintId) {
-				// 	blueprintIds.add(unprotectString(studio.blueprintId))
-				// }
-				// if (rundown.getShowStyleBase()?.blueprintId) {
-				// 	blueprintIds.add(unprotectString(rundown.getShowStyleBase().blueprintId))
-				// }
-
 				const actionContext = new ActionExecutionContext(
 					{
 						name: `${rundown.name}(${playlist.name})`,

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -136,14 +136,16 @@ export function takeNextPartInnerSync(
 
 	// beforeTake(rundown, previousPart || null, takePart)
 
-	const { blueprint } = waitForPromise(pBlueprint)
+	const { blueprint, blueprintId } = waitForPromise(pBlueprint)
 	if (blueprint.onPreTake) {
 		const span = profiler.startSpan('blueprint.onPreTake')
 		try {
 			waitForPromise(
-				Promise.resolve(blueprint.onPreTake(new PartEventContext(takeRundown, cache, takePartInstance))).catch(
-					logger.error
-				)
+				Promise.resolve(
+					blueprint.onPreTake(
+						new PartEventContext('onPreTake', blueprintId, takeRundown, cache, takePartInstance)
+					)
+				).catch(logger.error)
 			)
 			if (span) span.end()
 		} catch (e) {
@@ -160,7 +162,14 @@ export function takeNextPartInnerSync(
 			const resolvedPieces = getResolvedPieces(cache, showStyle, previousPartInstance)
 
 			const span = profiler.startSpan('blueprint.getEndStateForPart')
-			const context = new RundownContext(takeRundown, cache, undefined)
+			const context = new RundownContext(
+				{
+					name: `getEndStateForPart=${takeRundown.name}`,
+					identifier: `rundownId=${takeRundown._id},partInstanceId=${previousPartInstance._id}`,
+				},
+				takeRundown,
+				cache
+			)
 			previousPartEndState = blueprint.getEndStateForPart(
 				context,
 				playlist.previousPersistentState,
@@ -261,7 +270,15 @@ export function takeNextPartInnerSync(
 					const span = profiler.startSpan('blueprint.onRundownFirstTake')
 					waitForPromise(
 						Promise.resolve(
-							blueprint.onRundownFirstTake(new PartEventContext(takeRundown, cache, takePartInstance))
+							blueprint.onRundownFirstTake(
+								new PartEventContext(
+									'onRundownFirstTake',
+									blueprintId,
+									takeRundown,
+									cache,
+									takePartInstance
+								)
+							)
 						).catch(logger.error)
 					)
 					if (span) span.end()
@@ -272,7 +289,9 @@ export function takeNextPartInnerSync(
 				const span = profiler.startSpan('blueprint.onPostTake')
 				waitForPromise(
 					Promise.resolve(
-						blueprint.onPostTake(new PartEventContext(takeRundown, cache, takePartInstance))
+						blueprint.onPostTake(
+							new PartEventContext('onPostTake', blueprintId, takeRundown, cache, takePartInstance)
+						)
 					).catch(logger.error)
 				)
 				if (span) span.end()

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -266,7 +266,7 @@ function getTimelineRundown(cache: CacheForRundownPlaylist, studio: Studio): Tim
 					{
 						name: `onTimelineGenerate=${activeRundown.name}`,
 						identifier: `blueprintId=${showStyleBlueprint0.blueprintId},rundownId=${activeRundown._id},currentPartInstanceId=${currentPartInstance?._id},nextPartInstanceId=${nextPartInstance?._id}`,
-						blackHoleUserNotes: true, // TODO-CONTEXT store/show these notes
+						tempSendUserNotesIntoBlackHole: true, // TODO-CONTEXT store/show these notes
 					},
 					activeRundown,
 					cache,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This implements the changes in https://github.com/nrkno/tv-automation-sofie-blueprints-integration/pull/76 which change the logging api in blueprint methods to have a clear separation between messages intended for a user (notifyUser*) vs messages intended for the system log (log*)

* **Other information**:

This is based on the localisation work from @gundelsby, so the PR is targetting that branch with the intention it can be merged to there before that work gets merged

Note: the TODO-CONTEXT need a follow up task to implement the flow for those notes getting to a user. Previously it was not possible to get these messages to a user, so this was done as a intermediary step to get the desired typings implemented now, with the messages going to the log instead

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
