### PR TITLE
fix: evaluate transition properties when leaving part

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -34,12 +34,6 @@ export function unprotectPartInstance(partInstance: PartInstance): IBlueprintPar
 	return partInstance as any
 }
 
-export interface TransformTransitionProps {
-	allowed: boolean
-	preroll?: number
-	transitionPreroll?: number | null
-	transitionKeepalive?: number | null
-}
 export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	_id: PartInstanceId
 	rundownId: RundownId
@@ -65,7 +59,7 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	previousPartEndState?: PartEndState
 
 	/** The transition props as used when entering this PartInstance */
-	transProps?: TransformTransitionProps
+	allowedToUseTransition?: boolean
 }
 
 export interface PartInstanceTimings extends IBlueprintPartInstanceTimings {
@@ -99,7 +93,7 @@ export class PartInstance implements DBPartInstance {
 	public segmentId: SegmentId
 	public rundownId: RundownId
 
-	public transProps?: TransformTransitionProps
+	public allowedToUseTransition?: boolean
 
 	constructor(document: DBPartInstance, isTemporary?: boolean) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -34,6 +34,12 @@ export function unprotectPartInstance(partInstance: PartInstance): IBlueprintPar
 	return partInstance as any
 }
 
+export interface TransformTransitionProps {
+	allowed: boolean
+	preroll?: number
+	transitionPreroll?: number | null
+	transitionKeepalive?: number | null
+}
 export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	_id: PartInstanceId
 	rundownId: RundownId
@@ -57,6 +63,9 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 
 	/** The end state of the previous part, to allow for bits of this to part to be based on what the previous did/was */
 	previousPartEndState?: PartEndState
+
+	/** The transition props as used when entering this PartInstance */
+	transProps?: TransformTransitionProps
 }
 
 export interface PartInstanceTimings extends IBlueprintPartInstanceTimings {
@@ -89,6 +98,8 @@ export class PartInstance implements DBPartInstance {
 	public _id: PartInstanceId
 	public segmentId: SegmentId
 	public rundownId: RundownId
+
+	public transProps?: TransformTransitionProps
 
 	constructor(document: DBPartInstance, isTemporary?: boolean) {
 		_.each(_.keys(document), (key) => {

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -196,10 +196,7 @@ export function takeNextPartInnerSync(
 			'timings.take': now,
 			'timings.playOffset': timeOffset || 0,
 			// set transition properties to what will be used to generate timeline later:
-			'transProps.allowed': currentPartInstance ? !currentPartInstance.part.disableOutTransition : false,
-			'transProps.preroll': partInstance.part.prerollDuration,
-			'transProps.transitionPreroll': partInstance.part.transitionPrerollDuration,
-			'transProps.transitionKeepalive': partInstance.part.transitionKeepaliveDuration,
+			allowedToUseTransition: currentPartInstance && !currentPartInstance.part.disableOutTransition,
 		},
 		$unset: {} as { string: 0 | 1 },
 	}

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -195,6 +195,11 @@ export function takeNextPartInnerSync(
 			isTaken: true,
 			'timings.take': now,
 			'timings.playOffset': timeOffset || 0,
+			// set transition properties to what will be used to generate timeline later:
+			'transProps.allowed': currentPartInstance ? !currentPartInstance.part.disableOutTransition : false,
+			'transProps.preroll': partInstance.part.prerollDuration,
+			'transProps.transitionPreroll': partInstance.part.transitionPrerollDuration,
+			'transProps.transitionKeepalive': partInstance.part.transitionKeepaliveDuration,
 		},
 		$unset: {} as { string: 0 | 1 },
 	}

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -45,7 +45,7 @@ import { Part, PartId } from '../../../lib/collections/Parts'
 import { prefixAllObjectIds, getSelectedPartInstancesFromCache } from './lib'
 import { createPieceGroupFirstObject, getResolvedPiecesFromFullTimeline } from './pieces'
 import { PackageInfo } from '../../coreSystem'
-import { PartInstance, PartInstanceId } from '../../../lib/collections/PartInstances'
+import { PartInstance, PartInstanceId, TransformTransitionProps } from '../../../lib/collections/PartInstances'
 import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { CacheForRundownPlaylist, CacheForStudioBase } from '../../DatabaseCaches'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
@@ -490,6 +490,10 @@ function buildTimelineObjsForRundown(
 
 				const groupClasses: string[] = ['previous_part']
 				let prevObjs: Array<TimelineObjRundown & OnGenerateTimelineObjExt> = [previousPartGroup]
+				let previousTransProps: TransformTransitionProps | undefined = undefined
+				if (partInstancesInfo.previous.partInstance.transProps) {
+					previousTransProps = partInstancesInfo.previous.partInstance.transProps
+				}
 				prevObjs = prevObjs.concat(
 					transformPartIntoTimeline(
 						activePlaylist._id,
@@ -499,7 +503,7 @@ function buildTimelineObjsForRundown(
 						previousPartGroup,
 						partInstancesInfo.previous.nowInPart,
 						false,
-						undefined,
+						previousTransProps,
 						activePlaylist.holdState
 					)
 				)
@@ -777,13 +781,6 @@ function transformBaselineItemsIntoTimeline(
 		})
 	})
 	return timelineObjs
-}
-
-interface TransformTransitionProps {
-	allowed: boolean
-	preroll?: number
-	transitionPreroll?: number | null
-	transitionKeepalive?: number | null
 }
 
 export function hasPieceInstanceDefinitelyEnded(


### PR DESCRIPTION
A transition on a part can delay pieces inside that part. When leaving the part the overlap with the next part is calculated, during said calculation we need to consider the transition properties such that the timing of the pieces will remain correct. In order to do this without looking at the previous previous part we should save these transition properties on the part instances.

This PR changes:
 * Save the transition properties on the part instance during a take
 * Consider the transition properties during transformation from the _previous_ part to timeline