### PR TITLE
fix: current rundown name

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -349,8 +349,12 @@ body.no-overflow {
 
 				&.rundown-name {
 					width: auto;
-					max-width: calc(30vw - 138px);
+					max-width: calc(40vw - 138px);
 					min-width: 100%;
+
+					> strong {
+						margin-right: 0.4em;
+					}
 				}
 			}
 
@@ -2131,6 +2135,11 @@ body.no-overflow {
 }
 
 .rundown-divider-timeline {
+	display: flex;
+	flex-wrap: wrap;
+	flex-direction: row;
+	align-items: stretch;
+	align-content: space-between;
 	overflow: hidden;
 	user-select: none;
 	-moz-user-select: none;
@@ -2159,8 +2168,18 @@ body.no-overflow {
 		display: inline-block;
 	}
 
+	> .rundown-divider-timeline__playlist-name {
+		margin: 0.7em 1em 0.4em 0; // center vertically
+		line-height: 1.2em;
+		font-size: 1.17em;
+		letter-spacing: 0px;
+		font-weight: 200;
+		hyphens: auto;
+		-webkit-hyphens: auto;
+		-ms-hyphens: auto;
+	}
+
 	> .rundown-divider-timeline__notifications-group {
-		display: inline-block;
 		vertical-align: bottom;
 		white-space: nowrap;
 		margin-bottom: 0.6em;
@@ -2168,7 +2187,6 @@ body.no-overflow {
 	}
 
 	.rundown-divider-timeline__notifications {
-		display: inline-block;
 		font-size: 0.8em;
 		font-weight: 400;
 		> svg {
@@ -2185,9 +2203,8 @@ body.no-overflow {
 
 	> .rundown-divider-timeline__expected-start,
 	> .rundown-divider-timeline__expected-duration {
-		display: inline-block;
-		vertical-align: top;
-		margin: 0.72em 0.5em 0.5em;
+		vertical-align: bottom;
+		margin: 1em 0.5em 0.5em;
 
 		> time {
 			font-weight: 600;
@@ -2200,7 +2217,7 @@ body.no-overflow {
 	}
 
 	> .rundown-divider-timeline__expected-duration {
-		float: right;
+		margin-left: auto;
 	}
 }
 

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -199,6 +199,7 @@ const WarningDisplay = withTranslation()(
 interface ITimingDisplayProps {
 	rundownPlaylist: RundownPlaylist
 	currentRundown: Rundown | undefined
+	rundownCount: number
 }
 
 export enum RundownViewKbdShortcuts {
@@ -231,8 +232,8 @@ const TimingDisplay = withTranslation()(
 	withTiming<ITimingDisplayProps & WithTranslation, {}>()(
 		class TimingDisplay extends React.Component<Translated<WithTiming<ITimingDisplayProps>>> {
 			private renderRundownName() {
-				const { rundownPlaylist, currentRundown } = this.props
-				return currentRundown ? (
+				const { rundownPlaylist, currentRundown, rundownCount } = this.props
+				return currentRundown && (rundownPlaylist.name !== currentRundown.name || rundownCount > 1) ? (
 					<span
 						className="timing-clock-label left hide-overflow rundown-name"
 						title={`${currentRundown.name} - ${rundownPlaylist.name}`}>
@@ -1207,7 +1208,11 @@ const RundownHeader = withTranslation()(
 										</NavLink>
 									</div>
 								</div>
-								<TimingDisplay rundownPlaylist={this.props.playlist} currentRundown={this.props.currentRundown} />
+								<TimingDisplay
+									rundownPlaylist={this.props.playlist}
+									currentRundown={this.props.currentRundown}
+									rundownCount={this.props.rundownIds.length}
+								/>
 								<RundownSystemStatus
 									studio={this.props.studio}
 									playlist={this.props.playlist}

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -5,9 +5,11 @@ import Moment from 'react-moment'
 import { withTiming, WithTiming } from './RundownTiming/withTiming'
 import { RundownUtils } from '../../lib/rundown'
 import { withTranslation } from 'react-i18next'
+import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 
 interface IProps {
 	rundown: Rundown
+	playlist: RundownPlaylist
 }
 
 interface ITrackedProps {
@@ -77,11 +79,12 @@ const RundownCountdown = withTranslation()(
 export const RundownDividerHeader = withTranslation()(
 	class RundownDividerHeader extends React.Component<Translated<IProps>> {
 		render() {
-			const { t } = this.props
+			const { t, rundown, playlist } = this.props
 			return (
 				<div className="rundown-divider-timeline">
-					<h2 className="rundown-divider-timeline__title">{this.props.rundown.name}</h2>
-					{this.props.rundown.expectedStart && (
+					<h2 className="rundown-divider-timeline__title">{rundown.name}</h2>
+					<h3 className="rundown-divider-timeline__playlist-name">{playlist.name}</h3>
+					{rundown.expectedStart && (
 						<div className="rundown-divider-timeline__expected-start">
 							<span>{t('Planned Start')}</span>&nbsp;
 							<Moment
@@ -89,19 +92,19 @@ export const RundownDividerHeader = withTranslation()(
 								calendar={{
 									sameElse: 'lll',
 								}}>
-								{this.props.rundown.expectedStart}
+								{rundown.expectedStart}
 							</Moment>
 							&nbsp;
 							<RundownCountdown
 								className="rundown-divider-timeline__expected-start__countdown"
-								expectedStart={this.props.rundown.expectedStart}
+								expectedStart={rundown.expectedStart}
 							/>
 						</div>
 					)}
-					{this.props.rundown.expectedDuration && (
+					{rundown.expectedDuration && (
 						<div className="rundown-divider-timeline__expected-duration">
 							<span>{t('Planned Duration')}</span>&nbsp;
-							<Moment interval={0} format="HH:mm:ss" date={this.props.rundown.expectedDuration} />
+							<Moment interval={0} format="HH:mm:ss" date={rundown.expectedDuration} />
 						</div>
 					)}
 				</div>

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4234,13 +4234,19 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.12.42"
+					"version": "12.12.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
+					"integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
 				},
 				"@types/underscore": {
-					"version": "1.10.23"
+					"version": "1.10.23",
+					"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.23.tgz",
+					"integrity": "sha512-vX1NPekXhrLquFWskH2thcvFAha187F/lM6xYOoEMZWwJ/6alSk0/ttmGP/YRqcqtCv0TMbZjYAdZyHAEcuU4g=="
 				},
 				"gh-pages": {
-					"version": "3.0.0"
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.0.0.tgz",
+					"integrity": "sha512-oaOfVcrSwnqoWUgZ6cmCDM6mUuWyOSG+SHjqxGBawN0F3SKaF5NwbeYDG+w2RNXO2HJ/5Iam4o7dP5NAtoHuwQ=="
 				},
 				"moment": {
 					"version": "2.29.1",
@@ -4249,17 +4255,23 @@
 				},
 				"timeline-state-resolver-types": {
 					"version": "5.2.0-nightly-release27-20201116-130832-ff186bba.0",
+					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.2.0-nightly-release27-20201116-130832-ff186bba.0.tgz",
+					"integrity": "sha512-W8fhajEo7UOQegB37+EcPJ/p9U4FB6ks+MAjwlA4tWv96lBSx/kaJTThhAK5opqcnFbG1xtWdvvyBVY0woGF4g==",
 					"requires": {
 						"tslib": "^1.13.0"
 					},
 					"dependencies": {
 						"tslib": {
-							"version": "1.13.0"
+							"version": "1.13.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+							"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 						}
 					}
 				},
 				"tslib": {
-					"version": "2.0.3"
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
 				},
 				"underscore": {
 					"version": "1.11.0",
@@ -17427,7 +17439,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix/feature change.

* **What is the current behavior?** (You can also link to an open issue here)

In the Rundown View, only the Playlist name is displayed.

* **What is the new behavior (if this is a feature change)?**

Now, the name of the rundown containing the Current Part (or the next, if no current) is shown, with the playlist name appended to it:

![obraz](https://user-images.githubusercontent.com/3635991/99569628-26282180-29d1-11eb-8e9e-106e4a26ca50.png)

If there is only a single rundown of the same name as the playlist, we fall back to existing behavior.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
