### PR TITLE
chore(circleci): add auth params for pulling images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: sofietv/tv-automation-meteor-base:1.11.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - restore_cache:
@@ -39,6 +42,9 @@ jobs:
   tests:
     docker:
       - image: sofietv/tv-automation-meteor-base:1.11.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - run:
@@ -48,6 +54,9 @@ jobs:
   lint:
     docker:
       - image: sofietv/tv-automation-meteor-base:1.11.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - run:
@@ -58,6 +67,9 @@ jobs:
   validate-prod-dependencies:
     docker:
       - image: sofietv/tv-automation-meteor-base:1.11.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - run:
@@ -67,6 +79,9 @@ jobs:
   validate-all-dependencies:
     docker:
       - image: sofietv/tv-automation-meteor-base:1.11.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - run:
@@ -77,6 +92,9 @@ jobs:
   publish-tag:
     docker:
       - image: circleci/buildpack-deps:buster
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - setup_remote_docker:
           version: 19.03.8
@@ -88,7 +106,7 @@ jobs:
       - run:
           name: Publish Docker Image to Docker Hub
           command: |
-            if [ -z "$DOCKERHUB_PASS" ]; then
+            if [ -z "$DOCKERHUB_IMAGE" ]; then
               echo "Skipping"
             else
               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
@@ -108,6 +126,9 @@ jobs:
   publish-branch:
     docker:
       - image: circleci/buildpack-deps:buster
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     steps:
       - setup_remote_docker:
           version: 19.03.8
@@ -119,7 +140,7 @@ jobs:
       - run:
           name: Publish Docker Image to Docker Hub
           command: |
-            if [ -z "$DOCKERHUB_PASS" ]; then
+            if [ -z "$DOCKERHUB_IMAGE" ]; then
               echo "Skipping"
             else
               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

CI config fix

* **What is the current behavior?** (You can also link to an open issue here)

> On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.
> 
> Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.
> 
> We are currently working on a partnership with Docker to minimize the impact of this change for our users and will share more details as we get them.

* **What is the new behavior (if this is a feature change)?**

Add the required authentication parameters using the existing variables used to publish images.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
