### PR TITLE
feat: improved rundown divider

### DIFF
--- a/meteor/client/lib/notifications/NotificationCenterPanel.tsx
+++ b/meteor/client/lib/notifications/NotificationCenterPanel.tsx
@@ -7,6 +7,7 @@ import { MeteorReactComponent } from '../MeteorReactComponent'
 import { NotificationCenter, Notification, NoticeLevel, NotificationAction } from './notifications'
 import { ContextMenuTrigger, ContextMenu, MenuItem } from '@jstarpl/react-contextmenu'
 import * as _ from 'underscore'
+import { RundownId } from '../../../lib/collections/Rundowns'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { CriticalIcon, WarningIcon, CollapseChevrons, InformationIcon } from '../notificationIcons'
 import update from 'immutability-helper'
@@ -152,7 +153,7 @@ interface IState {
 
 interface ITrackedProps {
 	notifications: Array<Notification>
-	highlightedSource: SegmentId | string | undefined
+	highlightedSource: RundownId | SegmentId | string | undefined
 	highlightedLevel: NoticeLevel
 }
 
@@ -161,15 +162,13 @@ interface ITrackedProps {
  * @class NotificationCenterPopUps
  * @extends React.Component<IProps>
  */
-export const NotificationCenterPopUps = translateWithTracker<IProps, IState, ITrackedProps>(
-	(props: IProps, state: IState) => {
-		return {
-			notifications: NotificationCenter.getNotifications(),
-			highlightedSource: NotificationCenter.getHighlightedSource(),
-			highlightedLevel: NotificationCenter.getHighlightedLevel(),
-		}
+export const NotificationCenterPopUps = translateWithTracker<IProps, IState, ITrackedProps>(() => {
+	return {
+		notifications: NotificationCenter.getNotifications(),
+		highlightedSource: NotificationCenter.getHighlightedSource(),
+		highlightedLevel: NotificationCenter.getHighlightedLevel(),
 	}
-)(
+})(
 	class NotificationCenterPopUps extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		private readonly DISMISS_ANIMATION_DURATION = 500
 		private readonly LEAVE_ANIMATION_DURATION = 150

--- a/meteor/client/lib/notifications/notifications.ts
+++ b/meteor/client/lib/notifications/notifications.ts
@@ -8,6 +8,7 @@ import { Time, ProtectedString, unprotectString, isProtectedString, protectStrin
 import { HTMLAttributes } from 'react'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { RundownAPI } from '../../../lib/api/rundown'
+import { RundownId } from '../../../lib/collections/Rundowns'
 
 /**
  * Priority level for Notifications.
@@ -110,7 +111,7 @@ export class NotifierHandle {
 	}
 }
 
-type NotificationsSource = SegmentId | string | undefined
+type NotificationsSource = RundownId | SegmentId | string | undefined
 /**
  * Singleton handling all the notifications.
  *

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2117,6 +2117,11 @@ body.no-overflow {
 	color: $rundown-divider-color;
 	background: $rundown-divider-background-color;
 
+	margin-left: 0;
+	margin-right: 0;
+	padding-left: 1em;
+	padding-right: 1em;
+
 	> .rundown-divider-timeline__title {
 		margin: 0 1em 0 0; // center vertically
 		padding: 0.3em;
@@ -2157,7 +2162,7 @@ body.no-overflow {
 	> .rundown-divider-timeline__expected-duration {
 		display: inline-block;
 		vertical-align: top;
-		margin: 0.95em 0.5em 0.5em;
+		margin: 0.72em 0.5em 0.5em;
 
 		> time {
 			font-weight: 600;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -24,7 +24,8 @@ $segment-item-disabled-color: #c9c9c9;
 $segment-nextline-shade-width: 1.875rem;
 $segment-nextline-shade-fill: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.5));
 
-$rundown-divider-background-color: rgba(0, 0, 0, 0.2);
+$rundown-divider-color: #000000;
+$rundown-divider-background-color: #dddddd;
 
 $liveline-timecode-color: #ffff00; //$general-live-color;
 $hold-status-color: $liveline-timecode-color;
@@ -2105,11 +2106,6 @@ body.no-overflow {
 }
 
 .rundown-divider-timeline {
-	display: grid;
-	grid-column-gap: 0;
-	grid-row-gap: 0;
-	grid-template-columns: [rundown-name] 50% [rundown-details] auto;
-	grid-template-rows: auto;
 	overflow: hidden;
 	user-select: none;
 	-moz-user-select: none;
@@ -2117,18 +2113,41 @@ body.no-overflow {
 
 	width: auto;
 	margin: 1.5em;
-	// padding: 0 0 0.15em 0.15em;
 
+	color: $rundown-divider-color;
 	background: $rundown-divider-background-color;
-	.rundown-divider-timeline__title {
-		margin: auto 0 auto 0; // center vertically
+
+	> .rundown-divider-timeline__title {
+		margin: 0 1em 0 0; // center vertically
 		padding: 0.3em;
 		line-height: 1.2em;
 		letter-spacing: 0px;
-		font-weight: 400;
+		font-weight: 600;
 		hyphens: auto;
 		-webkit-hyphens: auto;
 		-ms-hyphens: auto;
+		display: inline-block;
+	}
+
+	> .rundown-divider-timeline__notifications {
+		display: inline-block;
+		font-size: 0.8em;
+		font-weight: 400;
+		> svg {
+			height: 1.5em;
+			width: 1.5em;
+			vertical-align: bottom;
+			filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.3));
+			margin-right: 0.3em;
+			position: relative;
+			top: 0.05em;
+		}
+		margin-right: 0.8em;
+	}
+
+	> .rundown-divider-timeline__expected-start,
+	> .rundown-divider-timeline__expected-duration {
+		display: inline-block;
 	}
 }
 

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2129,7 +2129,15 @@ body.no-overflow {
 		display: inline-block;
 	}
 
-	> .rundown-divider-timeline__notifications {
+	> .rundown-divider-timeline__notifications-group {
+		display: inline-block;
+		vertical-align: bottom;
+		white-space: nowrap;
+		margin-bottom: 0.6em;
+		margin-left: 0.5em;
+	}
+
+	.rundown-divider-timeline__notifications {
 		display: inline-block;
 		font-size: 0.8em;
 		font-weight: 400;
@@ -2149,8 +2157,7 @@ body.no-overflow {
 	> .rundown-divider-timeline__expected-duration {
 		display: inline-block;
 		vertical-align: top;
-		margin-top: 0.95em;
-		margin-right: 0.5em;
+		margin: 0.95em 0.5em 0.5em;
 
 		> time {
 			font-weight: 600;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2148,6 +2148,22 @@ body.no-overflow {
 	> .rundown-divider-timeline__expected-start,
 	> .rundown-divider-timeline__expected-duration {
 		display: inline-block;
+		vertical-align: top;
+		margin-top: 0.95em;
+		margin-right: 0.5em;
+
+		> time {
+			font-weight: 600;
+		}
+
+		> .rundown-divider-timeline__expected-start__countdown {
+			font-weight: 600;
+			color: $general-late-color;
+		}
+	}
+
+	> .rundown-divider-timeline__expected-duration {
+		float: right;
 	}
 }
 

--- a/meteor/client/styles/shelf/inspector.scss
+++ b/meteor/client/styles/shelf/inspector.scss
@@ -6,6 +6,8 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 
+	background: #1f1f1f;
+
 	> dl {
 		margin: 0 0.5em;
 

--- a/meteor/client/styles/shelf/shelf.scss
+++ b/meteor/client/styles/shelf/shelf.scss
@@ -57,6 +57,7 @@
 	.rundown-view__shelf__contents {
 		flex: 1 1;
 		display: flex;
+		overflow: hidden;
 
 		> .rundown-view__shelf__contents__pane {
 			position: relative;

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -1,12 +1,96 @@
 import * as React from 'react'
 import { Rundown } from '../../../lib/collections/Rundowns'
+import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { NotificationCenter, NoticeLevel } from '../../lib/notifications/notifications'
+import { ProtectedString, unprotectStringArray, unprotectString } from '../../../lib/lib'
+import { WarningIconSmall, CriticalIconSmall } from '../../lib/notificationIcons'
 
 interface IProps {
 	rundown: Rundown
 }
 
-export const RundownDividerHeader: React.SFC<IProps> = (props: IProps) => (
-	<div className="rundown-divider-timeline">
-		<h2 className="rundown-divider-timeline__title">{props.rundown.name}</h2>
-	</div>
+interface ITrackedProps {
+	notificationsFromRundown: {
+		critical: number
+		warning: number
+	}
+}
+
+export const RundownDividerHeader = translateWithTracker<IProps, {}, ITrackedProps>(
+	(props: IProps) => {
+		const activeIds = unprotectStringArray(
+			props.rundown
+				.getSegments(
+					{},
+					{
+						fields: {
+							_id: 1,
+						},
+					}
+				)
+				.map((segment) => segment._id)
+		)
+		activeIds.push(unprotectString(props.rundown._id))
+		const notificationsFromRundown = NotificationCenter.getNotifications().filter(
+			(notification) => notification.source && activeIds.includes(notification.source as string)
+		)
+		return {
+			notificationsFromRundown: {
+				critical: notificationsFromRundown.reduce(
+					(mem, notification) => (notification.status === NoticeLevel.CRITICAL ? mem + 1 : mem),
+					0
+				),
+				warning: notificationsFromRundown.reduce(
+					(mem, notification) => (notification.status === NoticeLevel.WARNING ? mem + 1 : mem),
+					0
+				),
+			},
+		}
+	},
+	(data, props: IProps, nextProps: IProps) => {
+		if (
+			props.rundown._id !== nextProps.rundown._id ||
+			props.rundown.name !== nextProps.rundown.name ||
+			props.rundown.expectedStart !== nextProps.rundown.expectedStart ||
+			props.rundown.expectedDuration !== nextProps.rundown.expectedDuration
+		) {
+			return true
+		}
+		return false
+	}
+)(
+	class RundownDividerHeader extends React.Component<Translated<IProps & ITrackedProps>> {
+		render() {
+			const { t } = this.props
+			return (
+				<div className="rundown-divider-timeline">
+					<h2 className="rundown-divider-timeline__title">{this.props.rundown.name}</h2>
+					<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--critical">
+						<CriticalIconSmall />
+						<span className="rundown-divider-timeline__notifications__count">
+							{this.props.notificationsFromRundown.critical}
+						</span>
+					</div>
+					<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--warning">
+						<WarningIconSmall />
+						<span className="rundown-divider-timeline__notifications__count">
+							{this.props.notificationsFromRundown.warning}
+						</span>
+					</div>
+					{this.props.rundown.expectedStart && (
+						<div className="rundown-divider-timeline__expected-start">
+							<span>{t('Planned Start')}</span>
+							{this.props.rundown.expectedStart}
+						</div>
+					)}
+					{this.props.rundown.expectedDuration && (
+						<div className="rundown-divider-timeline__expected-duration">
+							<span>{t('Planned Duration')}</span>
+							{this.props.rundown.expectedDuration}
+						</div>
+					)}
+				</div>
+			)
+		}
+	}
 )

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -116,17 +116,19 @@ export const RundownDividerHeader = translateWithTracker<IProps, {}, ITrackedPro
 			return (
 				<div className="rundown-divider-timeline">
 					<h2 className="rundown-divider-timeline__title">{this.props.rundown.name}</h2>
-					<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--critical">
-						<CriticalIconSmall />
-						<span className="rundown-divider-timeline__notifications__count">
-							{this.props.notificationsFromRundown.critical}
-						</span>
-					</div>
-					<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--warning">
-						<WarningIconSmall />
-						<span className="rundown-divider-timeline__notifications__count">
-							{this.props.notificationsFromRundown.warning}
-						</span>
+					<div className="rundown-divider-timeline__notifications-group">
+						<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--critical">
+							<CriticalIconSmall />
+							<span className="rundown-divider-timeline__notifications__count">
+								{this.props.notificationsFromRundown.critical}
+							</span>
+						</div>
+						<div className="rundown-divider-timeline__notifications rundown-divider-timeline__notifications--warning">
+							<WarningIconSmall />
+							<span className="rundown-divider-timeline__notifications__count">
+								{this.props.notificationsFromRundown.warning}
+							</span>
+						</div>
 					</div>
 					{this.props.rundown.expectedStart && (
 						<div className="rundown-divider-timeline__expected-start">

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -183,7 +183,7 @@ class RundownViewNotifier extends WithManagedTracker {
 							t('The Rundown has been UNSYNCED from {{nrcsName}}! No data updates will currently come through.', {
 								nrcsName: rundown.externalNRCSName || 'NRCS',
 							}),
-							'Rundown',
+							rundown._id,
 							getCurrentTime(),
 							true,
 							[
@@ -434,7 +434,7 @@ class RundownViewNotifier extends WithManagedTracker {
 							<div>{item.message || t('There is an unknown problem with the part.')}</div>
 						</>
 					),
-					item.origin.segmentId || 'unknown',
+					item.origin.segmentId || item.origin.rundownId || 'unknown',
 					getCurrentTime(),
 					true,
 					[

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -214,6 +214,8 @@ export class RundownPlaylist implements DBRundownPlaylist {
 				name: 1,
 				_rank: 1,
 				playlistId: 1,
+				expectedStart: 1,
+				expectedDuration: 1,
 			},
 		})
 		const segments = Segments.find(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature/improvement

* **What is the current behavior?** (You can also link to an open issue here)

The Rundown View uses a simple rundown divider, with just the name of the rundown visible.

* **What is the new behavior (if this is a feature change)?**

This uses a new Rundown Divider Header that shows additional information about the rundown:

![obraz](https://user-images.githubusercontent.com/3635991/96331610-edf29380-105e-11eb-8d2f-9125ac9330df.png)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
 