### PR TITLE
fix: better part instance simulation

### DIFF
--- a/meteor/__mocks__/_setupMocks.ts
+++ b/meteor/__mocks__/_setupMocks.ts
@@ -13,6 +13,7 @@ makeCompatible(Promise, Fiber)
 jest.mock('meteor/meteor', (...args) => require('./meteor').setup(args), { virtual: true })
 jest.mock('meteor/random', (...args) => require('./random').setup(args), { virtual: true })
 jest.mock('meteor/check', (...args) => require('./check').setup(args), { virtual: true })
+jest.mock('meteor/tracker', (...args) => require('./tracker').setup(args), { virtual: true })
 jest.mock('meteor/accounts-base', (...args) => require('./accounts-base').setup(args), { virtual: true })
 
 jest.mock('meteor/meteorhacks:picker', (...args) => require('./meteorhacks-picker').setup(args), { virtual: true })

--- a/meteor/__mocks__/tracker.ts
+++ b/meteor/__mocks__/tracker.ts
@@ -1,0 +1,113 @@
+/**
+ * This is a very rudimentary mock of a Meteor Tracker. It is quite likely buggy and may not accurately represent
+ * the order in which flags are turned on/off, since that's not clear from Meteor documentation.
+ * Also, all of the Tracker.flush() and related methods are not implemented.
+ */
+
+export namespace TrackerMock {
+	type ComputationCallback = (computation: Computation) => void
+	type AutorunCallback<T> = (computation: Computation) => T
+	export let currentComputation: Computation | null = null
+	export let active: boolean = false
+
+	export class Dependency {
+		private dependents: Computation[] = []
+		public changed = (): void => {
+			this.dependents.forEach((comp) => comp.invalidate())
+		}
+		public depend = (): void => {
+			if (TrackerMock.currentComputation) {
+				const comp = TrackerMock.currentComputation
+				if (comp) {
+					const length = this.dependents.push(comp)
+					comp.onStop(() => {
+						this.dependents.splice(length - 1, 1)
+					})
+				}
+			}
+		}
+		public hasDependents = (): boolean => {
+			return this.dependents.length > 0
+		}
+	}
+
+	export class Computation {
+		private onInvalidateClbs: Array<ComputationCallback> = []
+		private onStopClbs: Array<ComputationCallback> = []
+		stopped: boolean = false
+		invalidated: boolean = false
+		firstRun: boolean = true
+		parentComputation: Computation | null = null
+
+		private runAll = (clbs: Array<ComputationCallback>) => {
+			clbs.forEach((clb) => clb(this))
+		}
+		public stop = () => {
+			this.stopped = true
+			this.runAll(this.onInvalidateClbs)
+			this.onInvalidateClbs.length = 0
+			this.runAll(this.onStopClbs)
+			this.onStopClbs.length = 0
+			return
+		}
+		public invalidate = () => {
+			this.invalidated = true
+			this.runAll(this.onInvalidateClbs)
+			this.invalidated = false
+			return
+		}
+		public onInvalidate = (clb: ComputationCallback) => {
+			this.onInvalidateClbs.push(clb)
+		}
+		public onStop = (clb: ComputationCallback) => {
+			this.onStopClbs.push(clb)
+		}
+	}
+
+	export function autorun<T>(runFunc: AutorunCallback<T>, options = {}): T {
+		const comp = new TrackerMock.Computation()
+		comp.parentComputation = TrackerMock.currentComputation
+
+		TrackerMock.currentComputation = comp
+		TrackerMock.active = !!TrackerMock.currentComputation
+		const result = runFunc(comp)
+		comp.firstRun = false
+		comp.onInvalidate(() => {
+			runFunc(comp)
+		})
+		TrackerMock.currentComputation = comp.parentComputation
+		TrackerMock.active = !!TrackerMock.currentComputation
+
+		return result
+	}
+	export function flush() {
+		throw new Error(`Tracker.flush() is not implemented in the mock Tracker`)
+	}
+	export function nonreactive<T>(runFunc: () => T): T {
+		const comp = TrackerMock.currentComputation
+		TrackerMock.currentComputation = null
+		TrackerMock.active = !!TrackerMock.currentComputation
+		const result = runFunc()
+		TrackerMock.currentComputation = comp
+		TrackerMock.active = !!TrackerMock.currentComputation
+		return result
+	}
+	export function inFlush(): boolean {
+		throw new Error(`Tracker.inFlush() is not implemented in the mock Tracker`)
+	}
+	export function onInvalidate(clb: ComputationCallback) {
+		if (TrackerMock.currentComputation) {
+			TrackerMock.currentComputation.onInvalidate(clb)
+		}
+		return
+	}
+	export function afterFlush(clb: Function) {
+		throw new Error(`Tracker.afterFlush() is not implemented in the mock Tracker`)
+	}
+}
+
+export function setup() {
+	return {
+		Tracker: TrackerMock,
+	}
+}

--- a/meteor/client/lib/invalidatingTime.ts
+++ b/meteor/client/lib/invalidatingTime.ts
@@ -5,9 +5,14 @@ import { getCurrentTime } from '../../lib/lib'
 export function invalidateAfter(timeout: number): void {
 	const time = new Tracker.Dependency()
 	time.depend()
-	setTimeout(() => {
+	const t = setTimeout(() => {
 		time.changed()
 	}, timeout)
+	if (Tracker.currentComputation) {
+		Tracker.currentComputation.onInvalidate(() => {
+			clearTimeout(t)
+		})
+	}
 }
 
 /** Invalidate a reactive computation after when a given time is reached */

--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -227,14 +227,21 @@ export namespace RundownUtils {
 	 * @export
 	 * @param {ShowStyleBase} showStyleBase
 	 * @param {RundownPlaylist} playlist
-	 * @param {Segment} segment
+	 * @param {DBSegment} segment
+	 * @param {Set<SegmentId>} segmentsBeforeThisInRundownSet
+	 * @param {PartId[]} orderedAllPartIds
+	 * @param {boolean} [pieceInstanceSimulation=false] Can be used client-side to simulate the contents of a
+	 * 		PartInstance, whose contents are being streamed in. When ran in a reactive context, the computation will
+	 * 		be eventually invalidated so that the actual data can be streamed in (to show that the part is actually empty)
+	 * @return {*}  {({
 	 */
 	export function getResolvedSegment(
 		showStyleBase: ShowStyleBase,
 		playlist: RundownPlaylist,
 		segment: DBSegment,
 		segmentsBeforeThisInRundownSet: Set<SegmentId>,
-		orderedAllPartIds: PartId[]
+		orderedAllPartIds: PartId[],
+		pieceInstanceSimulation: boolean = false
 	): {
 		/** A Segment with some additional information */
 		segmentExtended: SegmentExtended
@@ -395,7 +402,8 @@ export namespace RundownUtils {
 							'piece.startedPlayback': 0,
 							'piece.timings': 0,
 						},
-					}
+					},
+					pieceInstanceSimulation
 				)
 
 				const partStarted = partE.instance.timings?.startedPlayback

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -149,7 +149,8 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			props.playlist,
 			segment,
 			props.segmentsIdsBefore,
-			props.orderedAllPartIds
+			props.orderedAllPartIds,
+			true
 		)
 		let notes: Array<SegmentNote> = []
 		o.parts.forEach((part) => {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -416,8 +416,6 @@ export const SegmentTimelinePart = withTranslation()(
 		}
 	})(
 		class SegmentTimelinePart0 extends React.Component<Translated<WithTiming<IProps>>, IState> {
-			private delayedInstanceUpdate: NodeJS.Timer | undefined
-
 			constructor(props: Translated<WithTiming<IProps>>) {
 				super(props)
 
@@ -575,38 +573,10 @@ export const SegmentTimelinePart = withTranslation()(
 				super.componentWillUnmount && super.componentWillUnmount()
 				window.removeEventListener(RundownViewEvents.highlight, this.onHighlight)
 				this.highlightTimeout && clearTimeout(this.highlightTimeout)
-				this.delayedInstanceUpdate && clearTimeout(this.delayedInstanceUpdate)
-			}
-
-			queueDelayedUpdate() {
-				this.delayedInstanceUpdate = setTimeout(() => {
-					this.delayedInstanceUpdate = undefined
-					this.forceUpdate()
-				}, 5000)
 			}
 
 			shouldComponentUpdate(nextProps: WithTiming<IProps>, nextState: IState) {
 				if (!_.isMatch(this.props, nextProps) || !_.isMatch(this.state, nextState)) {
-					if (this.delayedInstanceUpdate) clearTimeout(this.delayedInstanceUpdate)
-					if (
-						this.props.part.instance.isTemporary === true &&
-						nextProps.part.instance.isTemporary === false &&
-						this.props.part.pieces.length > 0 &&
-						nextProps.part.pieces.length === 0 &&
-						!nextProps.part.instance.part.invalid
-					) {
-						this.queueDelayedUpdate()
-						return false
-					} else if (
-						this.props.part.instance.isTemporary === false &&
-						nextProps.part.instance.isTemporary === false &&
-						this.props.part.pieces.length === 0 &&
-						nextProps.part.pieces.length === 0 &&
-						!nextProps.part.instance.part.invalid
-					) {
-						this.queueDelayedUpdate()
-						return false
-					}
 					return true
 				} else {
 					return false

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4255,6 +4255,8 @@
 				},
 				"timeline-state-resolver-types": {
 					"version": "5.2.0-nightly-release27-20201116-130832-ff186bba.0",
+					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.2.0-nightly-release27-20201116-130832-ff186bba.0.tgz",
+					"integrity": "sha512-W8fhajEo7UOQegB37+EcPJ/p9U4FB6ks+MAjwlA4tWv96lBSx/kaJTThhAK5opqcnFbG1xtWdvvyBVY0woGF4g==",
 					"requires": {
 						"tslib": "^1.13.0"
 					},
@@ -4267,7 +4269,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3"
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
 				},
 				"underscore": {
 					"version": "1.11.0",

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4234,13 +4234,19 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.12.42"
+					"version": "12.12.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
+					"integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
 				},
 				"@types/underscore": {
-					"version": "1.10.23"
+					"version": "1.10.23",
+					"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.23.tgz",
+					"integrity": "sha512-vX1NPekXhrLquFWskH2thcvFAha187F/lM6xYOoEMZWwJ/6alSk0/ttmGP/YRqcqtCv0TMbZjYAdZyHAEcuU4g=="
 				},
 				"gh-pages": {
-					"version": "3.0.0"
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.0.0.tgz",
+					"integrity": "sha512-oaOfVcrSwnqoWUgZ6cmCDM6mUuWyOSG+SHjqxGBawN0F3SKaF5NwbeYDG+w2RNXO2HJ/5Iam4o7dP5NAtoHuwQ=="
 				},
 				"moment": {
 					"version": "2.29.1",
@@ -4254,7 +4260,9 @@
 					},
 					"dependencies": {
 						"tslib": {
-							"version": "1.13.0"
+							"version": "1.13.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+							"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 						}
 					}
 				},
@@ -17427,7 +17435,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a fix/improvement.

* **What is the current behavior?** (You can also link to an open issue here)

When a PartInstance is instantiated, it may be that it's PieceInstances take a little bit to stream into the Client. In order to avoid an empty Part, the GUI keeps a Part unupdated for a little while, until the PieceInstances stream in. There may unfortunately be a little bit of a jank at the Segment level.

* **What is the new behavior (if this is a feature change)?**

The simulation of the PieceInstances is now moved to the `RundownUtils.getResolvedSegment` and it's internal functions. When using a simulation of a PartInstance's contents, a reactive dependency is registered to force the segment to be re-resolved after `X` time, though in general that's going to be probably canceled by the streamed in PieceInstances. Also, the simulation is only used if less than `X` time has passed since the partInstance has been taken/nexted, so that this doesn't go into an infinite loop.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
