### PR TITLE
fix: PeripheralDevice name fix

### DIFF
--- a/meteor/lib/collections/PeripheralDevices.ts
+++ b/meteor/lib/collections/PeripheralDevices.ts
@@ -19,7 +19,11 @@ export interface PeripheralDevice {
 	/** If set, this device is owned by that organization */
 	organizationId: OrganizationId | null
 
+	/** Name of the device (set by the device, modifiable by user) */
 	name: string
+
+	/** Name of the device (set by the device) */
+	deviceName?: string
 
 	category: PeripheralDeviceAPI.DeviceCategory
 	type: PeripheralDeviceAPI.DeviceType

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -75,12 +75,11 @@ export namespace ServerPeripheralDeviceAPI {
 					type: options.type,
 					subType: options.subType,
 
-					name: (
+					name:
 						// Only allow name changes if the name is unmodified:
-						(existingDevice.name === existingDevice.deviceName || existingDevice.deviceName === undefined) ?
-						options.name :
-						existingDevice.name
-					),
+						existingDevice.name === existingDevice.deviceName || existingDevice.deviceName === undefined
+							? options.name
+							: existingDevice.name,
 					deviceName: options.name,
 					parentDeviceId: options.parentDeviceId,
 					versions: options.versions,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A small feature


* **What is the current behavior?** (You can also link to an open issue here)
Devices can't modify their names, its set on first connection then won't change.


* **What is the new behavior (if this is a feature change)?**
The the user hasn't modified the name, it'll be updated to the device name whenever the device reconnects.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
