### PR TITLE
RouteSets: allow "no layers" be routed into "some layers"

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -10,6 +10,7 @@ import { TransformedCollection } from '../../lib/typings/meteor'
 import ClassNames from 'classnames'
 import { ColorPickerEvent, ColorPicker } from './colorPicker'
 import { IconPicker, IconPickerEvent } from './iconPicker'
+import { Random } from 'meteor/random'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType
@@ -601,6 +602,8 @@ const EditAttributeDropdown = wrapEditAttribute(
 )
 const EditAttributeDropdownText = wrapEditAttribute(
 	class EditAttributeDropdownText extends EditAttributeBase {
+		private _id: string
+
 		constructor(props) {
 			super(props)
 
@@ -608,6 +611,8 @@ const EditAttributeDropdownText = wrapEditAttribute(
 			this.handleChangeText = this.handleChangeText.bind(this)
 			this.handleBlurText = this.handleBlurText.bind(this)
 			this.handleEscape = this.handleEscape.bind(this)
+
+			this._id = Random.id()
 		}
 		handleChangeDropdown(event) {
 			// because event.target.value is always a string, use the original value instead
@@ -620,7 +625,7 @@ const EditAttributeDropdownText = wrapEditAttribute(
 			this.handleUpdate(this.props.optionsAreNumbers ? parseInt(value, 10) : value)
 		}
 		handleChangeText(event) {
-			this.handleEdit(event.target.value)
+			this.handleChangeDropdown(event)
 		}
 		handleBlurText(event) {
 			this.handleUpdate(event.target.value)
@@ -727,19 +732,11 @@ const EditAttributeDropdownText = wrapEditAttribute(
 						onBlur={this.handleBlurText}
 						onKeyUp={this.handleEscape}
 						disabled={this.props.disabled}
+						spellCheck={false}
+						list={this._id}
 					/>
 
-					<select
-						className={
-							'form-control' +
-							' ' +
-							(this.props.className || '') +
-							' ' +
-							(this.state.editing ? this.props.modifiedClassName || '' : '')
-						}
-						value={this.getAttributeText()}
-						onChange={this.handleChangeDropdown}
-						disabled={this.props.disabled}>
+					<datalist id={this._id}>
 						{this.getOptions(true).map((o, j) =>
 							Array.isArray(o.value) ? (
 								<optgroup key={j} label={o.name}>
@@ -755,7 +752,7 @@ const EditAttributeDropdownText = wrapEditAttribute(
 								</option>
 							)
 						)}
-					</select>
+					</datalist>
 				</div>
 			)
 		}

--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -21,6 +21,7 @@ export type EditAttributeType =
 	| 'float'
 	| 'checkbox'
 	| 'dropdown'
+	| 'dropdowntext'
 	| 'switch'
 	| 'multiselect'
 	| 'json'
@@ -42,6 +43,8 @@ export class EditAttribute extends React.Component<IEditAttribute> {
 			return <EditAttributeSwitch {...this.props} />
 		} else if (this.props.type === 'dropdown') {
 			return <EditAttributeDropdown {...this.props} />
+		} else if (this.props.type === 'dropdowntext') {
+			return <EditAttributeDropdownText {...this.props} />
 		} else if (this.props.type === 'multiselect') {
 			return <EditAttributeMultiSelect {...this.props} />
 		} else if (this.props.type === 'json') {
@@ -592,6 +595,168 @@ const EditAttributeDropdown = wrapEditAttribute(
 						)
 					)}
 				</select>
+			)
+		}
+	}
+)
+const EditAttributeDropdownText = wrapEditAttribute(
+	class EditAttributeDropdownText extends EditAttributeBase {
+		constructor(props) {
+			super(props)
+
+			this.handleChangeDropdown = this.handleChangeDropdown.bind(this)
+			this.handleChangeText = this.handleChangeText.bind(this)
+			this.handleBlurText = this.handleBlurText.bind(this)
+			this.handleEscape = this.handleEscape.bind(this)
+		}
+		handleChangeDropdown(event) {
+			// because event.target.value is always a string, use the original value instead
+			let option = _.find(this.getOptions(), (o) => {
+				return o.value + '' === event.target.value + ''
+			})
+
+			let value = option ? option.value : event.target.value
+
+			this.handleUpdate(this.props.optionsAreNumbers ? parseInt(value, 10) : value)
+		}
+		handleChangeText(event) {
+			this.handleEdit(event.target.value)
+		}
+		handleBlurText(event) {
+			this.handleUpdate(event.target.value)
+		}
+		handleEscape(event) {
+			let e = event as KeyboardEvent
+			if (e.key === 'Escape') {
+				this.handleDiscard()
+			}
+		}
+		getOptions(addOptionForCurrentValue?: boolean) {
+			let options: Array<{ value: any; name: string; i?: number }> = []
+
+			if (Array.isArray(this.props.options)) {
+				// is it an enum?
+				for (let key in this.props.options) {
+					let val = this.props.options[key]
+					if (typeof val === 'object') {
+						options.push({
+							name: val.name,
+							value: val.value,
+						})
+					} else {
+						options.push({
+							name: val,
+							value: val,
+						})
+					}
+				}
+			} else if (typeof this.props.options === 'object') {
+				// Is options an enum?
+				let keys = Object.keys(this.props.options)
+				let first = this.props.options[keys[0]]
+				if (this.props.options[first] + '' === keys[0] + '') {
+					// is an enum, only pick
+					for (let key in this.props.options) {
+						if (!_.isNaN(parseInt(key, 10))) {
+							// key is a number (the key)
+							let enumValue = this.props.options[key]
+							let enumKey = this.props.options[enumValue]
+							options.push({
+								name: enumValue,
+								value: enumKey,
+							})
+						}
+					}
+				} else {
+					for (let key in this.props.options) {
+						let val = this.props.options[key]
+						if (Array.isArray(val)) {
+							options.push({
+								name: key,
+								value: val,
+							})
+						} else {
+							options.push({
+								name: key + ': ' + val,
+								value: val,
+							})
+						}
+					}
+				}
+			}
+
+			if (addOptionForCurrentValue) {
+				let currentValue = this.getAttribute()
+				let currentOption = _.find(options, (o) => {
+					if (Array.isArray(o.value)) {
+						return _.contains(o.value, currentValue)
+					}
+					return o.value === currentValue
+				})
+				if (!currentOption) {
+					// if currentOption not found, then add it to the list:
+					options.push({
+						name: 'Value: ' + currentValue,
+						value: currentValue,
+					})
+				}
+			}
+
+			for (let i = 0; i < options.length; i++) {
+				options[i].i = i
+			}
+
+			return options
+		}
+		render() {
+			return (
+				<div className="input-dropdowntext">
+					<input
+						type="text"
+						className={
+							'form-control' +
+							' ' +
+							(this.state.valueError ? 'error ' : '') +
+							(this.props.className || '') +
+							' ' +
+							(this.state.editing ? this.props.modifiedClassName || '' : '')
+						}
+						placeholder={this.props.label}
+						value={this.getEditAttribute() || ''}
+						onChange={this.handleChangeText}
+						onBlur={this.handleBlurText}
+						onKeyUp={this.handleEscape}
+						disabled={this.props.disabled}
+					/>
+
+					<select
+						className={
+							'form-control' +
+							' ' +
+							(this.props.className || '') +
+							' ' +
+							(this.state.editing ? this.props.modifiedClassName || '' : '')
+						}
+						value={this.getAttributeText()}
+						onChange={this.handleChangeDropdown}
+						disabled={this.props.disabled}>
+						{this.getOptions(true).map((o, j) =>
+							Array.isArray(o.value) ? (
+								<optgroup key={j} label={o.name}>
+									{o.value.map((v, i) => (
+										<option key={i} value={v + ''}>
+											{v}
+										</option>
+									))}
+								</optgroup>
+							) : (
+								<option key={o.i} value={o.value + ''}>
+									{o.name}
+								</option>
+							)
+						)}
+					</select>
+				</div>
 			)
 		}
 	}

--- a/meteor/client/styles/editAttribute.scss
+++ b/meteor/client/styles/editAttribute.scss
@@ -9,3 +9,16 @@
 .warn:focus {
 	color: #ffffff;
 }
+
+.input-dropdowntext {
+	display: inline-block;
+
+	input.input {
+		margin-right: 0;
+	}
+	select.input {
+		margin-left: 0;
+		width: 1em;
+		appearance: menulist;
+	}
+}

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -1099,6 +1099,7 @@ const StudioRoutings = withTranslation()(
 												obj={this.props.studio}
 												type="dropdowntext"
 												options={Object.keys(this.props.studio.mappings)}
+												label={t('None')}
 												collection={Studios}
 												className="input text-input input-l"></EditAttribute>
 										</label>

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -13,6 +13,7 @@ import {
 	StudioRouteBehavior,
 	RouteMapping,
 	StudioRouteSetExclusivityGroup,
+	getActiveRoutes,
 } from '../../../lib/collections/Studios'
 import { EditAttribute, EditAttributeBase } from '../../lib/EditAttribute'
 import { doModalDialog } from '../../lib/ModalDialog'
@@ -204,9 +205,8 @@ const StudioDevices = withTranslation()(
 
 interface IDeviceMappingSettingsProps {
 	studio: Studio
-	layerId: string
 	mapping: BlueprintMapping
-	prefix?: string
+	attribute: string
 	showOptional?: boolean
 }
 
@@ -227,18 +227,17 @@ const DeviceMappingSettings = withTranslation()(
 			)
 		}
 
-		renderCasparCGMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderCasparCGMappingSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('CasparCG Channel')}
-							{showOptional && this.renderOptionalInput(prefix + '.channel', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.channel', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.channel'}
+								attribute={attribute + '.channel'}
 								obj={this.props.studio}
 								type="int"
 								collection={Studios}
@@ -249,10 +248,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('CasparCG Layer')}
-							{showOptional && this.renderOptionalInput(prefix + '.layer', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.layer', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.layer'}
+								attribute={attribute + '.layer'}
 								obj={this.props.studio}
 								type="int"
 								collection={Studios}
@@ -263,10 +262,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Preview when not on air')}
-							{showOptional && this.renderOptionalInput(prefix + '.previewWhenNotOnAir', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.previewWhenNotOnAir', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.previewWhenNotOnAir'}
+								attribute={attribute + '.previewWhenNotOnAir'}
 								obj={this.props.studio}
 								type="checkbox"
 								collection={Studios}
@@ -278,18 +277,17 @@ const DeviceMappingSettings = withTranslation()(
 			)
 		}
 
-		renderAtemMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderAtemMappingSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Mapping type')}
-							{showOptional && this.renderOptionalInput(prefix + '.mappingType', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.mappingType', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.mappingType'}
+								attribute={attribute + '.mappingType'}
 								obj={this.props.studio}
 								type="dropdown"
 								options={TSR.MappingAtemType}
@@ -301,10 +299,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Index')}
-							{showOptional && this.renderOptionalInput(prefix + '.index', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.index', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.index'}
+								attribute={attribute + '.index'}
 								obj={this.props.studio}
 								type="int"
 								collection={Studios}
@@ -314,18 +312,17 @@ const DeviceMappingSettings = withTranslation()(
 				</React.Fragment>
 			)
 		}
-		renderLawoMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderLawoMappingSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Mapping type')}
-							{showOptional && this.renderOptionalInput(prefix + '.mappingType', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.mappingType', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.mappingType'}
+								attribute={attribute + '.mappingType'}
 								obj={this.props.studio}
 								type="dropdown"
 								options={TSR.MappingLawoType}
@@ -337,10 +334,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Identifier')}
-							{showOptional && this.renderOptionalInput(prefix + '.identifier', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.identifier', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.identifier'}
+								attribute={attribute + '.identifier'}
 								obj={this.props.studio}
 								type="text"
 								collection={Studios}
@@ -350,10 +347,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Priority')}
-							{showOptional && this.renderOptionalInput(prefix + '.priority', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.priority', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.priority'}
+								attribute={attribute + '.priority'}
 								obj={this.props.studio}
 								type="int"
 								collection={Studios}
@@ -363,18 +360,17 @@ const DeviceMappingSettings = withTranslation()(
 				</React.Fragment>
 			)
 		}
-		renderPanasonicPTZSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderPanasonicPTZSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Mapping type')}
-							{showOptional && this.renderOptionalInput(prefix + '.mappingType', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.mappingType', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.mappingType'}
+								attribute={attribute + '.mappingType'}
 								obj={this.props.studio}
 								type="dropdown"
 								options={TSR.MappingPanasonicPtzType}
@@ -386,23 +382,22 @@ const DeviceMappingSettings = withTranslation()(
 				</React.Fragment>
 			)
 		}
-		renderTCPSendSettings(layerId: string, prefix?: string, _showOptional?: boolean) {
+		renderTCPSendSettings(attribute: string, _showOptional?: boolean) {
 			const { t } = this.props
 			return <React.Fragment></React.Fragment>
 		}
 
-		renderHyperdeckMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderHyperdeckMappingSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Mapping type')}
-							{showOptional && this.renderOptionalInput(prefix + '.mappingType', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.mappingType', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.mappingType'}
+								attribute={attribute + '.mappingType'}
 								obj={this.props.studio}
 								type="dropdown"
 								options={TSR.MappingHyperdeckType}
@@ -414,12 +409,11 @@ const DeviceMappingSettings = withTranslation()(
 				</React.Fragment>
 			)
 		}
-		renderPharosMappingSettings(layerId: string, prefix?: string, _showOptional?: boolean) {
+		renderPharosMappingSettings(attribute: string, _showOptional?: boolean) {
 			return <React.Fragment></React.Fragment>
 		}
-		renderSisyfosMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderSisyfosMappingSettings(prefix: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
@@ -438,19 +432,18 @@ const DeviceMappingSettings = withTranslation()(
 				</React.Fragment>
 			)
 		}
-		renderQuantelMappingSettings(layerId: string, prefix?: string, showOptional?: boolean) {
+		renderQuantelMappingSettings(attribute: string, showOptional?: boolean) {
 			const { t } = this.props
-			prefix = prefix || 'mappings.' + layerId
 
 			return (
 				<React.Fragment>
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Quantel Port ID')}
-							{showOptional && this.renderOptionalInput(prefix + '.portId', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.portId', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.portId'}
+								attribute={attribute + '.portId'}
 								obj={this.props.studio}
 								type="text"
 								collection={Studios}
@@ -461,10 +454,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Quantel Channel ID')}
-							{showOptional && this.renderOptionalInput(prefix + '.channelId', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.channelId', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.channelId'}
+								attribute={attribute + '.channelId'}
 								obj={this.props.studio}
 								type="int"
 								collection={Studios}
@@ -475,10 +468,10 @@ const DeviceMappingSettings = withTranslation()(
 					<div className="mod mvs mhs">
 						<label className="field">
 							{t('Mode')}
-							{showOptional && this.renderOptionalInput(prefix + '.mode', this.props.studio, Studios)}
+							{showOptional && this.renderOptionalInput(attribute + '.mode', this.props.studio, Studios)}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={prefix + '.mode'}
+								attribute={attribute + '.mode'}
 								obj={this.props.studio}
 								type="dropdown"
 								options={TSR.QuantelControlMode}
@@ -491,26 +484,26 @@ const DeviceMappingSettings = withTranslation()(
 			)
 		}
 		render() {
-			const { layerId, mapping, prefix, showOptional } = this.props
+			const { mapping, attribute, showOptional } = this.props
 
 			return mappingIsCasparCG(mapping)
-				? this.renderCasparCGMappingSettings(layerId, prefix, showOptional)
+				? this.renderCasparCGMappingSettings(attribute, showOptional)
 				: mappingIsAtem(mapping)
-				? this.renderAtemMappingSettings(layerId, prefix, showOptional)
+				? this.renderAtemMappingSettings(attribute, showOptional)
 				: mappingIsLawo(mapping)
-				? this.renderLawoMappingSettings(layerId, prefix, showOptional)
+				? this.renderLawoMappingSettings(attribute, showOptional)
 				: mappingIsPanasonicPtz(mapping)
-				? this.renderPanasonicPTZSettings(layerId, prefix, showOptional)
+				? this.renderPanasonicPTZSettings(attribute, showOptional)
 				: mappingIsTCPSend(mapping)
-				? this.renderTCPSendSettings(layerId, prefix, showOptional)
+				? this.renderTCPSendSettings(attribute, showOptional)
 				: mappingIsHyperdeck(mapping)
-				? this.renderHyperdeckMappingSettings(layerId, prefix, showOptional)
+				? this.renderHyperdeckMappingSettings(attribute, showOptional)
 				: mappingIsPharos(mapping)
-				? this.renderPharosMappingSettings(layerId, prefix, showOptional)
+				? this.renderPharosMappingSettings(attribute, showOptional)
 				: mappingIsSisyfos(mapping)
-				? this.renderSisyfosMappingSettings(layerId, prefix, showOptional)
+				? this.renderSisyfosMappingSettings(attribute, showOptional)
 				: mappingIsQuantel(mapping)
-				? this.renderQuantelMappingSettings(layerId, prefix, showOptional)
+				? this.renderQuantelMappingSettings(attribute, showOptional)
 				: null
 		}
 	}
@@ -622,20 +615,8 @@ const StudioMappings = withTranslation()(
 
 		renderMappings() {
 			const { t } = this.props
-			const activeRouteSets = Object.entries(this.props.studio.routeSets).filter(([_id, routeSet]) => routeSet.active)
-			const layerOverrides: {
-				[id: string]: string[]
-			} = {}
-			for (let [routeSetId, routeSet] of activeRouteSets) {
-				for (let routeMap of routeSet.routes) {
-					if (layerOverrides[routeMap.mappedLayer] === undefined) {
-						layerOverrides[routeMap.mappedLayer] = []
-					}
-					if (!layerOverrides[routeMap.mappedLayer].includes(routeSetId)) {
-						layerOverrides[routeMap.mappedLayer].push(routeSetId)
-					}
-				}
-			}
+
+			const activeRoutes = getActiveRoutes(this.props.studio)
 
 			return _.map(this.props.studio.mappings, (mapping: MappingExt, layerId: string) => {
 				// If an internal mapping, then hide it
@@ -649,14 +630,14 @@ const StudioMappings = withTranslation()(
 							})}>
 							<th className="settings-studio-device__name c3 notifications-s notifications-text">
 								{layerId}
-								{layerOverrides[layerId] !== undefined ? (
+								{activeRoutes.existing[layerId] !== undefined ? (
 									<Tooltip
 										overlay={t('This layer is now rerouted by an active Route Set: {{routeSets}}', {
-											routeSets: layerOverrides[layerId].join(', '),
-											count: layerOverrides[layerId].length,
+											routeSets: activeRoutes.existing[layerId].join(', '),
+											count: activeRoutes.existing[layerId].length,
 										})}
 										placement="right">
-										<span className="notification">{layerOverrides[layerId].length}</span>
+										<span className="notification">{activeRoutes.existing[layerId].length}</span>
 									</Tooltip>
 								) : null}
 							</th>
@@ -806,7 +787,11 @@ const StudioMappings = withTranslation()(
 													className="input text-input input-l"></EditAttribute>
 											</label>
 										</div>
-										<DeviceMappingSettings layerId={layerId} mapping={mapping} studio={this.props.studio} />
+										<DeviceMappingSettings
+											mapping={mapping}
+											studio={this.props.studio}
+											attribute={'mappings.' + layerId}
+										/>
 									</div>
 									<div className="mod alright">
 										<button className={ClassNames('btn btn-primary')} onClick={(e) => this.finishEditItem(layerId)}>
@@ -1091,7 +1076,12 @@ const StudioRoutings = withTranslation()(
 						<p className="text-s dimmed mhs">{t('There are no routes set up yet')}</p>
 					) : null}
 					{routeSet.routes.map((route, index) => {
-						const sourceMapping = this.props.studio.mappings[route.mappedLayer]
+						const deviceTypeFromMappedLayer: TSR.DeviceType | undefined = route.mappedLayer
+							? this.props.studio.mappings[route.mappedLayer]?.device
+							: undefined
+						const routeDeviceType: TSR.DeviceType | undefined = route.mappedLayer
+							? deviceTypeFromMappedLayer
+							: route.deviceType
 						return (
 							<div className="route-sets-editor mod pan mas" key={index}>
 								<button
@@ -1102,12 +1092,12 @@ const StudioRoutings = withTranslation()(
 								<div>
 									<div className="mod mvs mhs">
 										<label className="field">
-											{t('Source Layer ID')}
+											{t('Original Layer')}
 											<EditAttribute
 												modifiedClassName="bghl"
 												attribute={`routeSets.${routeSetId}.routes.${index}.mappedLayer`}
 												obj={this.props.studio}
-												type="dropdown"
+												type="dropdowntext"
 												options={Object.keys(this.props.studio.mappings)}
 												collection={Studios}
 												className="input text-input input-l"></EditAttribute>
@@ -1115,7 +1105,7 @@ const StudioRoutings = withTranslation()(
 									</div>
 									<div className="mod mvs mhs">
 										<label className="field">
-											{t('New Layer ID')}
+											{t('New Layer')}
 											<EditAttribute
 												modifiedClassName="bghl"
 												attribute={`routeSets.${routeSetId}.routes.${index}.outputMappedLayer`}
@@ -1127,13 +1117,25 @@ const StudioRoutings = withTranslation()(
 									</div>
 									<div className="mod mvs mhs">
 										{t('Device Type')}
-										{sourceMapping ? (
-											<span className="mls">{TSR.DeviceType[sourceMapping.device]}</span>
+										{route.mappedLayer ? (
+											deviceTypeFromMappedLayer ? (
+												<span className="mls">{TSR.DeviceType[deviceTypeFromMappedLayer]}</span>
+											) : (
+												<span className="mls dimmed">{t('Source Layer not found')}</span>
+											)
 										) : (
-											<span className="mls dimmed">{t('Source Layer not found')}</span>
+											<EditAttribute
+												modifiedClassName="bghl"
+												attribute={`routeSets.${routeSetId}.routes.${index}.deviceType`}
+												obj={this.props.studio}
+												type="dropdown"
+												options={TSR.DeviceType}
+												optionsAreNumbers={true}
+												collection={Studios}
+												className="input text-input input-l"></EditAttribute>
 										)}
 									</div>
-									{sourceMapping && route.remapping !== undefined && (
+									{routeDeviceType && route.remapping !== undefined && (
 										<>
 											<div className="mod mvs mhs">
 												<label className="field">
@@ -1158,15 +1160,14 @@ const StudioRoutings = withTranslation()(
 												</label>
 											</div>
 											<DeviceMappingSettings
-												layerId={route.mappedLayer}
 												mapping={
 													{
-														device: sourceMapping.device,
+														device: routeDeviceType,
 														...route.remapping,
 													} as BlueprintMapping
 												}
 												studio={this.props.studio}
-												prefix={`routeSets.${routeSetId}.routes.${index}.remapping`}
+												attribute={`routeSets.${routeSetId}.routes.${index}.remapping`}
 												showOptional={true}
 											/>
 										</>

--- a/meteor/lib/collections/Studios.ts
+++ b/meteor/lib/collections/Studios.ts
@@ -1,7 +1,13 @@
 import { TransformedCollection } from '../typings/meteor'
 import { applyClassToDocument, registerCollection, ProtectedString, omit } from '../lib'
 import * as _ from 'underscore'
-import { IBlueprintConfig, BlueprintMappings, BlueprintMapping, TSR } from 'tv-automation-sofie-blueprints-integration'
+import {
+	IBlueprintConfig,
+	BlueprintMappings,
+	BlueprintMapping,
+	TSR,
+	LookaheadMode,
+} from 'tv-automation-sofie-blueprints-integration'
 import { Meteor } from 'meteor/meteor'
 import { ObserveChangesForHash, createMongoCollection } from './lib'
 import { BlueprintId } from './Blueprints'
@@ -106,18 +112,30 @@ export enum StudioRouteBehavior {
 	ACTIVATE_ONLY = 2,
 }
 export interface RouteMapping extends ResultingMappingRoute {
-	mappedLayer: string
+	/** Which original layer to route. If false, a "new" layer will be inserted during routing */
+	mappedLayer: string | undefined
 }
 export interface ResultingMappingRoutes {
-	[mappedLayer: string]: ResultingMappingRoute[]
+	/** Routes that route existing layers */
+	existing: {
+		[mappedLayer: string]: ResultingMappingRoute[]
+	}
+	/** Routes that create new layers, from nothing */
+	inserted: ResultingMappingRoute[]
 }
 export interface ResultingMappingRoute {
 	outputMappedLayer: string
+	deviceType?: TSR.DeviceType
 	remapping?: Partial<BlueprintMapping>
 }
 
 export function getActiveRoutes(studio: Studio): ResultingMappingRoutes {
-	const routes: ResultingMappingRoutes = {}
+	const routes: ResultingMappingRoutes = {
+		existing: {},
+		inserted: [],
+	}
+
+	let i = 0
 
 	const exclusivityGroups: { [groupId: string]: true } = {}
 	_.each(studio.routeSets, (routeSet) => {
@@ -132,11 +150,17 @@ export function getActiveRoutes(studio: Studio): ResultingMappingRoutes {
 			}
 			if (useRoute) {
 				_.each(routeSet.routes, (routeMapping) => {
-					if (routeMapping.mappedLayer && routeMapping.outputMappedLayer) {
-						if (!routes[routeMapping.mappedLayer]) {
-							routes[routeMapping.mappedLayer] = []
+					if (routeMapping.outputMappedLayer) {
+						if (routeMapping.mappedLayer) {
+							// Route an existing layer
+							if (!routes.existing[routeMapping.mappedLayer]) {
+								routes.existing[routeMapping.mappedLayer] = []
+							}
+							routes.existing[routeMapping.mappedLayer].push(omit(routeMapping, 'mappedLayer'))
+						} else {
+							// Insert a new routed layer
+							routes.inserted.push(omit(routeMapping, 'mappedLayer'))
 						}
-						routes[routeMapping.mappedLayer].push(omit(routeMapping, 'mappedLayer'))
 					}
 				})
 			}
@@ -147,21 +171,35 @@ export function getActiveRoutes(studio: Studio): ResultingMappingRoutes {
 }
 export function getRoutedMappings(inputMappings: MappingsExt, mappingRoutes: ResultingMappingRoutes): MappingsExt {
 	const outputMappings: MappingsExt = {}
-	_.each(inputMappings, (inputMapping, inputLayer) => {
-		const routes = mappingRoutes[inputLayer]
+	for (let inputLayer of Object.keys(inputMappings)) {
+		const inputMapping = inputMappings[inputLayer]
+
+		const routes = mappingRoutes.existing[inputLayer]
 		if (routes) {
-			_.each(routes, (route) => {
+			for (let route of routes) {
 				const routedMapping: MappingExt = {
 					...inputMapping,
 					...(route.remapping || {}),
 				}
 				outputMappings[route.outputMappedLayer] = routedMapping
-			})
+			}
 		} else {
 			// If no route is found at all, pass it through (backwards compatibility)
 			outputMappings[inputLayer] = inputMapping
 		}
-	})
+	}
+	// also insert new routed layers:
+	for (let route of mappingRoutes.inserted) {
+		if (route.remapping && route.deviceType && route.remapping.deviceId) {
+			const routedMapping: MappingExt = {
+				lookahead: route.remapping.lookahead || LookaheadMode.NONE,
+				device: route.deviceType,
+				deviceId: route.remapping.deviceId,
+				...route.remapping,
+			}
+			outputMappings[route.outputMappedLayer] = routedMapping
+		}
+	}
 	return outputMappings
 }
 

--- a/meteor/lib/collections/Timeline.ts
+++ b/meteor/lib/collections/Timeline.ts
@@ -97,11 +97,12 @@ export function getRoutedTimeline(
 ): TimelineObjGeneric[] {
 	const outputTimelineObjs: TimelineObjGeneric[] = []
 
-	_.each(inputTimelineObjs, (obj) => {
+	for (let obj of inputTimelineObjs) {
 		const inputLayer = obj.layer + ''
-		const routes = mappingRoutes[inputLayer]
+		const routes = mappingRoutes.existing[inputLayer]
 		if (routes) {
-			_.each(routes, (route, i) => {
+			for (let i = 0; i < routes.length; i++) {
+				const route = routes[i]
 				const routedObj: TimelineObjGeneric = {
 					...obj,
 					layer: route.outputMappedLayer,
@@ -111,12 +112,12 @@ export function getRoutedTimeline(
 					routedObj.id = `_${i}_${routedObj.id}`
 				}
 				outputTimelineObjs.push(routedObj)
-			})
+			}
 		} else {
 			// If no route is found at all, pass it through (backwards compatibility)
 			outputTimelineObjs.push(obj)
 		}
-	})
+	}
 	return outputTimelineObjs
 }
 export interface TimelineComplete {


### PR DESCRIPTION
This PR adds some additional functionality to the routeSets.

Mainly, it allows "no layer" to be routed into "some layer". This means that a user should be able to define ALL layer mappings in routeSets, should that be desireable.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
