### PR TITLE
chore: rename Route Sets panel to Switchboard

### DIFF
--- a/meteor/client/lib/switchboardIcons.tsx
+++ b/meteor/client/lib/switchboardIcons.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-export function RouteSetsIcon() {
+export function SwitchboardIcon() {
 	return (
 		<svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
 			<path

--- a/meteor/client/styles/statusbar.scss
+++ b/meteor/client/styles/statusbar.scss
@@ -189,7 +189,7 @@
 			}
 		}
 
-		&.status-bar__controls__button--route-set-panel {
+		&.status-bar__controls__button--switchboard-panel {
 			position: fixed;
 			right: 0.3125rem;
 			bottom: 4.3125rem;

--- a/meteor/client/styles/supportPanel.scss
+++ b/meteor/client/styles/supportPanel.scss
@@ -33,7 +33,7 @@
 }
 
 .support-pop-up-panel,
-.route-set-pop-up-panel {
+.switchboard-pop-up-panel {
 	position: fixed;
 	bottom: rem(13px);
 	right: -1px;
@@ -86,7 +86,7 @@
 	width: 22rem;
 }
 
-.route-set-pop-up-panel {
+.switchboard-pop-up-panel {
 	bottom: 4.8rem;
 	top: auto;
 	z-index: -1;
@@ -97,24 +97,24 @@
 	width: 28rem;
 	max-width: 28rem;
 
-	> .route-set-pop-up-panel__inside {
+	> .switchboard-pop-up-panel__inside {
 		width: 28rem;
 	}
 }
 
-.route-set-pop-up-panel .route-set-pop-up-panel__group {
+.switchboard-pop-up-panel .switchboard-pop-up-panel__group {
 	width: 28rem;
 	border-top: 1px solid #d7d7d7;
 	margin-top: 0.75em;
 	padding-top: 10px;
 	user-select: none;
 
-	.route-set-pop-up-panel__group__controls {
-		.route-set-pop-up-panel__group__controls__active {
+	.switchboard-pop-up-panel__group__controls {
+		.switchboard-pop-up-panel__group__controls__active {
 			font-weight: 400;
 		}
 
-		.route-set-pop-up-panel__group__controls__inactive {
+		.switchboard-pop-up-panel__group__controls__inactive {
 			color: #727272;
 		}
 
@@ -131,7 +131,7 @@
 		background: #eee;
 		z-index: 1900;
 	}
-	.route-set-pop-up-panel {
+	.switchboard-pop-up-panel {
 		color: #000;
 		background: #eee;
 		z-index: -1;

--- a/meteor/client/ui/RundownView/RundownRightHandControls.tsx
+++ b/meteor/client/ui/RundownView/RundownRightHandControls.tsx
@@ -24,8 +24,8 @@ import * as On_Air_MouseOver from './On_Air_MouseOver.json'
 import { SupportPopUpToggle } from '../SupportPopUp'
 import classNames from 'classnames'
 import { NoticeLevel } from '../../lib/notifications/notifications'
-import { RouteSetsIcon } from '../../lib/routeSetIcons'
-import { RouteSetsPopUp } from './RouteSetsPopUp'
+import { SwitchboardIcon } from '../../lib/switchboardIcons'
+import { SwitchboardPopUp } from './SwitchboardPopUp'
 
 interface IProps {
 	studioRouteSets: {
@@ -54,7 +54,7 @@ interface IProps {
 interface IState {
 	onAirHover: boolean
 	rewindHover: boolean
-	isRouteSetsOpen: boolean
+	isSwitchboardOpen: boolean
 }
 
 export class RundownRightHandControls extends React.Component<IProps, IState> {
@@ -80,7 +80,7 @@ export class RundownRightHandControls extends React.Component<IProps, IState> {
 		this.state = {
 			onAirHover: false,
 			rewindHover: false,
-			isRouteSetsOpen: false,
+			isSwitchboardOpen: false,
 		}
 
 		this.fullscreenOut = {
@@ -161,7 +161,7 @@ export class RundownRightHandControls extends React.Component<IProps, IState> {
 
 	onRouteSetsToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
 		this.setState({
-			isRouteSetsOpen: !this.state.isRouteSetsOpen,
+			isSwitchboardOpen: !this.state.isSwitchboardOpen,
 		})
 	}
 
@@ -254,17 +254,17 @@ export class RundownRightHandControls extends React.Component<IProps, IState> {
 								<button
 									className={classNames(
 										'status-bar__controls__button',
-										'status-bar__controls__button--route-set-panel',
+										'status-bar__controls__button--switchboard-panel',
 										'notifications-s notifications-text',
 										{
-											'status-bar__controls__button--open': this.state.isRouteSetsOpen,
+											'status-bar__controls__button--open': this.state.isSwitchboardOpen,
 										}
 									)}
 									role="button"
 									onClick={this.onRouteSetsToggle}
 									tabIndex={0}>
-									<RouteSetsIcon />
-									{activeRoutes > 0 && <span className="notification">{activeRoutes}</span>}
+									<SwitchboardIcon />
+									{activeRoutes > 0 && <span className="notification">&nbsp;</span>}
 								</button>
 								<VelocityReact.VelocityTransitionGroup
 									enter={{
@@ -281,8 +281,8 @@ export class RundownRightHandControls extends React.Component<IProps, IState> {
 										easing: 'ease-in',
 										duration: 500,
 									}}>
-									{this.state.isRouteSetsOpen && (
-										<RouteSetsPopUp
+									{this.state.isSwitchboardOpen && (
+										<SwitchboardPopUp
 											availableRouteSets={availableRouteSets}
 											studioRouteSetExclusivityGroups={this.props.studioRouteSetExclusivityGroups}
 											onStudioRouteSetSwitch={this.props.onStudioRouteSetSwitch}

--- a/meteor/client/ui/RundownView/SwitchboardPopUp.tsx
+++ b/meteor/client/ui/RundownView/SwitchboardPopUp.tsx
@@ -17,8 +17,11 @@ interface IProps {
 	}
 }
 
-export const RouteSetsPopUp = withTranslation()(
-	class RouteSetsPopUp extends React.Component<Translated<IProps>> {
+/**
+ * This is a panel for which Route Sets are active in the current studio
+ */
+export const SwitchboardPopUp = withTranslation()(
+	class SwitchboardPopUp extends React.Component<Translated<IProps>> {
 		render() {
 			const { t } = this.props
 			const exclusivityGroups: {
@@ -31,22 +34,22 @@ export const RouteSetsPopUp = withTranslation()(
 			}
 
 			return (
-				<div className="route-set-pop-up-panel">
-					<div className="route-set-pop-up-panel__inside">
-						<h2 className="mhn mvn">{t('Route Sets')}</h2>
+				<div className="switchboard-pop-up-panel">
+					<div className="switchboard-pop-up-panel__inside">
+						<h2 className="mhn mvn">{t('Switchboard')}</h2>
 						{Object.entries(exclusivityGroups).map(([key, routeSets]) => (
-							<div className="route-set-pop-up-panel__group" key={key}>
+							<div className="switchboard-pop-up-panel__group" key={key}>
 								{this.props.studioRouteSetExclusivityGroups[key]?.name && (
 									<p className="mhs mbs mtn">{this.props.studioRouteSetExclusivityGroups[key]?.name}</p>
 								)}
 								{routeSets.length === 2 &&
 								routeSets[0][1].behavior === StudioRouteBehavior.ACTIVATE_ONLY &&
 								routeSets[1][1].behavior === StudioRouteBehavior.ACTIVATE_ONLY ? (
-									<div key={routeSets[0][0]} className="route-set-pop-up-panel__group__controls mhm mbs">
+									<div key={routeSets[0][0]} className="switchboard-pop-up-panel__group__controls mhm mbs">
 										<span
 											className={classNames({
-												'route-set-pop-up-panel__group__controls__active': routeSets[0][1].active,
-												'route-set-pop-up-panel__group__controls__inactive': !routeSets[0][1].active,
+												'switchboard-pop-up-panel__group__controls__active': routeSets[0][1].active,
+												'switchboard-pop-up-panel__group__controls__inactive': !routeSets[0][1].active,
 											})}>
 											{routeSets[0][1].name}
 										</span>
@@ -75,19 +78,19 @@ export const RouteSetsPopUp = withTranslation()(
 										</a>
 										<span
 											className={classNames({
-												'route-set-pop-up-panel__group__controls__active': routeSets[1][1].active,
-												'route-set-pop-up-panel__group__controls__inactive': !routeSets[1][1].active,
+												'switchboard-pop-up-panel__group__controls__active': routeSets[1][1].active,
+												'switchboard-pop-up-panel__group__controls__inactive': !routeSets[1][1].active,
 											})}>
 											{routeSets[1][1].name}
 										</span>
 									</div>
 								) : (
 									routeSets.map(([id, routeSet]) => (
-										<div key={id} className="route-set-pop-up-panel__group__controls mhm mbs">
+										<div key={id} className="switchboard-pop-up-panel__group__controls mhm mbs">
 											<span
 												className={classNames({
-													'route-set-pop-up-panel__group__controls__active': !routeSet.active,
-													'route-set-pop-up-panel__group__controls__inactive': routeSet.active,
+													'switchboard-pop-up-panel__group__controls__active': !routeSet.active,
+													'switchboard-pop-up-panel__group__controls__inactive': routeSet.active,
 												})}>
 												{t('Off')}
 											</span>
@@ -112,8 +115,8 @@ export const RouteSetsPopUp = withTranslation()(
 											</a>
 											<span
 												className={classNames({
-													'route-set-pop-up-panel__group__controls__active': routeSet.active,
-													'route-set-pop-up-panel__group__controls__inactive': !routeSet.active,
+													'switchboard-pop-up-panel__group__controls__active': routeSet.active,
+													'switchboard-pop-up-panel__group__controls__inactive': !routeSet.active,
 												})}>
 												{routeSet.name}
 											</span>

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -1416,7 +1416,12 @@ const StudioRoutings = withTranslation()(
 			const { t } = this.props
 			return (
 				<div>
-					<h2 className="mhn">{t('Route Sets')}</h2>
+					<h2 className="mhn mbs">{t('Route Sets')}</h2>
+					<p className="mhn mvs text-s dimmed">
+						{t(
+							'Controls for exposed Route Sets will be displayed to the producer within the Rundown View in the Switchboard.'
+						)}
+					</p>
 					<h3 className="mhn">{t('Exclusivity Groups')}</h3>
 					<table className="expando settings-studio-mappings-table">
 						<tbody>{this.renderExclusivityGroups()}</tbody>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a chore implementation of a change of the name of the "Route Sets".

* **What is the current behavior?** (You can also link to an open issue here)

The panel in the Rundown View is named "Route Sets", the same as the backend feature is called.

* **What is the new behavior (if this is a feature change)?**

The panel (and all of it's components) are now renamed to Switchboard.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
