### PR TITLE
fix: Ingest performance in updateExpectedPlayoutItemsOnRundown

### DIFF
--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -77,8 +77,10 @@ export function updateExpectedPlayoutItemsOnRundown(cache: CacheForRundownPlayli
 	const adlibPiecesGrouped = _.groupBy(adlibPiecesInThisRundown, 'partId')
 
 	for (const part of cache.Parts.findFetch({ rundownId: rundown._id })) {
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)]))
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)]))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)] || []))
+		intermediaryItems.push(
+			...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)] || [])
+		)
 	}
 
 	cache.deferAfterSave(() => {

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -7,7 +7,7 @@ import { DBRundown, RundownId } from '../../../lib/collections/Rundowns'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { logger } from '../../logging'
 import { PartId, DBPart } from '../../../lib/collections/Parts'
-import { saveIntoDb, protectString } from '../../../lib/lib'
+import { saveIntoDb, protectString, unprotectString } from '../../../lib/lib'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { getAllPiecesFromCache, getAllAdLibPiecesFromCache } from '../playout/lib'
 
@@ -66,9 +66,19 @@ export function updateExpectedPlayoutItemsOnRundown(cache: CacheForRundownPlayli
 
 	const intermediaryItems: ExpectedPlayoutItemGenericWithPiece[] = []
 
+	const piecesStartingInThisRundown = cache.Pieces.findFetch({
+		startRundownId: rundown._id,
+	})
+	const piecesGrouped = _.groupBy(piecesStartingInThisRundown, 'startPartId')
+
+	const adlibPiecesInThisRundown = cache.AdLibPieces.findFetch({
+		rundownId: rundown._id,
+	})
+	const adlibPiecesGrouped = _.groupBy(adlibPiecesInThisRundown, 'partId')
+
 	for (const part of cache.Parts.findFetch({ rundownId: rundown._id })) {
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, getAllPiecesFromCache(cache, part)))
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, getAllAdLibPiecesFromCache(cache, part)))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)]))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)]))
 	}
 
 	cache.deferAfterSave(() => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a performance issue related to updating ExpectedPlayoutItems, that is done in `updateExpectedPlayoutItemsOnRundown`, called at the end of the ingest methods.


* **What is the current behavior?** (You can also link to an open issue here)
`getAllPiecesFromCache` and `getAllAdLibPiecesFromCache`, performing `findFetch` on the cached collections, are executed for every Part, which makes the whole process extremely slow for long rundown because of the need for iterating over all the Pieces and AdlibPieces multiple times. O(m x n)


* **What is the new behavior (if this is a feature change)?**
Pieces and AdLibPieces are fetched and grouped by their `startPartId` or `partId`. O(n)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
