### PR TITLE
fix: ensure that the piece is actually playing in sourceLayerOnPartStop

### DIFF
--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -476,7 +476,7 @@ export namespace ServerPlayoutAdLibAPI {
 				!pieceInstance.userDuration &&
 				!pieceInstance.piece.virtual &&
 				filter(pieceInstance) &&
-				pieceInstance.resolvedStart &&
+				pieceInstance.resolvedStart !== undefined &&
 				pieceInstance.resolvedStart <= relativeStopAt
 			) {
 				switch (pieceInstance.piece.lifespan) {

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -472,7 +472,13 @@ export namespace ServerPlayoutAdLibAPI {
 		const stoppedInfiniteIds = new Set<PieceId>()
 
 		for (const pieceInstance of resolvedPieces) {
-			if (!pieceInstance.userDuration && !pieceInstance.piece.virtual && filter(pieceInstance)) {
+			if (
+				!pieceInstance.userDuration &&
+				!pieceInstance.piece.virtual &&
+				filter(pieceInstance) &&
+				pieceInstance.resolvedStart &&
+				pieceInstance.resolvedStart <= relativeStopAt
+			) {
 				switch (pieceInstance.piece.lifespan) {
 					case PieceLifespan.WithinPart:
 					case PieceLifespan.OutOnSegmentChange:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Before, sourceLayerOnPartStop would stop all pieces that it could find on a given source layer. The expected behavior is to stop only the currently playing pieces.

* **What is the current behavior?** (You can also link to an open issue here)

All pieces on a given source layer are stopped. As a result, pieces with effective negative length (with enable: X, and userDuration.end: Y, X > Y) would be set.

* **What is the new behavior (if this is a feature change)?**

The method filters the pieces resolvedStart value to only mutate pieces that should be currently playing.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
