### PR TITLE
fix: ensure visible overflow time label on Pieces

### DIFF
--- a/meteor/client/styles/_itemTypeColors.scss
+++ b/meteor/client/styles/_itemTypeColors.scss
@@ -16,6 +16,124 @@ $segment-layer-background-script: #005a25;
 $segment-layer-background-mic: #1e6820;
 $segment-layer-background-guest: #008a92;
 
+@mixin item-type-text-outline($selectors) {
+	&.camera {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-camera),
+				-1px 1px 1px var(--segment-layer-background-camera), -1px -1px 1px var(--segment-layer-background-camera),
+				1px 1px 1px var(--segment-layer-background-camera), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-camera--second),
+					-1px 1px 1px var(--segment-layer-background-camera--second),
+					-1px -1px 1px var(--segment-layer-background-camera--second),
+					1px 1px 1px var(--segment-layer-background-camera--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
+	&.graphics {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-graphics),
+				-1px 1px 1px var(--segment-layer-background-graphics), -1px -1px 1px var(--segment-layer-background-graphics),
+				1px 1px 1px var(--segment-layer-background-graphics), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-graphics--second),
+					-1px 1px 1px var(--segment-layer-background-graphics--second),
+					-1px -1px 1px var(--segment-layer-background-graphics--second),
+					1px 1px 1px var(--segment-layer-background-graphics--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
+	&.lower-third {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-lower-third),
+				-1px 1px 1px var(--segment-layer-background-lower-third),
+				-1px -1px 1px var(--segment-layer-background-lower-third),
+				1px 1px 1px var(--segment-layer-background-lower-third), 1px 1px 3px rgba(0, 0, 0, 1),
+				1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-lower-third--second),
+					-1px 1px 1px var(--segment-layer-background-lower-third--second),
+					-1px -1px 1px var(--segment-layer-background-lower-third--second),
+					1px 1px 1px var(--segment-layer-background-lower-third--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
+	&.live-speak {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-vt), -1px 1px 1px var(--segment-layer-background-vt),
+				-1px -1px 1px var(--segment-layer-background-vt), 1px 1px 1px var(--segment-layer-background-vt),
+				1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+	}
+
+	&.vt {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-vt), -1px 1px 1px var(--segment-layer-background-vt),
+				-1px -1px 1px var(--segment-layer-background-vt), 1px 1px 1px var(--segment-layer-background-vt),
+				1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-vt--second),
+					-1px 1px 1px var(--segment-layer-background-vt--second),
+					-1px -1px 1px var(--segment-layer-background-vt--second),
+					1px 1px 1px var(--segment-layer-background-vt--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
+	&.remote {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-remote),
+				-1px 1px 1px var(--segment-layer-background-remote), -1px -1px 1px var(--segment-layer-background-remote),
+				1px 1px 1px var(--segment-layer-background-remote), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-remote--second),
+					-1px 1px 1px var(--segment-layer-background-remote--second),
+					-1px -1px 1px var(--segment-layer-background-remote--second),
+					1px 1px 1px var(--segment-layer-background-remote--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
+	&.script {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-script),
+				-1px 1px 1px var(--segment-layer-background-script), -1px -1px 1px var(--segment-layer-background-script),
+				1px 1px 1px var(--segment-layer-background-script), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+	}
+
+	&.mic {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-guest),
+				-1px 1px 1px var(--segment-layer-background-guest), -1px -1px 1px var(--segment-layer-background-guest),
+				1px 1px 1px var(--segment-layer-background-guest), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+	}
+}
+
 @mixin item-type-colors {
 	&.camera {
 		background: var(--segment-layer-background-camera);

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1654,6 +1654,8 @@ body.no-overflow {
 								right: 0;
 								transform: translate3d(0, 0, 15px);
 								text-align: right;
+								margin: 0;
+								padding: 0 0.3em;
 								max-width: calc(100% - 10px);
 								overflow: hidden;
 								text-overflow: clip;
@@ -1694,7 +1696,15 @@ body.no-overflow {
 							}
 
 							&.label-overflow-time {
-								font-weight: 500;
+								text-shadow: 1px -1px 1px black, -1px 1px 1px black, -1px -1px 1px black, 1px 1px 1px black,
+									1px 1px 3px black, 1px 1px 8px black, 1px 1px 8px black, 1px 1px 8px black;
+								top: -7px;
+								right: -5px;
+								color: white;
+								font-weight: 600;
+								padding: 0;
+								font-size: 0.8em;
+								margin: 0;
 							}
 
 							> .segment-timeline__piece__label {
@@ -1716,8 +1726,6 @@ body.no-overflow {
 								margin-left: 0.5em;
 							}
 						}
-
-						@include item-type-text-outline('.segment-timeline__piece__label.label-overflow-time');
 
 						&.hide-overflow-labels {
 							.segment-timeline__piece__label {

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1676,10 +1676,6 @@ body.no-overflow {
 								> .label-icon.label-infinite-icon {
 									margin: 0 0 0 0;
 								}
-
-								> .last-words {
-									float: right;
-								}
 							}
 
 							&.last-words {
@@ -1698,8 +1694,7 @@ body.no-overflow {
 							}
 
 							&.label-overflow-time {
-								font-weight: 300;
-								padding-right: 10px;
+								font-weight: 500;
 							}
 
 							> .segment-timeline__piece__label {
@@ -1721,6 +1716,8 @@ body.no-overflow {
 								margin-left: 0.5em;
 							}
 						}
+
+						@include item-type-text-outline('.segment-timeline__piece__label.label-overflow-time');
 
 						&.hide-overflow-labels {
 							.segment-timeline__piece__label {

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -27,8 +27,8 @@ export interface ICustomLayerItemProps {
 	elementPosition: OffsetPosition
 	cursorPosition: OffsetPosition
 	cursorTimePosition: number
-	getItemLabelOffsetLeft?: () => { [key: string]: string }
-	getItemLabelOffsetRight?: () => { [key: string]: string }
+	getItemLabelOffsetLeft?: () => React.CSSProperties
+	getItemLabelOffsetRight?: () => React.CSSProperties
 	getItemDuration?: () => number
 	setAnchoredElsWidths?: (rightAnchoredWidth: number, leftAnchoredWidth: number) => void
 }
@@ -38,7 +38,7 @@ export class CustomLayerItemRenderer<
 	IProps extends ICustomLayerItemProps,
 	IState extends ISourceLayerItemState
 > extends React.Component<ICustomLayerItemProps & IProps, ISourceLayerItemState & IState> {
-	getItemLabelOffsetLeft(): { [key: string]: string } {
+	getItemLabelOffsetLeft(): React.CSSProperties {
 		if (this.props.getItemLabelOffsetLeft && typeof this.props.getItemLabelOffsetLeft === 'function') {
 			return this.props.getItemLabelOffsetLeft()
 		} else {
@@ -46,7 +46,7 @@ export class CustomLayerItemRenderer<
 		}
 	}
 
-	getItemLabelOffsetRight(): { [key: string]: string } {
+	getItemLabelOffsetRight(): React.CSSProperties {
 		if (this.props.getItemLabelOffsetRight && typeof this.props.getItemLabelOffsetRight === 'function') {
 			return this.props.getItemLabelOffsetRight()
 		} else {

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -371,9 +371,9 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 							/>
 						</div>
 					)}
+					<span className="segment-timeline__piece__label last-words">{this.end}</span>
 					{this.renderInfiniteIcon()}
 					{this.renderOverflowTimeLabel()}
-					<span className="segment-timeline__piece__label last-words">{this.end}</span>
 				</span>
 				<FloatingInspector shown={this.props.showMiniInspector && this.props.itemElement !== undefined}>
 					{this.getPreviewUrl() ? (

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -95,7 +95,7 @@ export const SourceLayerItem = withTranslation()(
 			})
 		}
 
-		getItemLabelOffsetLeft = (): { [key: string]: string } => {
+		getItemLabelOffsetLeft = (): React.CSSProperties => {
 			if (this.props.relative) {
 				return {}
 			} else {
@@ -220,7 +220,7 @@ export const SourceLayerItem = withTranslation()(
 							let styleObj = {
 								maxWidth:
 									this.state.rightAnchoredWidth > 0
-										? (this.state.elementWidth - this.state.rightAnchoredWidth).toString() + 'px'
+										? (this.state.elementWidth - this.state.rightAnchoredWidth - 10).toString() + 'px'
 										: maxLabelWidth !== undefined
 										? (maxLabelWidth * this.props.timeScale).toString() + 'px'
 										: nextIsTouching
@@ -245,7 +245,7 @@ export const SourceLayerItem = withTranslation()(
 							let styleObj = {
 								maxWidth:
 									this.state.rightAnchoredWidth > 0
-										? (this.state.elementWidth - this.state.rightAnchoredWidth).toString() + 'px'
+										? (this.state.elementWidth - this.state.rightAnchoredWidth - 10).toString() + 'px'
 										: maxLabelWidth !== undefined
 										? (maxLabelWidth * this.props.timeScale).toString() + 'px'
 										: nextIsTouching
@@ -261,7 +261,7 @@ export const SourceLayerItem = withTranslation()(
 			}
 		}
 
-		getItemLabelOffsetRight = (): { [key: string]: string } => {
+		getItemLabelOffsetRight = (): React.CSSProperties => {
 			if (this.props.relative) {
 				return {}
 			} else {
@@ -461,6 +461,10 @@ export const SourceLayerItem = withTranslation()(
 		componentDidMount() {
 			if (this.props.isLiveLine) {
 				this.mountResizeObserver()
+			} else if (this.state.itemElement) {
+				this.setState({
+					elementWidth: getElementWidth(this.state.itemElement),
+				})
 			}
 			window.addEventListener(RundownViewEvents.highlight, this.onHighlight)
 		}
@@ -472,7 +476,7 @@ export const SourceLayerItem = withTranslation()(
 			clearTimeout(this.highlightTimeout)
 		}
 
-		componentDidUpdate(prevProps: ISourceLayerItemProps) {
+		componentDidUpdate(prevProps: ISourceLayerItemProps, prevState: ISourceLayerItemState) {
 			if (prevProps.scrollLeft !== this.props.scrollLeft && this.state.showMiniInspector) {
 				const scrollLeftOffset = this.state.scrollLeftOffset + (this.props.scrollLeft - prevProps.scrollLeft)
 				const cursorTimePosition = this.state.cursorTimePosition + (this.props.scrollLeft - prevProps.scrollLeft)
@@ -488,6 +492,15 @@ export const SourceLayerItem = withTranslation()(
 				this.mountResizeObserver()
 			} else if (!this.props.isLiveLine && this._resizeObserver) {
 				this.unmountResizeObserver()
+			}
+
+			if (
+				this.state.itemElement &&
+				(this.state.itemElement !== prevState.itemElement || this.props.timeScale !== prevProps.timeScale)
+			) {
+				this.setState({
+					elementWidth: getElementWidth(this.state.itemElement),
+				})
 			}
 		}
 

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -461,11 +461,8 @@ export const SourceLayerItem = withTranslation()(
 		componentDidMount() {
 			if (this.props.isLiveLine) {
 				this.mountResizeObserver()
-			} else if (this.state.itemElement) {
-				this.setState({
-					elementWidth: getElementWidth(this.state.itemElement),
-				})
 			}
+
 			window.addEventListener(RundownViewEvents.highlight, this.onHighlight)
 		}
 
@@ -492,15 +489,6 @@ export const SourceLayerItem = withTranslation()(
 				this.mountResizeObserver()
 			} else if (!this.props.isLiveLine && this._resizeObserver) {
 				this.unmountResizeObserver()
-			}
-
-			if (
-				this.state.itemElement &&
-				(this.state.itemElement !== prevState.itemElement || this.props.timeScale !== prevProps.timeScale)
-			) {
-				this.setState({
-					elementWidth: getElementWidth(this.state.itemElement),
-				})
 			}
 		}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

In some situations, the "time overflow" label may not be legible, as it overlaps with the left-anchored label (usually, the Piece name)

* **What is the new behavior (if this is a feature change)?**

Some fixes to ensure that the left-anchored label has a set `max-width` as well as styling improvements to make the "time overflow" label more prominent.

![obraz](https://user-images.githubusercontent.com/3635991/97193153-feb2b000-17a8-11eb-993e-69b990274a84.png)



* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
