### PR TITLE
feat: show the state of infinites in all segments depending on playback

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -77,7 +77,7 @@ interface IProps {
 	onContextMenu?: (contextMenuContext: IContextMenuContext) => void
 	onItemClick?: (piece: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
 	onItemDoubleClick?: (item: PieceUi, e: React.MouseEvent<HTMLDivElement>) => void
-	onHeaderNoteClick?: (level: NoteType) => void
+	onHeaderNoteClick?: (segmentId: SegmentId, level: NoteType) => void
 	segmentRef?: (el: SegmentTimelineClass, segmentId: SegmentId) => void
 	isLastSegment: boolean
 	lastValidPartIndex: number | undefined
@@ -826,7 +826,9 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							{criticalNotes > 0 && (
 								<div
 									className="segment-timeline__title__notes__note segment-timeline__title__notes__note--critical"
-									onClick={(e) => this.props.onHeaderNoteClick && this.props.onHeaderNoteClick(NoteType.ERROR)}>
+									onClick={(e) =>
+										this.props.onHeaderNoteClick && this.props.onHeaderNoteClick(this.props.segment._id, NoteType.ERROR)
+									}>
 									<CriticalIconSmall />
 									<div className="segment-timeline__title__notes__count">{criticalNotes}</div>
 								</div>
@@ -834,7 +836,10 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							{warningNotes > 0 && (
 								<div
 									className="segment-timeline__title__notes__note segment-timeline__title__notes__note--warning"
-									onClick={(e) => this.props.onHeaderNoteClick && this.props.onHeaderNoteClick(NoteType.WARNING)}>
+									onClick={(e) =>
+										this.props.onHeaderNoteClick &&
+										this.props.onHeaderNoteClick(this.props.segment._id, NoteType.WARNING)
+									}>
 									<WarningIconSmall />
 									<div className="segment-timeline__title__notes__count">{warningNotes}</div>
 								</div>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -139,7 +139,6 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			'piece.lifespan': {
 				$in: [PieceLifespan.OutOnRundownEnd, PieceLifespan.OutOnRundownChange],
 			},
-			'piece.virtual': true,
 			reset: {
 				$ne: true,
 			},

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -24,7 +24,7 @@ import { NoteType, SegmentNote } from '../../../lib/api/notes'
 import { getElementWidth } from '../../utils/dimensions'
 import { isMaintainingFocus, scrollToSegment, getHeaderHeight } from '../../lib/viewPort'
 import { PubSub } from '../../../lib/api/pubsub'
-import { unprotectString, equalSets, equivalentArrays } from '../../../lib/lib'
+import { unprotectString, equalSets, equivalentArrays, equalArrays } from '../../../lib/lib'
 import { RundownUtils } from '../../lib/rundown'
 import { Settings } from '../../../lib/Settings'
 import { RundownId } from '../../../lib/collections/Rundowns'
@@ -78,7 +78,7 @@ interface IProps {
 	onTimeScaleChange?: (timeScaleVal: number) => void
 	onContextMenu?: (contextMenuContext: IContextMenuContext) => void
 	onSegmentScroll?: () => void
-	onHeaderNoteClick?: (level: NoteType) => void
+	onHeaderNoteClick?: (segmentId: SegmentId, level: NoteType) => void
 	followLiveSegments: boolean
 	segmentRef?: (el: React.ComponentClass, sId: string) => void
 	isLastSegment: boolean
@@ -174,8 +174,11 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			props.onTimeScaleChange !== nextProps.onTimeScaleChange ||
 			props.segmentId !== nextProps.segmentId ||
 			props.segmentRef !== nextProps.segmentRef ||
-			props.timeScale !== nextProps.timeScale
+			props.timeScale !== nextProps.timeScale ||
+			!equalSets(props.segmentsIdsBefore, nextProps.segmentsIdsBefore) ||
+			!equalArrays(props.orderedAllPartIds, nextProps.orderedAllPartIds)
 		) {
+			console.log('Forcing render')
 			return true
 		}
 		// Check rundown changes that are important to the segment
@@ -743,6 +746,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 		}
 
 		render() {
+			console.log(`${this.props.segmentui?.name}`)
 			return (
 				(this.props.segmentui && (
 					<SegmentTimeline

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -1395,6 +1395,14 @@ export function assertNever(_never: never): void {
 	// Do nothing. This is a type guard
 }
 
+/**
+ * This is a fast, shallow compare of two Sets.
+ *
+ * **Note**: This is a shallow compare, so it will return false if the objects in the arrays are identical, but not the same.
+ *
+ * @param a
+ * @param b
+ */
 export function equalSets<T extends any>(a: Set<T>, b: Set<T>): boolean {
 	if (a === b) return true
 	if (a.size !== b.size) return false
@@ -1404,6 +1412,14 @@ export function equalSets<T extends any>(a: Set<T>, b: Set<T>): boolean {
 	return true
 }
 
+/**
+ * This is a fast, shallow compare of two arrays that are used as unsorted lists. The ordering of the elements is ignored.
+ *
+ * **Note**: This is a shallow compare, so it will return false if the objects in the arrays are identical, but not the same.
+ *
+ * @param a
+ * @param b
+ */
 export function equivalentArrays<T>(a: T[], b: T[]): boolean {
 	if (a === b) return true
 	if (a.length !== b.length) return false
@@ -1413,6 +1429,13 @@ export function equivalentArrays<T>(a: T[], b: T[]): boolean {
 	return true
 }
 
+/**
+ * This is a fast, shallow compare of two arrays of the same type.
+ *
+ * **Note**: This is a shallow compare, so it will return false if the objects in the arrays are identical, but not the same.
+ * @param a
+ * @param b
+ */
 export function equalArrays<T>(a: T[], b: T[]): boolean {
 	if (a === b) return true
 	if (a.length !== b.length) return false

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -1412,3 +1412,12 @@ export function equivalentArrays<T>(a: T[], b: T[]): boolean {
 	}
 	return true
 }
+
+export function equalArrays<T>(a: T[], b: T[]): boolean {
+	if (a === b) return true
+	if (a.length !== b.length) return false
+	for (let i = 0; i < a.length; i++) {
+		if (b[i] !== a[i]) return false
+	}
+	return true
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature

* **What is the current behavior?** (You can also link to an open issue here)

State of infinites across all segments is correctly shown only on page load and in current segment

* **What is the new behavior (if this is a feature change)?**

The change causes all Segments to update when infinites are cropped/inserted, but should not add additional re-renders beyond that.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
