### PR TITLE
fix: Hide/disable buttons for user without studio permissions

### DIFF
--- a/meteor/client/lib/localStorage.ts
+++ b/meteor/client/lib/localStorage.ts
@@ -1,7 +1,7 @@
 import { Settings } from '../../lib/Settings'
 import { getUserRoles } from '../../lib/collections/Users'
 
-enum UiAllowAccess {
+enum LocalStorageProperty {
 	STUDIO = 'studioMode',
 	CONFIGURE = 'configureMode',
 	DEVELOPER = 'developerMode',
@@ -11,57 +11,59 @@ enum UiAllowAccess {
 }
 
 export function setAllowStudio(studioMode: boolean) {
-	localStorage.setItem(UiAllowAccess.STUDIO, studioMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.STUDIO, studioMode ? '1' : '0')
 }
 export function getAllowStudio(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().studio
 	}
-	return localStorage.getItem(UiAllowAccess.STUDIO) === '1'
+	return localStorage.getItem(LocalStorageProperty.STUDIO) === '1'
 }
 
 export function setAllowConfigure(configureMode: boolean) {
-	localStorage.setItem(UiAllowAccess.CONFIGURE, configureMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.CONFIGURE, configureMode ? '1' : '0')
 }
 export function getAllowConfigure(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().configurator
 	}
-	return localStorage.getItem(UiAllowAccess.CONFIGURE) === '1'
+	return localStorage.getItem(LocalStorageProperty.CONFIGURE) === '1'
 }
 
 export function setAllowService(serviceMode: boolean) {
-	localStorage.setItem(UiAllowAccess.SERVICE, serviceMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.SERVICE, serviceMode ? '1' : '0')
 }
 export function getAllowService(): boolean {
-	return localStorage.getItem(UiAllowAccess.SERVICE) === '1'
+	return localStorage.getItem(LocalStorageProperty.SERVICE) === '1'
 }
 
 export function setAllowDeveloper(developerMode: boolean) {
-	localStorage.setItem(UiAllowAccess.DEVELOPER, developerMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.DEVELOPER, developerMode ? '1' : '0')
 }
 export function getAllowDeveloper(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().developer
 	}
-	return localStorage.getItem(UiAllowAccess.DEVELOPER) === '1'
+	return localStorage.getItem(LocalStorageProperty.DEVELOPER) === '1'
 }
 
 export function setAllowTesting(testingMode: boolean) {
-	localStorage.setItem(UiAllowAccess.TESTING, testingMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.TESTING, testingMode ? '1' : '0')
 }
 export function getAllowTesting(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().developer
 	}
-	return localStorage.getItem(UiAllowAccess.TESTING) === '1'
+	return localStorage.getItem(LocalStorageProperty.TESTING) === '1'
 }
 
+// GUI features: ----------------------------------
+
 export function setAllowSpeaking(speakingMode: boolean) {
-	localStorage.setItem(UiAllowAccess.SPEAKING, speakingMode ? '1' : '0')
+	localStorage.setItem(LocalStorageProperty.SPEAKING, speakingMode ? '1' : '0')
 }
 export function getAllowSpeaking(): boolean {
-	return localStorage.getItem(UiAllowAccess.SPEAKING) === '1'
+	return localStorage.getItem(LocalStorageProperty.SPEAKING) === '1'
 }
 
 export function setHelpMode(helpMode: boolean) {

--- a/meteor/client/lib/notifications/NotificationCenterPanel.tsx
+++ b/meteor/client/lib/notifications/NotificationCenterPanel.tsx
@@ -80,6 +80,7 @@ class NotificationPopUp extends React.Component<IPopUpProps> {
 							{defaultAction ? (
 								<div className="notification-pop-up__actions--default">
 									<button
+										disabled={defaultAction.disabled}
 										className="btn btn-default notification-pop-up__actions--button"
 										onClick={(e) => this.triggerEvent(defaultAction, e)}>
 										<CoreIcon.NrkArrowLeft
@@ -96,6 +97,7 @@ class NotificationPopUp extends React.Component<IPopUpProps> {
 									{_.map(allActions, (action: NotificationAction, i: number) => {
 										return (
 											<button
+												disabled={action.disabled}
 												key={i}
 												className={ClassNames(
 													'btn',

--- a/meteor/client/lib/notifications/notifications.ts
+++ b/meteor/client/lib/notifications/notifications.ts
@@ -42,6 +42,8 @@ export interface NotificationAction {
 	icon?: any
 	/** The method that will be called when the user takes the aciton. */
 	action?: Function
+	/** If true, will disable the action (ie the button will show, but not clickable). */
+	disabled?: boolean
 }
 
 /** A source of notifications */

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -4,6 +4,7 @@ import { withTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { INoteBase, NoteType } from '../../../lib/api/notes'
 import { Rundown } from '../../../lib/collections/Rundowns'
+import { getAllowStudio } from '../../lib/localStorage'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { RundownUtils } from '../../lib/rundown'
 import { iconDragHandle, iconRemove, iconResync } from './icons'
@@ -54,16 +55,18 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 	return connectDropTarget(
 		<li id={htmlElementId} className={classNames.join(' ')}>
 			<span className="rundown-list-item__name">
-				{connectDragSource(
-					<span className="draghandle">
-						<Tooltip
-							overlay={t('Drag to reorder or move out of playlist')}
-							placement="top"
-							overlayStyle={{ display: props.renderTooltips ? undefined : 'none' }}>
-							<button className="rundown-list-item__action">{iconDragHandle()}</button>
-						</Tooltip>
-					</span>
-				)}
+				{getAllowStudio()
+					? connectDragSource(
+							<span className="draghandle">
+								<Tooltip
+									overlay={t('Drag to reorder or move out of playlist')}
+									placement="top"
+									overlayStyle={{ display: props.renderTooltips ? undefined : 'none' }}>
+									<button className="rundown-list-item__action">{iconDragHandle()}</button>
+								</Tooltip>
+							</span>
+					  )
+					: null}
 				<b className="rundown-name">{rundownNameContent}</b>
 				{isActive === true ? (
 					<Tooltip overlay={t('This rundown is currently active')} placement="bottom">

--- a/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
@@ -34,6 +34,7 @@ import { MeteorCall } from '../../../lib/api/methods'
 import { RundownUtils } from '../../lib/rundown'
 import PlaylistRankMethodToggle from './PlaylistRankMethodToggle'
 import JonasFormattedTime from './JonasFormattedTime'
+import { getAllowConfigure, getAllowService, getAllowStudio } from '../../lib/localStorage'
 
 export interface RundownPlaylistUi extends RundownPlaylist {
 	rundowns: Rundown[]
@@ -306,12 +307,14 @@ export const RundownPlaylistUi = DropTarget(
 										<Link to={playlistViewURL}>{playlist.name}</Link>
 									</span>
 								</h2>
-								<PlaylistRankMethodToggle
-									manualSortingActive={playlist.rundownRanksAreSetInSofie === true}
-									toggleCallbackHandler={() => {
-										this.handleResetRundownOrderClick()
-									}}
-								/>
+								{getAllowStudio() ? (
+									<PlaylistRankMethodToggle
+										manualSortingActive={playlist.rundownRanksAreSetInSofie === true}
+										toggleCallbackHandler={() => {
+											this.handleResetRundownOrderClick()
+										}}
+									/>
+								) : null}
 							</span>
 							<span className="rundown-list-item__text">
 								{playlist.expectedStart ? (

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2808,6 +2808,7 @@ export function handleRundownReloadResponse(
 					{
 						label: t('Leave it in Sofie (mark the rundown as unsynced)'),
 						type: 'default',
+						disabled: !getAllowStudio(),
 						action: () => {
 							doUserAction(
 								t,

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -37,6 +37,7 @@ import { MeteorCall } from '../../../lib/api/methods'
 import { getSegmentPartNotes } from '../../../lib/rundownNotifications'
 import { RankedNote, IMediaObjectIssue } from '../../../lib/api/rundownNotifications'
 import { Settings } from '../../../lib/Settings'
+import { getAllowStudio } from '../../lib/localStorage'
 
 export const onRONotificationClick = new ReactiveVar<((e: RONotificationEvent) => void) | undefined>(undefined)
 export const reloadRundownPlaylistClick = new ReactiveVar<((e: any) => void) | undefined>(undefined)
@@ -196,6 +197,7 @@ class RundownViewNotifier extends WithManagedTracker {
 								{
 									label: t('Re-sync'),
 									type: 'primary',
+									disabled: !getAllowStudio(),
 									action: () => {
 										doModalDialog({
 											title: t('Re-sync Rundown'),
@@ -311,6 +313,7 @@ class RundownViewNotifier extends WithManagedTracker {
 										{
 											label: t('Restart'),
 											type: 'primary',
+											disabled: !getAllowStudio(),
 											action: () => {
 												doModalDialog({
 													title: t('Restart {{device}}', { device: parent.name }),
@@ -701,12 +704,14 @@ class RundownViewNotifier extends WithManagedTracker {
 						`rundownPlaylist_${playlistId}`,
 						getCurrentTime(),
 						true,
+
 						[
 							{
 								label: t('Reload {{nrcsName}} Data', {
 									nrcsName: (firstRundown && firstRundown.externalNRCSName) || 'NRCS',
 								}),
 								type: 'primary',
+								disabled: !getAllowStudio(),
 								action: (e) => {
 									const reloadFunc = reloadRundownPlaylistClick.get()
 									if (reloadFunc) {

--- a/meteor/client/ui/Status/MediaManager.tsx
+++ b/meteor/client/ui/Status/MediaManager.tsx
@@ -20,6 +20,7 @@ import { doUserAction, UserAction } from '../../lib/userAction'
 import { MeteorCall } from '../../../lib/api/methods'
 import Tooltip from 'rc-tooltip'
 import { MediaManagerAPI } from '../../../lib/api/mediaManager'
+import { getAllowConfigure, getAllowStudio } from '../../lib/localStorage'
 
 interface IMediaManagerStatusProps {}
 
@@ -434,12 +435,16 @@ export const MediaManagerStatus = translateWithTracker<IMediaManagerStatusProps,
 						<h1>{t('Media Transfer Status')}</h1>
 					</header>
 					<div className="mod mvl alright">
-						<button className="btn btn-secondary mls" onClick={this.actionAbortAll}>
-							{t('Abort All')}
-						</button>
-						<button className="btn btn-secondary mls" onClick={this.actionRestartAll}>
-							{t('Restart All')}
-						</button>
+						{getAllowStudio() || getAllowConfigure() ? (
+							<React.Fragment>
+								<button className="btn btn-secondary mls" onClick={this.actionAbortAll}>
+									{t('Abort All')}
+								</button>
+								<button className="btn btn-secondary mls" onClick={this.actionRestartAll}>
+									{t('Restart All')}
+								</button>
+							</React.Fragment>
+						) : null}
 					</div>
 					<div className="mod mvl">{this.renderWorkFlows()}</div>
 				</div>

--- a/meteor/client/ui/Status/SystemStatus.tsx
+++ b/meteor/client/ui/Status/SystemStatus.tsx
@@ -15,7 +15,7 @@ import { doModalDialog } from '../../lib/ModalDialog'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { callPeripheralDeviceFunction, PeripheralDevicesAPI } from '../../lib/clientAPI'
 import { NotificationCenter, NoticeLevel, Notification } from '../../lib/notifications/notifications'
-import { getAllowConfigure, getAllowDeveloper, getHelpMode } from '../../lib/localStorage'
+import { getAllowConfigure, getAllowDeveloper, getAllowStudio, getHelpMode } from '../../lib/localStorage'
 import { PubSub } from '../../../lib/api/pubsub'
 import ClassNames from 'classnames'
 import { TSR } from 'tv-automation-sofie-blueprints-integration'
@@ -239,7 +239,8 @@ export const DeviceItem = reacti18next.withTranslation()(
 
 					<div className="actions-container">
 						<div className="device-item__actions">
-							{this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
+							{getAllowStudio() &&
+							this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
 							this.props.device.subType === TSR.DeviceType.CASPARCG ? (
 								<React.Fragment>
 									<button
@@ -254,7 +255,8 @@ export const DeviceItem = reacti18next.withTranslation()(
 									</button>
 								</React.Fragment>
 							) : null}
-							{this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
+							{getAllowStudio() &&
+							this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
 							this.props.device.subType === TSR.DeviceType.HYPERDECK ? (
 								<React.Fragment>
 									<button
@@ -268,7 +270,8 @@ export const DeviceItem = reacti18next.withTranslation()(
 									</button>
 								</React.Fragment>
 							) : null}
-							{this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
+							{getAllowStudio() &&
+							this.props.device.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
 							this.props.device.subType === TSR.DeviceType.QUANTEL ? (
 								<React.Fragment>
 									<button
@@ -282,7 +285,7 @@ export const DeviceItem = reacti18next.withTranslation()(
 									</button>
 								</React.Fragment>
 							) : null}
-							{getAllowDeveloper() && (
+							{getAllowDeveloper() ? (
 								<button
 									key="button-ignore"
 									className={ClassNames('btn btn-secondary', {
@@ -295,8 +298,8 @@ export const DeviceItem = reacti18next.withTranslation()(
 									}}>
 									<FontAwesomeIcon icon={faEye} />
 								</button>
-							)}
-							{this.props.showRemoveButtons && (
+							) : null}
+							{this.props.showRemoveButtons ? (
 								<button
 									key="button-device"
 									className="btn btn-primary"
@@ -320,8 +323,8 @@ export const DeviceItem = reacti18next.withTranslation()(
 									}}>
 									<FontAwesomeIcon icon={faTrash} />
 								</button>
-							)}
-							{this.props.device.subType === PeripheralDeviceAPI.SUBTYPE_PROCESS ? (
+							) : null}
+							{getAllowStudio() && this.props.device.subType === PeripheralDeviceAPI.SUBTYPE_PROCESS ? (
 								<React.Fragment>
 									<button
 										className="btn btn-secondary"
@@ -340,7 +343,9 @@ export const DeviceItem = reacti18next.withTranslation()(
 																new Notification(
 																	undefined,
 																	NoticeLevel.NOTIFICATION,
-																	t('Device "{{deviceName}}" restarting...', { deviceName: this.props.device.name }),
+																	t('Device "{{deviceName}}" restarting...', {
+																		deviceName: this.props.device.name,
+																	}),
 																	'SystemStatus'
 																)
 															)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR hides / disables a number of buttons & functions for users that doesn't have studio permissions.

Most notable are:
* Buttons in Notifications are now disabled
* Reordering (dragging) of rundowns is now disabled
* Device-buttons in status view are hidden

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
