### PR TITLE
fix: Remove deleted segments from ingestDataCache

### DIFF
--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -131,6 +131,7 @@ import { removeEmptyPlaylists } from '../rundownPlaylist'
 import { profiler } from '../profiler'
 import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { syncPlayheadInfinitesForNextPartInstance } from '../playout/infinites'
+import { IngestDataCache } from '../../../lib/collections/IngestDataCache'
 
 /** Priority for handling of synchronous events. Lower means higher priority */
 export enum RundownSyncFunctionPriority {
@@ -1051,6 +1052,13 @@ function handleRemovedSegment(
 						`handleRemovedSegment: removeSegments: Segment ${segmentExternalId} not found`
 					)
 				}
+
+				cache.defer(() => {
+					IngestDataCache.remove({
+						segmentId: segmentId,
+						rundownId: rundownId,
+					})
+				})
 			}
 		}
 

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -64,7 +64,6 @@ import { rundownContentAllowWrite } from '../security/rundown'
 import { modifyPlaylistExternalId } from './ingest/lib'
 import { triggerUpdateTimelineAfterIngestData } from './playout/playout'
 import { profiler } from './profiler'
-import { IngestDataCache } from '../../lib/collections/IngestDataCache'
 
 export function selectShowStyleVariant(
 	studio: Studio,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -64,6 +64,7 @@ import { rundownContentAllowWrite } from '../security/rundown'
 import { modifyPlaylistExternalId } from './ingest/lib'
 import { triggerUpdateTimelineAfterIngestData } from './playout/playout'
 import { profiler } from './profiler'
+import { IngestDataCache } from '../../lib/collections/IngestDataCache'
 
 export function selectShowStyleVariant(
 	studio: Studio,
@@ -266,6 +267,11 @@ export function removeSegments(cache: CacheForRundownPlaylist, rundownId: Rundow
 		_id: { $in: segmentIds },
 		rundownId: rundownId,
 	})
+	IngestDataCache.remove({
+		segmentId: { $in: segmentIds },
+		rundownId: rundownId,
+	})
+
 	if (count > 0) {
 		afterRemoveSegments(cache, rundownId, segmentIds)
 	}

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -267,11 +267,6 @@ export function removeSegments(cache: CacheForRundownPlaylist, rundownId: Rundow
 		_id: { $in: segmentIds },
 		rundownId: rundownId,
 	})
-	IngestDataCache.remove({
-		segmentId: { $in: segmentIds },
-		rundownId: rundownId,
-	})
-
 	if (count > 0) {
 		afterRemoveSegments(cache, rundownId, segmentIds)
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Cleans up segments from `ingestDataCache` when `dataSegmentDelete` is recieved.


* **What is the current behavior?** (You can also link to an open issue here)
The cached ingest data for a segment remains after a segment is deleted from the NRCS.


* **What is the new behavior (if this is a feature change)?**
The ingest data will be cleaned up.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
