### PR TITLE
Fix/unsync playlist

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -30,6 +30,7 @@ import {
 	IBlueprintPart,
 	IBlueprintPiece,
 	TSR,
+	IBlueprintRundownDB,
 } from 'tv-automation-sofie-blueprints-integration'
 import { ShowStyleBase, ShowStyleBases, DBShowStyleBase, ShowStyleBaseId } from '../../lib/collections/ShowStyleBases'
 import {
@@ -286,6 +287,20 @@ export function setupMockStudioBlueprint(showStyleBaseId: ShowStyleBaseId): Blue
 				): string | null => {
 					return SHOW_STYLE_ID
 				},
+				getRundownPlaylistInfo: (rundowns: IBlueprintRundownDB[]) => {
+					if (rundowns.length > 0) {
+						return {
+							order: null,
+							playlist: {
+								name: rundowns[0].name,
+								expectedStart: rundowns[0].expectedStart,
+								expectedDuration: rundowns[0].expectedDuration,
+								externalId: rundowns[0].externalId,
+							},
+						}
+					}
+					return null
+				},
 			}
 		}
 	)
@@ -335,6 +350,7 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 						// expectedStart?:
 						// expectedDuration?: number;
 						metaData: ingestRundown.payload,
+						playlistExternalId: 'readySteadyGo',
 					}
 					return {
 						rundown,

--- a/meteor/server/api/ingest/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/ingest/__tests__/rundownPlaylist.test.ts
@@ -1,0 +1,463 @@
+import { Meteor } from 'meteor/meteor'
+import { PeripheralDeviceAPI, PeripheralDeviceAPIMethods } from '../../../../lib/api/peripheralDevice'
+import { setupDefaultStudioEnvironment, setupMockPeripheralDevice } from '../../../../__mocks__/helpers/database'
+import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { PeripheralDevice } from '../../../../lib/collections/PeripheralDevices'
+import { testInFiber } from '../../../../__mocks__/helpers/jest'
+import { Segment, Segments } from '../../../../lib/collections/Segments'
+import { Part, Parts, PartId } from '../../../../lib/collections/Parts'
+import { IngestRundown, IngestSegment, IngestPart } from 'tv-automation-sofie-blueprints-integration'
+import { updatePartRanks, ServerRundownAPI } from '../../rundown'
+import { ServerPlayoutAPI } from '../../playout/playout'
+import { RundownInput } from '../rundownInput'
+import { RundownPlaylists, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
+import { unprotectString, protectString } from '../../../../lib/lib'
+import { PartInstances } from '../../../../lib/collections/PartInstances'
+import { getSegmentId } from '../lib'
+import * as MOS from 'mos-connection'
+
+import { wrapWithCacheForRundownPlaylistFromRundown, wrapWithCacheForRundownPlaylist } from '../../../DatabaseCaches'
+import { removeRundownPlaylistFromCache } from '../../playout/lib'
+import { MethodContext } from '../../../../lib/api/methods'
+
+require('../../peripheralDevice.ts') // include in order to create the Meteor methods needed
+
+const DEFAULT_CONTEXT: MethodContext = {
+	userId: null,
+	isSimulation: false,
+	connection: {
+		id: 'mockConnectionId',
+		close: () => {},
+		onClose: () => {},
+		clientAddress: '127.0.0.1',
+		httpHeaders: {},
+	},
+	setUserId: () => {},
+	unblock: () => {},
+}
+
+describe('Test ingest actions for rundowns and segments', () => {
+	let device: PeripheralDevice
+	let device2: PeripheralDevice
+	let externalId = 'abcde'
+	let externalId2 = 'fghij'
+	let externalId3 = 'klmno'
+	let segExternalId = 'zyxwv'
+	let segExternalId2 = 'utsrp'
+	let segExternalId3 = 'onmlk'
+	beforeAll(() => {
+		const env = setupDefaultStudioEnvironment()
+		device = env.ingestDevice
+
+		device2 = setupMockPeripheralDevice(
+			PeripheralDeviceAPI.DeviceCategory.INGEST,
+			// @ts-ignore
+			'mockDeviceType',
+			PeripheralDeviceAPI.SUBTYPE_PROCESS,
+			env.studio
+		)
+	})
+
+	testInFiber('unsyncing of rundown - one item list', () => {
+		// Cleanup any rundowns / playlists
+		RundownPlaylists.find()
+			.fetch()
+			.forEach((playlist) =>
+				wrapWithCacheForRundownPlaylist(playlist, (cache) => removeRundownPlaylistFromCache(cache, playlist))
+			)
+
+		const rundownData: IngestRundown = {
+			externalId: externalId,
+			name: 'MyMockRundown',
+			type: 'mock',
+			segments: [
+				{
+					externalId: 'segment0',
+					name: 'Segment 0',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part0',
+							name: 'Part 0',
+							rank: 0,
+						},
+						{
+							externalId: 'part1',
+							name: 'Part 1',
+							rank: 0,
+						},
+					],
+				},
+				{
+					externalId: 'segment1',
+					name: 'Segment 1',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part2',
+							name: 'Part 2',
+							rank: 0,
+						},
+					],
+				},
+			],
+		}
+
+		// Preparation: set up rundown
+		expect(Rundowns.findOne()).toBeFalsy()
+		Meteor.call(PeripheralDeviceAPIMethods.dataRundownCreate, device2._id, device2.token, rundownData)
+		const rundown = Rundowns.findOne() as Rundown
+		expect(rundown).toMatchObject({
+			externalId: rundownData.externalId,
+		})
+		const playlist = rundown.getRundownPlaylist()
+		expect(playlist).toBeTruthy()
+
+		const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
+		const getPlaylist = () => rundown.getRundownPlaylist() as RundownPlaylist
+		const resyncRundown = () => {
+			try {
+				ServerRundownAPI.resyncRundown(DEFAULT_CONTEXT, rundown._id)
+			} catch (e) {
+				if (e.toString().match(/does not support the method "reloadRundown"/)) {
+					// This is expected
+					return
+				}
+				throw e
+			}
+		}
+
+		const segments = getRundown().getSegments()
+		const parts = getRundown().getParts()
+
+		expect(segments).toHaveLength(2)
+		expect(parts).toHaveLength(3)
+
+		// Activate the rundown, make data updates and verify that it gets unsynced properly
+		ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlist._id, true)
+		expect(getRundown().unsynced).toEqual(false)
+
+		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData.externalId)
+		expect(getRundown().unsynced).toEqual(true)
+
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+
+		ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
+		const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
+		expect(partInstance).toHaveLength(1)
+		expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)
+
+		RundownInput.dataSegmentDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData.externalId,
+			segments[0].externalId
+		)
+		expect(getRundown().unsynced).toEqual(true)
+
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+
+		RundownInput.dataPartDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData.externalId,
+			segments[0].externalId,
+			parts[0].externalId
+		)
+		expect(getRundown().unsynced).toEqual(true)
+
+		resyncRundown()
+		expect(getRundown().unsynced).toEqual(false)
+	})
+
+	testInFiber('unsyncing of rundown - three item playlist', () => {
+		// Cleanup any rundowns / playlists
+		RundownPlaylists.find()
+			.fetch()
+			.forEach((playlist) =>
+				wrapWithCacheForRundownPlaylist(playlist, (cache) => removeRundownPlaylistFromCache(cache, playlist))
+			)
+
+		const rundownData: IngestRundown = {
+			externalId: externalId,
+			name: 'MyMockRundown',
+			type: 'mock',
+			segments: [
+				{
+					externalId: 'segment0',
+					name: 'Segment 0',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part0',
+							name: 'Part 0',
+							rank: 0,
+						},
+						{
+							externalId: 'part1',
+							name: 'Part 1',
+							rank: 0,
+						},
+					],
+				},
+				{
+					externalId: 'segment1',
+					name: 'Segment 1',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part2',
+							name: 'Part 2',
+							rank: 0,
+						},
+					],
+				},
+			],
+		}
+
+		const rundownData2: IngestRundown = {
+			externalId: externalId2,
+			name: 'MyMockRundown2',
+			type: 'mock',
+			segments: [
+				{
+					externalId: 'segment0',
+					name: 'Segment 0',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part0',
+							name: 'Part 0',
+							rank: 0,
+						},
+						{
+							externalId: 'part1',
+							name: 'Part 1',
+							rank: 0,
+						},
+					],
+				},
+				{
+					externalId: 'segment1',
+					name: 'Segment 1',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part2',
+							name: 'Part 2',
+							rank: 0,
+						},
+					],
+				},
+			],
+		}
+
+		const rundownData3: IngestRundown = {
+			externalId: externalId3,
+			name: 'MyMockRundown3',
+			type: 'mock',
+			segments: [
+				{
+					externalId: 'segment0',
+					name: 'Segment 0',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part0',
+							name: 'Part 0',
+							rank: 0,
+						},
+						{
+							externalId: 'part1',
+							name: 'Part 1',
+							rank: 0,
+						},
+					],
+				},
+				{
+					externalId: 'segment1',
+					name: 'Segment 1',
+					rank: 0,
+					parts: [
+						{
+							externalId: 'part2',
+							name: 'Part 2',
+							rank: 0,
+						},
+					],
+				},
+			],
+		}
+
+		// Preparation: set up rundown
+		expect(Rundowns.findOne()).toBeFalsy()
+		Meteor.call(PeripheralDeviceAPIMethods.dataRundownCreate, device2._id, device2.token, rundownData)
+		Meteor.call(PeripheralDeviceAPIMethods.dataRundownCreate, device2._id, device2.token, rundownData2)
+		Meteor.call(PeripheralDeviceAPIMethods.dataRundownCreate, device2._id, device2.token, rundownData3)
+		const rundown = Rundowns.findOne({ externalId: externalId }) as Rundown
+		expect(rundown).toMatchObject({
+			externalId: externalId,
+		})
+		const playlist = rundown.getRundownPlaylist()
+		expect(playlist).toBeTruthy()
+		expect(playlist.getRundowns()).toHaveLength(3)
+
+		const rundown2 = Rundowns.findOne({ externalId: externalId2 }) as Rundown
+		// const rundown3 = Rundowns.findOne({ externalId: externalId3 }) as Rundown
+		// ServerRundownAPI.moveRundown(DEFAULT_CONTEXT, rundown2._id, playlist._id, [rundown._id, rundown2._id])
+		// ServerRundownAPI.moveRundown(DEFAULT_CONTEXT, rundown3._id, playlist._id, [rundown._id, rundown2._id, rundown3._id])
+		// expect(playlist.getRundowns()).toHaveLength(3)
+		// console.log(playlist.getRundownIDs())
+
+		const getRundown = (rd: Rundown) => Rundowns.findOne(rd._id) as Rundown
+		// const playlist2 = getRundown(rundown2).getRundownPlaylist()
+		// expect(playlist._id).toEqual(playlist2._id)
+
+		const getPlaylist = () => rundown.getRundownPlaylist() as RundownPlaylist
+		const resyncRundown = (rd: Rundown) => {
+			try {
+				ServerRundownAPI.resyncRundown(DEFAULT_CONTEXT, rd._id)
+			} catch (e) {
+				if (e.toString().match(/does not support the method "reloadRundown"/)) {
+					// This is expected
+					return
+				}
+				throw e
+			}
+		}
+		const resyncPlaylist = () => {
+			try {
+				ServerRundownAPI.resyncRundownPlaylist(DEFAULT_CONTEXT, playlist._id)
+			} catch (e) {
+				if (e.toString().match(/does not support the method "reloadRundown"/)) {
+					// This is expected
+					return
+				}
+				throw e
+			}
+		}
+
+		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
+			ID: new MOS.MosString128(rundown.externalId),
+			Status: MOS.IMOSObjectAirStatus.READY,
+		} as MOS.IMOSROReadyToAir)
+		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
+			ID: new MOS.MosString128(rundown2.externalId),
+			Status: MOS.IMOSObjectAirStatus.READY,
+		} as MOS.IMOSROReadyToAir)
+		console.log(getRundown(rundown))
+		console.log(getRundown(rundown2))
+		console.log(getRundown(rundown).getRundownPlaylist())
+		console.log(getRundown(rundown2).getRundownPlaylist())
+		// Activate the rundown, make data updates and verify that it gets unsynced properly
+		ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlist._id, true)
+		console.log(getRundown(rundown))
+
+		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
+			ID: new MOS.MosString128(rundown.externalId),
+			Status: MOS.IMOSObjectAirStatus.NOT_READY,
+		} as MOS.IMOSROReadyToAir)
+		console.log(getRundown(rundown))
+
+		/*expect(getRundown(rundown3).unsynced).toEqual(false)
+
+		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData3.externalId)
+		console.log(getPlaylist().getRundownIDs())
+		expect(getRundown(rundown3).unsynced).toEqual(true)
+
+		// ServerRundownAPI.resyncRundownPlaylist(DEFAULT_CONTEXT, playlist._id)
+		resyncPlaylist()
+		expect(getRundown(rundown3).unsynced).toEqual(false)
+		*/
+		/* ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
+		const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
+		expect(partInstance).toHaveLength(1)
+		expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)
+
+		RundownInput.dataSegmentDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData.externalId,
+			segments[0].externalId
+		)
+		expect(getRundown().unsynced).toEqual(true)
+
+		resyncRundown(rundown)
+		expect(getRundown().unsynced).toEqual(false)
+
+		RundownInput.dataPartDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData.externalId,
+			segments[0].externalId,
+			parts[0].externalId
+		)
+		expect(getRundown().unsynced).toEqual(true)
+
+		resyncRundown(rundown)
+		expect(getRundown().unsynced).toEqual(false) */
+	})
+})
+
+/*
+000g</variant>
+<_valid>false</_valid>
+</content>
+</mosPayload>
+</mosExternalMetadata>
+<mosExternalMetadata><mosScope>PLAYLIST</mosScope>
+<mosSchema>https://nora.nrk.no/mos/timing</mosSchema>
+<mosPayload><timeIn>0</timeIn>
+<duration>8000</duration>
+
+<in>manual</in>
+<out>auto</out>
+</mosPayload>
+</mosExternalMetadata>
+</storyItem>
+<p>----------------------------------------------- </p>
+\r\n<p>Med p� report-it? </p>
+\r\n<p>Dra linje opp fra under strek. Den linjen som heter portrettbilde-splitt.</p>
+\r\n<p>Legg inn navn og bilde p� gjest i den malen.</p>
+\r\n<p>-----------------------------------------------</p>
+\r\n<p>Video:</p>
+\r\n<p>&lt;BTS&gt;&lt;</p>
+\r\n<p>&gt;</p>
+\r\n<p> </p>
+</storyBody>
+\r\n<mosExternalMetadata>\r\n<mosScope>PLAYLIST</mosScope>
+\r\n<mosSchema>http://MAENPSOSLO02:10505/schema/enps.dtd</mosSchema>
+\r\n<mosPayload>\r\n<Actual>0</Actual>
+\r\n<Approved>0</Approved>
+\r\n<Creator>N16426</Creator>
+\r\n<MediaTime>0</MediaTime>
+\r\n<ModBy>N16426</ModBy>
+\r\n<ModTime>20201113T120931Z</ModTime>
+\r\n<MOSItemDurations>\r\n\r\n\r\n\r\n</MOSItemDurations>
+\r\n<MOSItemEdDurations>\r\n\r\n\r\n\r\n</MOSItemEdDurations>
+\r\n<MOSObjSlugs>M: \r\nTema (00:00, Auto/OnNext): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig</MOSObjSlugs>
+\r\n<MOSSlugs>Uten tittel\r\nSak-1;Debatt 1-15\r\nhei-6\r\nhei-6\r\nhei-6</MOSSlugs>
+\r\n<MOSStatus>\r\n\r\n\r\n\r\n</MOSStatus>
+\r\n<Owner>N16426</Owner>
+\r\n<SourceMediaTime>0</SourceMediaTime>
+\r\n<SourceTextTime>0</SourceTextTime>
+\r\n<StoryLogPreview>&lt;\r\nTemasuper: \r\n-----------------------------------------------</StoryLogPreview>
+\r\n<TextTime>0</TextTime>
+\r\n<GUID>C076AE0A-E92D-43FD-88B4D81F31E7C5EC</GUID>
+\r\n<Kilde>sjekker </Kilde>
+\r\n<mosartType>KAM</mosartType>
+\r\n<mosartVariant>1</mosartVariant>
+\r\n<ReadTime>0</ReadTime>
+\r\n<ENPSItemType>3</ENPSItemType>
+\r\n</mosPayload>
+\r\n</mosExternalMetadata>
+\r\n</roStorySend>
+\r\n</mos>
+\r\n"}
+*/

--- a/meteor/server/api/ingest/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/ingest/__tests__/rundownPlaylist.test.ts
@@ -58,122 +58,9 @@ describe('Test ingest actions for rundowns and segments', () => {
 		)
 	})
 
-	testInFiber('unsyncing of rundown - one item list', () => {
-		// Cleanup any rundowns / playlists
-		RundownPlaylists.find()
-			.fetch()
-			.forEach((playlist) =>
-				wrapWithCacheForRundownPlaylist(playlist, (cache) => removeRundownPlaylistFromCache(cache, playlist))
-			)
-
-		const rundownData: IngestRundown = {
-			externalId: externalId,
-			name: 'MyMockRundown',
-			type: 'mock',
-			segments: [
-				{
-					externalId: 'segment0',
-					name: 'Segment 0',
-					rank: 0,
-					parts: [
-						{
-							externalId: 'part0',
-							name: 'Part 0',
-							rank: 0,
-						},
-						{
-							externalId: 'part1',
-							name: 'Part 1',
-							rank: 0,
-						},
-					],
-				},
-				{
-					externalId: 'segment1',
-					name: 'Segment 1',
-					rank: 0,
-					parts: [
-						{
-							externalId: 'part2',
-							name: 'Part 2',
-							rank: 0,
-						},
-					],
-				},
-			],
-		}
-
-		// Preparation: set up rundown
-		expect(Rundowns.findOne()).toBeFalsy()
-		Meteor.call(PeripheralDeviceAPIMethods.dataRundownCreate, device2._id, device2.token, rundownData)
-		const rundown = Rundowns.findOne() as Rundown
-		expect(rundown).toMatchObject({
-			externalId: rundownData.externalId,
-		})
-		const playlist = rundown.getRundownPlaylist()
-		expect(playlist).toBeTruthy()
-
-		const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
-		const getPlaylist = () => rundown.getRundownPlaylist() as RundownPlaylist
-		const resyncRundown = () => {
-			try {
-				ServerRundownAPI.resyncRundown(DEFAULT_CONTEXT, rundown._id)
-			} catch (e) {
-				if (e.toString().match(/does not support the method "reloadRundown"/)) {
-					// This is expected
-					return
-				}
-				throw e
-			}
-		}
-
-		const segments = getRundown().getSegments()
-		const parts = getRundown().getParts()
-
-		expect(segments).toHaveLength(2)
-		expect(parts).toHaveLength(3)
-
-		// Activate the rundown, make data updates and verify that it gets unsynced properly
-		ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlist._id, true)
-		expect(getRundown().unsynced).toEqual(false)
-
-		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData.externalId)
-		expect(getRundown().unsynced).toEqual(true)
-
-		resyncRundown()
-		expect(getRundown().unsynced).toEqual(false)
-
-		ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
-		const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
-		expect(partInstance).toHaveLength(1)
-		expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)
-
-		RundownInput.dataSegmentDelete(
-			DEFAULT_CONTEXT,
-			device2._id,
-			device2.token,
-			rundownData.externalId,
-			segments[0].externalId
-		)
-		expect(getRundown().unsynced).toEqual(true)
-
-		resyncRundown()
-		expect(getRundown().unsynced).toEqual(false)
-
-		RundownInput.dataPartDelete(
-			DEFAULT_CONTEXT,
-			device2._id,
-			device2.token,
-			rundownData.externalId,
-			segments[0].externalId,
-			parts[0].externalId
-		)
-		expect(getRundown().unsynced).toEqual(true)
-
-		resyncRundown()
-		expect(getRundown().unsynced).toEqual(false)
-	})
-
+	// Based on ingest.test.ts unsync test
+	// Test coverage that attempts to prevent a regression of R24 issue where 2nd,3rd... rundowns
+	// in an active and playing playlist could become unsynced from MOS and then not resync correctly.
 	testInFiber('unsyncing of rundown - three item playlist', () => {
 		// Cleanup any rundowns / playlists
 		RundownPlaylists.find()
@@ -307,7 +194,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 		expect(playlist.getRundowns()).toHaveLength(3)
 
 		const rundown2 = Rundowns.findOne({ externalId: externalId2 }) as Rundown
-		// const rundown3 = Rundowns.findOne({ externalId: externalId3 }) as Rundown
+		const rundown3 = Rundowns.findOne({ externalId: externalId3 }) as Rundown
 		// ServerRundownAPI.moveRundown(DEFAULT_CONTEXT, rundown2._id, playlist._id, [rundown._id, rundown2._id])
 		// ServerRundownAPI.moveRundown(DEFAULT_CONTEXT, rundown3._id, playlist._id, [rundown._id, rundown2._id, rundown3._id])
 		// expect(playlist.getRundowns()).toHaveLength(3)
@@ -349,115 +236,86 @@ describe('Test ingest actions for rundowns and segments', () => {
 			ID: new MOS.MosString128(rundown2.externalId),
 			Status: MOS.IMOSObjectAirStatus.READY,
 		} as MOS.IMOSROReadyToAir)
-		console.log(getRundown(rundown))
-		console.log(getRundown(rundown2))
-		console.log(getRundown(rundown).getRundownPlaylist())
-		console.log(getRundown(rundown2).getRundownPlaylist())
+		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
+			ID: new MOS.MosString128(rundown3.externalId),
+			Status: MOS.IMOSObjectAirStatus.READY,
+		} as MOS.IMOSROReadyToAir)
 		// Activate the rundown, make data updates and verify that it gets unsynced properly
 		ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlist._id, true)
-		console.log(getRundown(rundown))
+		ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
 
 		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
-			ID: new MOS.MosString128(rundown.externalId),
+			ID: new MOS.MosString128(rundown3.externalId),
 			Status: MOS.IMOSObjectAirStatus.NOT_READY,
 		} as MOS.IMOSROReadyToAir)
-		console.log(getRundown(rundown))
+		expect(getRundown(rundown3).airStatus).toEqual('NOT READY')
 
-		/*expect(getRundown(rundown3).unsynced).toEqual(false)
+		Meteor.call(PeripheralDeviceAPIMethods.mosRoReadyToAir, device2._id, device2.token, {
+			ID: new MOS.MosString128(rundown3.externalId),
+			Status: MOS.IMOSObjectAirStatus.READY,
+		} as MOS.IMOSROReadyToAir)
+		expect(getRundown(rundown3).airStatus).toEqual('READY')
 
-		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData3.externalId)
-		console.log(getPlaylist().getRundownIDs())
-		expect(getRundown(rundown3).unsynced).toEqual(true)
+		expect(getRundown(rundown).unsynced).toEqual(false)
+		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData.externalId)
+		expect(getRundown(rundown).unsynced).toEqual(true)
 
-		// ServerRundownAPI.resyncRundownPlaylist(DEFAULT_CONTEXT, playlist._id)
 		resyncPlaylist()
-		expect(getRundown(rundown3).unsynced).toEqual(false)
-		*/
-		/* ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
-		const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
-		expect(partInstance).toHaveLength(1)
-		expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)
+		expect(getRundown(rundown).unsynced).toEqual(false)
 
+		// Unsyncs on playing segment
 		RundownInput.dataSegmentDelete(
 			DEFAULT_CONTEXT,
 			device2._id,
 			device2.token,
 			rundownData.externalId,
-			segments[0].externalId
+			rundownData.segments[0].externalId
 		)
-		expect(getRundown().unsynced).toEqual(true)
+		expect(getRundown(rundown).unsynced).toEqual(true)
 
-		resyncRundown(rundown)
-		expect(getRundown().unsynced).toEqual(false)
+		resyncPlaylist()
+		expect(getRundown(rundown).unsynced).toEqual(false)
 
+		// Does not unsync on future playlist segment
+		RundownInput.dataSegmentDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData3.externalId,
+			rundownData3.segments[0].externalId
+		)
+		expect(getRundown(rundown3).unsynced).toEqual(false)
+
+		resyncPlaylist()
+		expect(getRundown(rundown3).unsynced).toEqual(false)
+		expect(getRundown(rundown3).getSegments()).toHaveLength(1)
+
+		// Does not get flustered by another change
+		RundownInput.dataSegmentDelete(
+			DEFAULT_CONTEXT,
+			device2._id,
+			device2.token,
+			rundownData3.externalId,
+			rundownData3.segments[1].externalId
+		)
+		expect(getRundown(rundown3).unsynced).toEqual(false)
+
+		resyncPlaylist()
+		expect(getRundown(rundown3).unsynced).toEqual(false)
+		expect(getRundown(rundown3).getSegments()).toHaveLength(0)
+
+		// Confirm that deleting a future part - stays in sync
 		RundownInput.dataPartDelete(
 			DEFAULT_CONTEXT,
 			device2._id,
 			device2.token,
-			rundownData.externalId,
-			segments[0].externalId,
-			parts[0].externalId
+			rundownData2.externalId,
+			rundownData2.segments[0].externalId,
+			rundownData2.segments[0].parts[0].externalId
 		)
-		expect(getRundown().unsynced).toEqual(true)
+		expect(getRundown(rundown2).unsynced).toEqual(false)
 
-		resyncRundown(rundown)
-		expect(getRundown().unsynced).toEqual(false) */
+		resyncPlaylist()
+		expect(getRundown(rundown2).unsynced).toEqual(false)
 	})
 })
-
-/*
-000g</variant>
-<_valid>false</_valid>
-</content>
-</mosPayload>
-</mosExternalMetadata>
-<mosExternalMetadata><mosScope>PLAYLIST</mosScope>
-<mosSchema>https://nora.nrk.no/mos/timing</mosSchema>
-<mosPayload><timeIn>0</timeIn>
-<duration>8000</duration>
-
-<in>manual</in>
-<out>auto</out>
-</mosPayload>
-</mosExternalMetadata>
-</storyItem>
-<p>----------------------------------------------- </p>
-\r\n<p>Med p� report-it? </p>
-\r\n<p>Dra linje opp fra under strek. Den linjen som heter portrettbilde-splitt.</p>
-\r\n<p>Legg inn navn og bilde p� gjest i den malen.</p>
-\r\n<p>-----------------------------------------------</p>
-\r\n<p>Video:</p>
-\r\n<p>&lt;BTS&gt;&lt;</p>
-\r\n<p>&gt;</p>
-\r\n<p> </p>
-</storyBody>
-\r\n<mosExternalMetadata>\r\n<mosScope>PLAYLIST</mosScope>
-\r\n<mosSchema>http://MAENPSOSLO02:10505/schema/enps.dtd</mosSchema>
-\r\n<mosPayload>\r\n<Actual>0</Actual>
-\r\n<Approved>0</Approved>
-\r\n<Creator>N16426</Creator>
-\r\n<MediaTime>0</MediaTime>
-\r\n<ModBy>N16426</ModBy>
-\r\n<ModTime>20201113T120931Z</ModTime>
-\r\n<MOSItemDurations>\r\n\r\n\r\n\r\n</MOSItemDurations>
-\r\n<MOSItemEdDurations>\r\n\r\n\r\n\r\n</MOSItemEdDurations>
-\r\n<MOSObjSlugs>M: \r\nTema (00:00, Auto/OnNext): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig\r\nNavn|Ett navn (00:08, Manual/Auto): vanlig</MOSObjSlugs>
-\r\n<MOSSlugs>Uten tittel\r\nSak-1;Debatt 1-15\r\nhei-6\r\nhei-6\r\nhei-6</MOSSlugs>
-\r\n<MOSStatus>\r\n\r\n\r\n\r\n</MOSStatus>
-\r\n<Owner>N16426</Owner>
-\r\n<SourceMediaTime>0</SourceMediaTime>
-\r\n<SourceTextTime>0</SourceTextTime>
-\r\n<StoryLogPreview>&lt;\r\nTemasuper: \r\n-----------------------------------------------</StoryLogPreview>
-\r\n<TextTime>0</TextTime>
-\r\n<GUID>C076AE0A-E92D-43FD-88B4D81F31E7C5EC</GUID>
-\r\n<Kilde>sjekker </Kilde>
-\r\n<mosartType>KAM</mosartType>
-\r\n<mosartVariant>1</mosartVariant>
-\r\n<ReadTime>0</ReadTime>
-\r\n<ENPSItemType>3</ENPSItemType>
-\r\n</mosPayload>
-\r\n</mosExternalMetadata>
-\r\n</roStorySend>
-\r\n</mos>
-\r\n"}
-*/

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -211,6 +211,31 @@ describe('Test recieved mos ingest payloads', () => {
 		expect(fixSnapshot(Parts.find({ rundownId: rundown._id }).fetch(), true)).toMatchSnapshot()
 	})
 
+	/* testInFiber('mosRoReadyToAir: ro not ready', () => {
+		const newStatus = MOS.IMOSObjectAirStatus.NOT_READY
+
+		let rundown = Rundowns.findOne() as Rundown
+		expect(rundown).toBeTruthy()
+		console.log(rundown)
+		expect(rundown.status).not.toEqual(newStatus.toString())
+
+		const payload = literal<MOS.IMOSROReadyToAir>({
+			ID: new MOS.MosString128(rundown.externalId),
+			Status: newStatus,
+		})
+
+		waitForPromise(MeteorCall.peripheralDevice.mosRoReadyToAir(device._id, device.token, payload))
+
+		rundown = Rundowns.findOne({ _id: rundown._id }) as Rundown
+		expect(rundown).toBeTruthy()
+		expect(rundown.airStatus).toEqual(newStatus.toString())
+
+		expect(fixSnapshot(RundownPlaylists.findOne(rundown.playlistId), true)).toMatchSnapshot()
+		expect(fixSnapshot(Rundowns.findOne(rundown._id), true)).toMatchSnapshot()
+		expect(fixSnapshot(Segments.find({ rundownId: rundown._id }).fetch(), true)).toMatchSnapshot()
+		expect(fixSnapshot(Parts.find({ rundownId: rundown._id }).fetch(), true)).toMatchSnapshot()
+	}) */
+
 	testInFiber('mosRoReadyToAir: Missing ro', () => {
 		const newStatus = MOS.IMOSObjectAirStatus.READY
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Additional test

* **What is the current behavior?** (You can also link to an open issue here)

Toggling playlists as _ready on air_ in ENPS causes unpredictable behavior in R24, including playlists becoming "unsynced" and not able to properly re-sync via GUI buttons. This test walks through the steps to avoid future regressions.

* **What is the new behavior (if this is a feature change)?**

Create a rundown playlist with 3 rundowns, activates the playlists, starts playing, keeps changing various data elements and checks that the rundowns stay in sync (or rather `unsync === false`).

* **Other information**:

Problem became apparent when dealing with rundown playlists for the first time in NRK national news rundowns.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
