### PR TITLE
fix: restore sourceDuration display on all Pieces

### DIFF
--- a/meteor/CHANGELOG.md
+++ b/meteor/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.12.1](https://github.com/nrkno/tv-automation-server-core/compare/v1.12.0...v1.12.1) (2020-10-12)
+
+
+### Bug Fixes
+
+* restore sourceDuration display on all Pieces ([72d2897](https://github.com/nrkno/tv-automation-server-core/commit/72d289710fedb5a7e16958f9c1260e9502095f9f))
+* show end of content markers in segment minimap ([06c95fa](https://github.com/nrkno/tv-automation-server-core/commit/06c95fa792913e7ac9cfc0d82496fa17a6a44411))
+
 ## [1.12.0](https://github.com/nrkno/tv-automation-server-core/compare/v1.10.1...v1.12.0) (2020-09-28)
 
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -113,9 +113,8 @@ export class CustomLayerItemRenderer<
 		const vtContent = innerPiece.content as VTContent | undefined
 		const seek = vtContent && vtContent.seek ? vtContent.seek : 0
 		if (
-			innerPiece.lifespan !== PieceLifespan.WithinPart &&
 			vtContent &&
-			vtContent.sourceDuration &&
+			vtContent.sourceDuration !== undefined &&
 			(this.props.piece.renderedInPoint || 0) + (vtContent.sourceDuration - seek) < (this.props.partDuration || 0)
 		) {
 			return (

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -120,7 +120,11 @@ export class CustomLayerItemRenderer<
 			return (
 				<div
 					className="segment-timeline__piece__source-finished"
-					style={{ left: ((vtContent.sourceDuration - seek) * this.props.timeScale).toString() + 'px' }}></div>
+					style={{
+						left: this.props.relative
+							? (((vtContent.sourceDuration - seek) / (this.getItemDuration() || 1)) * 100).toString() + '%'
+							: ((vtContent.sourceDuration - seek) * this.props.timeScale).toString() + 'px',
+					}}></div>
 			)
 		}
 		return null

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "automation-core",
-	"version": "1.12.0",
+	"version": "1.12.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-core",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "engines": {
     "node": "12.16"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

SourceDuration markers (shown when a Piece is longer than it's source content) aren't shown.

* **What is the new behavior (if this is a feature change)?**

SourceDuration markers are now shown on all Pieces.

* **Other information**:

As a result of the refactoring, a simple "infinite piece" check was replaced with a requirement of the Piece's lifetime to be other than "WithinPart". As a result, most of the Piece source duration markers were gone.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
