### PR TITLE
fix: clear the blueprint config caches when the blueprint is updated

### DIFF
--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -10,9 +10,19 @@ import {
 } from 'tv-automation-sofie-blueprints-integration'
 import { Studios, Studio, StudioId } from '../../../lib/collections/Studios'
 import { Meteor } from 'meteor/meteor'
-import { getShowStyleCompound, ShowStyleVariantId, ShowStyleCompound } from '../../../lib/collections/ShowStyleVariants'
+import {
+	getShowStyleCompound,
+	ShowStyleVariantId,
+	ShowStyleCompound,
+	ShowStyleVariant,
+	createShowStyleCompound,
+	ShowStyleVariants,
+} from '../../../lib/collections/ShowStyleVariants'
 import { protectString, objectPathGet, objectPathSet } from '../../../lib/lib'
 import { logger } from '../../../lib/logging'
+import { loadStudioBlueprint, loadShowStyleBlueprint } from './cache'
+import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from '../../../lib/collections/ShowStyleBases'
+import { BlueprintId, Blueprints } from '../../../lib/collections/Blueprints'
 
 /**
  * This whole ConfigRef logic will need revisiting for a multi-studio context, to ensure that there are strict boundaries across who can give to access to what.
@@ -139,3 +149,179 @@ export function applyToConfig(
 		objectPathSet(res, val.id, newVal)
 	}
 }
+
+const studioBlueprintConfigCache = new Map<BlueprintId, Map<StudioId, Cache>>()
+const showStyleBlueprintConfigCache = new Map<BlueprintId, Map<ShowStyleBaseId, Map<ShowStyleVariantId, Cache>>>()
+interface Cache {
+	config: unknown
+}
+
+export function resetStudioBlueprintConfig(studio: Studio): void {
+	for (const map of studioBlueprintConfigCache.values()) {
+		map.delete(studio._id)
+	}
+	getStudioBlueprintConfig(studio)
+}
+
+export function getStudioBlueprintConfig(studio: Studio): unknown {
+	let blueprintConfigMap = studio.blueprintId ? studioBlueprintConfigCache.get(studio.blueprintId) : undefined
+	if (!blueprintConfigMap && studio.blueprintId) {
+		blueprintConfigMap = new Map()
+		studioBlueprintConfigCache.set(studio.blueprintId, blueprintConfigMap)
+	}
+
+	const cachedConfig = blueprintConfigMap?.get(studio._id)
+	if (cachedConfig) {
+		return cachedConfig.config
+	}
+
+	logger.debug('Building Studio config')
+	const studioBlueprint = loadStudioBlueprint(studio)
+	if (studioBlueprint) {
+		const diffs = findMissingConfigs(studioBlueprint.blueprint.studioConfigManifest, studio.blueprintConfig)
+		if (diffs && diffs.length) {
+			logger.warn(`Studio "${studio._id}" missing required config: ${diffs.join(', ')}`)
+		}
+	} else {
+		logger.warn(`Studio blueprint "${studio.blueprintId}" not found!`)
+	}
+	const compiledConfig = preprocessStudioConfig(studio, studioBlueprint?.blueprint)
+	blueprintConfigMap?.set(studio._id, {
+		config: compiledConfig,
+	})
+	return compiledConfig
+}
+
+export function resetShowStyleBlueprintConfig(showStyleBase: ShowStyleBase, showStyleVariant: ShowStyleVariant): void {
+	for (const map of showStyleBlueprintConfigCache.values()) {
+		map.get(showStyleBase._id)?.delete(showStyleVariant._id)
+	}
+	getShowStyleBlueprintConfig(showStyleBase, showStyleVariant)
+}
+export function getShowStyleBlueprintConfig(showStyleBase: ShowStyleBase, showStyleVariant: ShowStyleVariant): unknown {
+	let blueprintConfigMap = showStyleBase.blueprintId
+		? showStyleBlueprintConfigCache.get(showStyleBase.blueprintId)
+		: new Map()
+	if (!blueprintConfigMap) {
+		blueprintConfigMap = new Map()
+		showStyleBlueprintConfigCache.set(showStyleBase.blueprintId, blueprintConfigMap)
+	}
+
+	let showStyleBaseMap = blueprintConfigMap.get(showStyleBase._id)
+	if (!showStyleBaseMap) {
+		showStyleBaseMap = new Map()
+		blueprintConfigMap.set(showStyleBase._id, showStyleBaseMap)
+	}
+
+	const cachedConfig = showStyleBaseMap.get(showStyleVariant._id)
+	if (cachedConfig) {
+		return cachedConfig.config
+	}
+
+	logger.debug('Building ShowStyle config')
+
+	const showStyleCompound = createShowStyleCompound(showStyleBase, showStyleVariant)
+	if (!showStyleCompound) throw new Meteor.Error(404, `no showStyleCompound for "${showStyleVariant._id}"`)
+
+	const showStyleBlueprint = loadShowStyleBlueprint(showStyleCompound)
+	if (showStyleBlueprint) {
+		const diffs = findMissingConfigs(
+			showStyleBlueprint.blueprint.showStyleConfigManifest,
+			showStyleCompound.blueprintConfig
+		)
+		if (diffs && diffs.length) {
+			logger.warn(
+				`ShowStyle "${showStyleCompound._id}-${
+					showStyleCompound.showStyleVariantId
+				}" missing required config: ${diffs.join(', ')}`
+			)
+		}
+	} else {
+		logger.warn(`ShowStyle blueprint "${showStyleCompound.blueprintId}" not found!`)
+	}
+
+	const compiledConfig = preprocessShowStyleConfig(showStyleCompound, showStyleBlueprint?.blueprint)
+	showStyleBaseMap.set(showStyleVariant._id, { config: compiledConfig })
+	return compiledConfig
+}
+
+Meteor.startup(() => {
+	if (Meteor.isServer) {
+		Studios.find(
+			{},
+			{
+				fields: {
+					_rundownVersionHash: 1,
+					blueprintId: 1,
+				},
+			}
+		).observeChanges({
+			changed: (id: StudioId) => {
+				for (const map of studioBlueprintConfigCache.values()) {
+					map.delete(id)
+				}
+			},
+			removed: (id: StudioId) => {
+				for (const map of studioBlueprintConfigCache.values()) {
+					map.delete(id)
+				}
+			},
+		})
+		ShowStyleBases.find(
+			{},
+			{
+				fields: {
+					_rundownVersionHash: 1,
+					blueprintId: 1,
+				},
+			}
+		).observeChanges({
+			changed: (id: ShowStyleBaseId) => {
+				for (const map of showStyleBlueprintConfigCache.values()) {
+					map.delete(id)
+				}
+			},
+			removed: (id: ShowStyleBaseId) => {
+				for (const map of showStyleBlueprintConfigCache.values()) {
+					map.delete(id)
+				}
+			},
+		})
+		ShowStyleVariants.find(
+			{},
+			{
+				fields: {
+					_rundownVersionHash: 1,
+					showStyleBaseId: 1,
+					_id: 1,
+				},
+			}
+		).observe({
+			changed: (doc: ShowStyleVariant) => {
+				for (const map of showStyleBlueprintConfigCache.values()) {
+					map.get(doc.showStyleBaseId)?.delete(doc._id)
+				}
+			},
+			removed: (doc: ShowStyleVariant) => {
+				for (const map of showStyleBlueprintConfigCache.values()) {
+					map.get(doc.showStyleBaseId)?.delete(doc._id)
+				}
+			},
+		})
+		Blueprints.find(
+			{},
+			{
+				fields: {
+					modified: 1,
+				},
+			}
+		).observeChanges({
+			changed: (id: BlueprintId) => {
+				studioBlueprintConfigCache.delete(id)
+			},
+			removed: (id: BlueprintId) => {
+				studioBlueprintConfigCache.delete(id)
+			},
+		})
+	}
+})

--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -156,6 +156,11 @@ interface Cache {
 	config: unknown
 }
 
+export function forceClearAllBlueprintConfigCaches() {
+	studioBlueprintConfigCache.clear()
+	showStyleBlueprintConfigCache.clear()
+}
+
 export function resetStudioBlueprintConfig(studio: Studio): void {
 	for (const map of studioBlueprintConfigCache.values()) {
 		map.delete(studio._id)

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -10,8 +10,6 @@ import {
 	unprotectObjectArray,
 	protectString,
 	getCurrentTime,
-	objectPathGet,
-	objectPathSet,
 	waitForPromise,
 } from '../../../../lib/lib'
 import { DBPart, PartId } from '../../../../lib/collections/Parts'
@@ -41,27 +39,25 @@ import {
 	IBlueprintExternalMessageQueueObj,
 	ExtendedIngestRundown,
 } from 'tv-automation-sofie-blueprints-integration'
-import { Studio, StudioId, Studios } from '../../../../lib/collections/Studios'
-import { ConfigRef, preprocessStudioConfig, findMissingConfigs, preprocessShowStyleConfig } from '../config'
+import { Studio, StudioId } from '../../../../lib/collections/Studios'
+import {
+	ConfigRef,
+	getStudioBlueprintConfig,
+	resetStudioBlueprintConfig,
+	getShowStyleBlueprintConfig,
+	resetShowStyleBlueprintConfig,
+} from '../config'
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from '../../../../lib/collections/ShowStyleBases'
-import {
-	getShowStyleCompound,
-	ShowStyleVariantId,
-	ShowStyleVariants,
-	ShowStyleVariant,
-	createShowStyleCompound,
-} from '../../../../lib/collections/ShowStyleVariants'
+import { ShowStyleVariantId, ShowStyleVariants, ShowStyleVariant } from '../../../../lib/collections/ShowStyleVariants'
 import { AsRunLogEvent, AsRunLog } from '../../../../lib/collections/AsRunLog'
 import { NoteType, INoteBase } from '../../../../lib/api/notes'
 import { loadCachedRundownData, loadIngestDataCachePart } from '../../ingest/ingestCache'
 import { RundownPlaylistId } from '../../../../lib/collections/RundownPlaylists'
 import { PieceInstances, unprotectPieceInstance } from '../../../../lib/collections/PieceInstances'
 import { unprotectPartInstance, PartInstance } from '../../../../lib/collections/PartInstances'
-import { Blueprints } from '../../../../lib/collections/Blueprints'
 import { ExternalMessageQueue } from '../../../../lib/collections/ExternalMessageQueue'
 import { extendIngestRundownCore } from '../../ingest/lib'
-import { loadStudioBlueprint, loadShowStyleBlueprint } from '../cache'
 import { CacheForRundownPlaylist, ReadOnlyCacheForRundownPlaylist } from '../../../DatabaseCaches'
 
 /** Common */
@@ -154,12 +150,6 @@ export class NotesContext extends CommonContext implements INotesContext {
 	}
 }
 
-const studioBlueprintConfigCache: { [studioId: string]: Cache } = {}
-const showStyleBlueprintConfigCache: { [showStyleBaseId: string]: { [showStyleVariantId: string]: Cache } } = {}
-interface Cache {
-	config: unknown
-}
-
 /** Studio */
 
 export class StudioConfigContext implements IStudioConfigContext {
@@ -176,34 +166,10 @@ export class StudioConfigContext implements IStudioConfigContext {
 		return this.studio
 	}
 	getStudioConfig(): unknown {
-		const studioId = unprotectString(this.studio._id)
-		if (studioBlueprintConfigCache[studioId]) {
-			return studioBlueprintConfigCache[studioId].config
-		}
-
-		logger.debug('Building Studio config')
-		const studioBlueprint = loadStudioBlueprint(this.studio)
-		if (studioBlueprint) {
-			const diffs = findMissingConfigs(
-				studioBlueprint.blueprint.studioConfigManifest,
-				this.studio.blueprintConfig
-			)
-			if (diffs && diffs.length) {
-				logger.warn(`Studio "${this.studio._id}" missing required config: ${diffs.join(', ')}`)
-			}
-		} else {
-			logger.warn(`Studio blueprint "${this.studio.blueprintId}" not found!`)
-		}
-		const compiledConfig = preprocessStudioConfig(this.studio, studioBlueprint?.blueprint)
-		studioBlueprintConfigCache[studioId] = {
-			config: compiledConfig,
-		}
-		return compiledConfig
+		return getStudioBlueprintConfig(this.studio)
 	}
 	protected wipeCache() {
-		const studioId = unprotectString(this.studio._id)
-		delete studioBlueprintConfigCache[studioId]
-		this.getStudioConfig()
+		resetStudioBlueprintConfig(this.studio)
 	}
 	getStudioConfigRef(configKey: string): string {
 		return ConfigRef.getStudioConfigRef(this.studio._id, configKey)
@@ -254,47 +220,11 @@ export class ShowStyleContext extends StudioContext implements IShowStyleContext
 		}
 	}
 	getShowStyleConfig(): unknown {
-		const cacheId = `${this.showStyleBaseId}.${this.showStyleVariantId}`
-		const cachedConfig = objectPathGet(showStyleBlueprintConfigCache, cacheId)
-		if (cachedConfig) {
-			return cachedConfig.config
-		}
-
-		logger.debug('Building ShowStyle config')
-		const showStyleBase = this.getShowStyleBase()
-		const showStyleVariant = this.getShowStyleVariant()
-
-		const showStyleCompound = createShowStyleCompound(showStyleBase, showStyleVariant)
-		if (!showStyleCompound) throw new Meteor.Error(404, `no showStyleCompound for "${showStyleVariant._id}"`)
-
-		const showStyleBlueprint = loadShowStyleBlueprint(showStyleCompound)
-		if (showStyleBlueprint) {
-			const diffs = findMissingConfigs(
-				showStyleBlueprint.blueprint.showStyleConfigManifest,
-				showStyleCompound.blueprintConfig
-			)
-			if (diffs && diffs.length) {
-				logger.warn(
-					`ShowStyle "${showStyleCompound._id}-${
-						showStyleCompound.showStyleVariantId
-					}" missing required config: ${diffs.join(', ')}`
-				)
-			}
-		} else {
-			logger.warn(`ShowStyle blueprint "${showStyleCompound.blueprintId}" not found!`)
-		}
-
-		const compiledConfig = preprocessShowStyleConfig(showStyleCompound, showStyleBlueprint?.blueprint)
-		objectPathSet(showStyleBlueprintConfigCache, cacheId, {
-			config: compiledConfig,
-		})
-		return compiledConfig
+		return getShowStyleBlueprintConfig(this.getShowStyleBase(), this.getShowStyleVariant())
 	}
 	wipeCache() {
 		super.wipeCache()
-		const cacheId = `${this.showStyleBaseId}.${this.showStyleVariantId}`
-		objectPath.del(showStyleBlueprintConfigCache, cacheId)
-		this.getShowStyleConfig()
+		resetShowStyleBlueprintConfig(this.getShowStyleBase(), this.getShowStyleVariant())
 	}
 	getShowStyleConfigRef(configKey: string): string {
 		return ConfigRef.getShowStyleConfigRef(this.showStyleVariantId, configKey)
@@ -542,41 +472,3 @@ export class AsRunEventContext extends RundownContext implements IAsRunEventCont
 		return ids.join(',')
 	}
 }
-
-Meteor.startup(() => {
-	if (Meteor.isServer) {
-		Studios.find(
-			{},
-			{
-				fields: {
-					_rundownVersionHash: 1,
-				},
-			}
-		).observeChanges({
-			changed: (id: StudioId) => delete studioBlueprintConfigCache[unprotectString(id)],
-		})
-		ShowStyleBases.find(
-			{},
-			{
-				fields: {
-					_rundownVersionHash: 1,
-				},
-			}
-		).observeChanges({
-			changed: (id: ShowStyleBaseId) => delete showStyleBlueprintConfigCache[unprotectString(id)],
-		})
-		ShowStyleVariants.find(
-			{},
-			{
-				fields: {
-					_rundownVersionHash: 1,
-					showStyleBaseId: 1,
-					_id: 1,
-				},
-			}
-		).observe({
-			changed: (doc: ShowStyleVariant) =>
-				objectPath.del(showStyleBlueprintConfigCache, `${doc.showStyleBaseId}.${doc._id}`),
-		})
-	}
-})

--- a/meteor/server/mockData/rundownData.ts
+++ b/meteor/server/mockData/rundownData.ts
@@ -18,6 +18,7 @@ import { PartInstances } from '../../lib/collections/PartInstances'
 import { PieceInstances } from '../../lib/collections/PieceInstances'
 import { updateTimeline } from '../api/playout/timeline'
 import { getActiveRundownPlaylistsInStudio } from '../api/playout/studio'
+import { forceClearAllBlueprintConfigCaches } from '../api/blueprints/config'
 
 if (!Settings.enableUserAccounts) {
 	// These are temporary method to fill the rundown database with some sample data
@@ -99,10 +100,11 @@ if (!Settings.enableUserAccounts) {
 			})
 		},
 
-		debug_forceClearAllActivationCaches() {
-			logger.info('forceClearAllActivationCaches')
+		debug_forceClearAllCaches() {
+			logger.info('forceClearAllCaches')
 
 			forceClearAllActivationCaches()
+			forceClearAllBlueprintConfigCaches()
 		},
 
 		debug_clearAllResetInstances() {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

When a new blueprint is uploaded, the config cache is not cleared. This means that the blueprint can be given a stale cache that does not match the typings it expects.


* **What is the new behavior (if this is a feature change)?**

Whenever the blueprint is modified, the relevant caches are cleared too.
Additionally some other lifecycle bits are handled, such as clearing caches for removed documents, and handling some less likely property changes


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
