### PR TITLE
fix: Warning, not Error on failed NTP-time update

### DIFF
--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -80,6 +80,7 @@ export type Time = number
 export type TimeDuration = number
 
 const systemTime = {
+	hasBeenSet: false,
 	diff: 0,
 	stdDev: 9999,
 }

--- a/meteor/server/api/systemTime/systemTime.ts
+++ b/meteor/server/api/systemTime/systemTime.ts
@@ -149,6 +149,7 @@ function updateServerTime(retries: number = 0) {
 					) / 10} ms)`
 				)
 
+				systemTime.hasBeenSet = true
 				systemTime.diff = result.mean
 				systemTime.stdDev = result.stdDev
 				setSystemStatus('systemTime', {
@@ -157,6 +158,7 @@ function updateServerTime(retries: number = 0) {
 				})
 			} else {
 				if (result.stdDev < systemTime.stdDev) {
+					systemTime.hasBeenSet = true
 					systemTime.diff = result.mean
 					systemTime.stdDev = result.stdDev
 				}
@@ -181,7 +183,7 @@ function updateServerTime(retries: number = 0) {
 			} else {
 				logger.info('Unable to set system time (' + (err.reason || err) + ')')
 				setSystemStatus('systemTime', {
-					statusCode: StatusCode.BAD,
+					statusCode: systemTime.hasBeenSet ? StatusCode.WARNING_MAJOR : StatusCode.BAD,
 					messages: [`Error message: ${err.toString()}`],
 				})
 			}


### PR DESCRIPTION
Instead of always setting systemStatus to ERROR, only show it as a warning if a previous setting of time was successful.

This means that if the time-retrieval fails on initial startup, it'll show as an ERROR.
But if it fails later, it'll show as a warning.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
