### PR TITLE
Feat: dataSegmentGet peripheral device method

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -99,6 +99,12 @@ export interface NewPeripheralDeviceAPI {
 	dataRundownDelete(deviceId: PeripheralDeviceId, deviceToken: string, rundownExternalId: string): Promise<void>
 	dataRundownCreate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown): Promise<void>
 	dataRundownUpdate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown): Promise<void>
+	dataSegmentGet(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		rundownExternalId: string,
+		segmentExternalId: string
+	): Promise<IngestSegment>
 	dataSegmentDelete(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,
@@ -319,6 +325,7 @@ export enum PeripheralDeviceAPIMethods {
 	'dataRundownDelete' = 'peripheralDevice.rundown.rundownDelete',
 	'dataRundownCreate' = 'peripheralDevice.rundown.rundownCreate',
 	'dataRundownUpdate' = 'peripheralDevice.rundown.rundownUpdate',
+	'dataSegmentGet' = 'peripheralDevice.rundown.segmentGet',
 	'dataSegmentDelete' = 'peripheralDevice.rundown.segmentDelete',
 	'dataSegmentCreate' = 'peripheralDevice.rundown.segmentCreate',
 	'dataSegmentUpdate' = 'peripheralDevice.rundown.segmentUpdate',

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -813,6 +813,16 @@ class ServerPeripheralDeviceAPIClass extends MethodContextAPI implements NewPeri
 	dataRundownUpdate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown) {
 		return makePromise(() => RundownInput.dataRundownUpdate(this, deviceId, deviceToken, ingestRundown))
 	}
+	dataSegmentGet(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		rundownExternalId: string,
+		segmentExternalId: string
+	) {
+		return makePromise(() =>
+			RundownInput.dataSegmentGet(this, deviceId, deviceToken, rundownExternalId, segmentExternalId)
+		)
+	}
 	dataSegmentDelete(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the `dataSegmentGet` peripheral device method, which returns an ingest segment reference by external Id. It is based on the existing `dataRundownGet` method. This allows devices like the iNews gateway to fetch the cached ingest data from core for an individual segment to compare against before sending any updates.

* **Other information**:
Requires https://github.com/nrkno/tv-automation-server-core-integration/pull/35

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
