### PR TITLE
fix: ignore "ResizeObserver loop limit exceeded" errors

### DIFF
--- a/meteor/client/lib/uncaughtErrorHandler.ts
+++ b/meteor/client/lib/uncaughtErrorHandler.ts
@@ -68,6 +68,8 @@ console.error = (...args: any[]) => {
 
 const originalOnError = window.onerror
 window.onerror = (event, source, line, col, error) => {
+	if (event && event.toString().match(/ResizeObserver loop limit exceeded/i)) return // This error is benign. https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+
 	try {
 		uncaughtErrorHandler({
 			event,

--- a/meteor/client/lib/uncaughtErrorHandler.ts
+++ b/meteor/client/lib/uncaughtErrorHandler.ts
@@ -66,9 +66,18 @@ console.error = (...args: any[]) => {
 	originalConsoleError(...args)
 }
 
+const IGNORED_ERRORS = [
+	// This error is benign. https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+	'ResizeObserver loop limit exceeded',
+].map((error) => new RegExp(error, 'i'))
+
 const originalOnError = window.onerror
 window.onerror = (event, source, line, col, error) => {
-	if (event && event.toString().match(/ResizeObserver loop limit exceeded/i)) return // This error is benign. https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+	if (event) {
+		const eventString = event.toString()
+		const ignored = IGNORED_ERRORS.find((errorPattern) => !!eventString.match(errorPattern))
+		if (ignored) return
+	}
 
 	try {
 		uncaughtErrorHandler({

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -17439,7 +17439,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},


### PR DESCRIPTION
This PR adds an ignore for the "ResizeObserver loop limit exceeded" error, to reduce noise in the logs.

The error is emitted for me when use `hover` feature of `rc-tooltip`. No issues in GUI are observed.

According to https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded the error is benign and can be ignored.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
