### PR TITLE
fix: downgraded i18n expressions to not use any fancy typescript

### DIFF
--- a/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
+++ b/meteor/client/ui/ClipTrimPanel/ClipTrimDialog.tsx
@@ -77,7 +77,7 @@ export const ClipTrimDialog = withTranslation()(
 										<strong>{selectedPiece.name}</strong>:&ensp;
 										{t(
 											"Trimming this clip has timed out. It's possible that the story is currently locked for writing in {{nrcsName}} and will eventually be updated. Make sure that the story is not being edited by other users.",
-											{ nrcsName: this.props.rundown?.externalNRCSName || 'NRCS' }
+											{ nrcsName: (this.props.rundown && this.props.rundown.externalNRCSName) || 'NRCS' }
 										)}
 									</>
 								),
@@ -129,7 +129,7 @@ export const ClipTrimDialog = withTranslation()(
 								<strong>{selectedPiece.name}</strong>:&ensp;
 								{t(
 									"Trimming this clip is taking longer than expected. It's possible that the story is locked for writing in {{nrcsName}}.",
-									{ nrcsName: this.props.rundown?.externalNRCSName || 'NRCS' }
+									{ nrcsName: (this.props.rundown && this.props.rundown.externalNRCSName) || 'NRCS' }
 								)}
 							</>
 						),

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1148,7 +1148,9 @@ const RundownHeader = withTranslation()(
 										<MenuItem onClick={(e) => this.resetRundown(e)}>{t('Reset Rundown')}</MenuItem>
 									) : null}
 									<MenuItem onClick={(e) => this.reloadRundownPlaylist(e)}>
-										{t('Reload {{nrcsName}} Data', { nrcsName: this.props.firstRundown?.externalNRCSName || 'NRCS' })}
+										{t('Reload {{nrcsName}} Data', {
+											nrcsName: (this.props.firstRundown && this.props.firstRundown.externalNRCSName) || 'NRCS',
+										})}
 									</MenuItem>
 									<MenuItem onClick={(e) => this.takeRundownSnapshot(e)}>{t('Store Snapshot')}</MenuItem>
 								</React.Fragment>

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -697,7 +697,9 @@ class RundownViewNotifier extends WithManagedTracker {
 						true,
 						[
 							{
-								label: t('Reload {{nrcsName}} Data', { nrcsName: firstRundown?.externalNRCSName || 'NRCS' }),
+								label: t('Reload {{nrcsName}} Data', {
+									nrcsName: (firstRundown && firstRundown.externalNRCSName) || 'NRCS',
+								}),
 								type: 'primary',
 								action: (e) => {
 									const reloadFunc = reloadRundownPlaylistClick.get()

--- a/meteor/client/ui/RundownView/RundownSystemStatus.tsx
+++ b/meteor/client/ui/RundownView/RundownSystemStatus.tsx
@@ -277,7 +277,9 @@ export const RundownSystemStatus = translateWithTracker(
 							})}>
 							<div className="indicator__tooltip">
 								<h4>
-									{t('{{nrcsName}} Connection', { nrcsName: this.props.firstRundown?.externalNRCSName || 'NRCS' })}
+									{t('{{nrcsName}} Connection', {
+										nrcsName: (this.props.firstRundown && this.props.firstRundown.externalNRCSName) || 'NRCS',
+									})}
 								</h4>
 								<div>
 									<h5>{t('Last update')}</h5>

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -659,11 +659,13 @@ export class ConfigManifestSettings<
 
 		const value = rawValue === undefined ? item.defaultVal : rawValue
 
+		const rawValueArr = rawValue as any[]
+
 		switch (item.type) {
 			case ConfigManifestEntryType.BOOLEAN:
 				return value ? t('true') : t('false')
 			case ConfigManifestEntryType.TABLE:
-				return t('{{count}} rows', { count: ((rawValue as any[]) || []).length })
+				return t('{{count}} rows', { count: (rawValueArr || []).length })
 			case ConfigManifestEntryType.SELECT:
 			case ConfigManifestEntryType.LAYER_MAPPINGS:
 			case ConfigManifestEntryType.SOURCE_LAYERS:


### PR DESCRIPTION
the i18n-extract-pot script does apparently only want javascript in the i18n expressions.
I got errors like Unable to parse code "{ nrcsName: this.props.firstRundown?.externalNRCSName || 'NRCS' }"


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
