### PR TITLE
feat: show inspector on collapsed layers

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1685,6 +1685,12 @@ body.no-overflow {
 								}
 							}
 						}
+
+						&.layer-count-1 {
+							.segment-timeline__layer {
+								max-height: $segment-layer-height / 2;
+							}
+						}
 					}
 				}
 			}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -248,7 +248,7 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 	static whyDidYouRender = true
 
 	renderInside(isOutputGroupCollapsed) {
-		if (this.props.layer.sourceLayers !== undefined) {
+		if (this.props.sourceLayers !== undefined) {
 			if (!this.props.layer.isFlattened) {
 				return this.props.sourceLayers.map((sourceLayer, index) => {
 					return (
@@ -324,12 +324,18 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 				: this.props.layer.isDefaultCollapsed
 		return (
 			<div
-				className={ClassNames('segment-timeline__output-group', {
-					collapsable:
-						this.props.layer.sourceLayers && this.props.layer.sourceLayers.length > 1 && !this.props.layer.isFlattened,
-					collapsed: isCollapsed,
-					flattened: this.props.layer.isFlattened,
-				})}>
+				className={ClassNames(
+					'segment-timeline__output-group',
+					{
+						collapsable:
+							this.props.layer.sourceLayers &&
+							this.props.layer.sourceLayers.length > 1 &&
+							!this.props.layer.isFlattened,
+						collapsed: isCollapsed,
+						flattened: this.props.layer.isFlattened,
+					},
+					`layer-count-${this.props.sourceLayers?.length || 0}`
+				)}>
 				{DEBUG_MODE && (
 					<div className="segment-timeline__debug-info red">
 						{RundownUtils.formatTimeToTimecode(this.props.startsAt)}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -533,6 +533,9 @@ export const SourceLayerItem = withTranslation()(
 			return
 		}
 
+		toggleMiniInspectorOn = (e: React.MouseEvent) => this.toggleMiniInspector(e, true)
+		toggleMiniInspectorOff = (e: React.MouseEvent) => this.toggleMiniInspector(e, false)
+
 		toggleMiniInspector = (e: MouseEvent | any, v: boolean) => {
 			this.setState({
 				showMiniInspector: v,
@@ -736,9 +739,9 @@ export const SourceLayerItem = withTranslation()(
 						onClick={this.itemClick}
 						onDoubleClick={this.itemDblClick}
 						onMouseUp={this.itemMouseUp}
-						onMouseMove={(e) => this.moveMiniInspector(e)}
-						onMouseOver={(e) => !this.props.outputGroupCollapsed && this.toggleMiniInspector(e, true)}
-						onMouseLeave={(e) => this.toggleMiniInspector(e, false)}
+						onMouseMove={this.moveMiniInspector}
+						onMouseOver={this.toggleMiniInspectorOn}
+						onMouseLeave={this.toggleMiniInspectorOff}
 						style={this.getItemStyle()}>
 						{this.renderInsideItem(typeClass)}
 						{DEBUG_MODE && (


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A change of UX

* **What is the current behavior?** (You can also link to an open issue here)

When an output group is collapsed, hoverscrub is disabled.

* **What is the new behavior (if this is a feature change)?**

The hoverscrub should always be available, regardless of collapsed state. Also, when an output group is collapsed and it only has a single source layer present, the items in that layer will no longer span the entire height of the output group, but instead show up using only half of the height.

![obraz](https://user-images.githubusercontent.com/3635991/100442891-12ec1480-30a9-11eb-9b49-f8bcac9c4632.png)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
