### PR TITLE
fix: return clientResponseError when normal operations instead of throwing in disableNextPiece

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -672,12 +672,34 @@ const RundownHeader = withTranslation()(
 			this.takeRundownSnapshot(e)
 		}
 
+		handleDisableNextPiece = (err: ClientAPI.ClientResponse<undefined>) => {
+			if (ClientAPI.isClientResponseError(err)) {
+				const { t } = this.props
+
+				if (err.error === 404) {
+					NotificationCenter.push(
+						new Notification(
+							undefined,
+							NoticeLevel.WARNING,
+							t('Could not find a Piece that can be disabled.'),
+							'userAction'
+						)
+					)
+					return false
+				}
+			}
+		}
+
 		disableNextPiece = (e: any) => {
 			const { t } = this.props
 
 			if (this.props.studioMode) {
-				doUserAction(t, e, UserAction.DISABLE_NEXT_PIECE, (e) =>
-					MeteorCall.userAction.disableNextPiece(e, this.props.playlist._id, false)
+				doUserAction(
+					t,
+					e,
+					UserAction.DISABLE_NEXT_PIECE,
+					(e) => MeteorCall.userAction.disableNextPiece(e, this.props.playlist._id, false),
+					this.handleDisableNextPiece
 				)
 			}
 		}
@@ -686,8 +708,12 @@ const RundownHeader = withTranslation()(
 			const { t } = this.props
 
 			if (this.props.studioMode) {
-				doUserAction(t, e, UserAction.DISABLE_NEXT_PIECE, (e) =>
-					MeteorCall.userAction.disableNextPiece(e, this.props.playlist._id, true)
+				doUserAction(
+					t,
+					e,
+					UserAction.DISABLE_NEXT_PIECE,
+					(e) => MeteorCall.userAction.disableNextPiece(e, this.props.playlist._id, true),
+					this.handleDisableNextPiece
 				)
 			}
 		}

--- a/meteor/lib/api/__tests__/client.test.ts
+++ b/meteor/lib/api/__tests__/client.test.ts
@@ -1,0 +1,73 @@
+import { ClientAPI } from '../client'
+import { Meteor } from 'meteor/meteor'
+
+describe('ClientAPI', () => {
+	it('Creates a responseSuccess object', () => {
+		const mockSuccessValue = {
+			someData: 'someValue',
+		}
+		const response = ClientAPI.responseSuccess(mockSuccessValue)
+		expect(response).toMatchObject({
+			success: 200,
+			result: mockSuccessValue,
+		})
+	})
+	it('Creates a responseError object', () => {
+		const mockErrorDetail = {
+			someData: 'someValue',
+		}
+		const mockErrorMessage = 'Some error'
+
+		{
+			const error = ClientAPI.responseError(420, mockErrorMessage, mockErrorDetail)
+			expect(error).toMatchObject({
+				error: 420,
+				message: mockErrorMessage,
+				details: mockErrorDetail,
+			})
+		}
+
+		{
+			const error = ClientAPI.responseError(mockErrorMessage)
+			expect(error).toMatchObject({
+				error: 500,
+				message: mockErrorMessage,
+				details: undefined,
+			})
+		}
+	})
+	describe('isClientResponseSuccess', () => {
+		it('Correctly recognizes a responseSuccess object', () => {
+			const response = ClientAPI.responseSuccess(undefined)
+			expect(ClientAPI.isClientResponseSuccess(response)).toBe(true)
+		})
+		it('Correctly recognizes a not-success object', () => {
+			const response = ClientAPI.responseError('Some error')
+			expect(ClientAPI.isClientResponseSuccess(response)).toBe(false)
+		})
+		it('Correctly recognizes that a Meteor.Error is not a success object', () => {
+			try {
+				throw new Meteor.Error(404)
+			} catch (e) {
+				expect(ClientAPI.isClientResponseSuccess(e)).toBe(false)
+			}
+		})
+	})
+	describe('isClientResponseError', () => {
+		it('Correctly recognizes a responseError object', () => {
+			const response = ClientAPI.responseError('Some error')
+			expect(ClientAPI.isClientResponseError(response)).toBe(true)
+		})
+		it('Correctly regognizes a not-error object', () => {
+			const response = ClientAPI.responseSuccess(undefined)
+			expect(ClientAPI.isClientResponseError(response)).toBe(false)
+		})
+		it('Correctly recognizes that a Meteor.Error is not an error object', () => {
+			try {
+				throw new Meteor.Error(404)
+			} catch (e) {
+				expect(ClientAPI.isClientResponseError(e)).toBe(false)
+			}
+		})
+	})
+})

--- a/meteor/lib/api/client.ts
+++ b/meteor/lib/api/client.ts
@@ -59,9 +59,11 @@ export namespace ClientAPI {
 	}
 	export type ClientResponse<Result> = ClientResponseError | ClientResponseSuccess<Result>
 	export function isClientResponseError(res: any): res is ClientResponseError {
-		return _.isObject(res) && !_.isArray(res) && res.error !== undefined
+		// a ClientResponseError has largely the same signature as a Meteor.Error, so we need to check that the
+		// `.errorType` is not equal `Meteor.Error`, since that's a signature of an exception thrown
+		return !!(_.isObject(res) && !_.isArray(res) && res.error !== undefined && res.errorType !== 'Meteor.Error')
 	}
 	export function isClientResponseSuccess(res: any): res is ClientResponseSuccess<any> {
-		return _.isObject(res) && !_.isArray(res) && res.error === undefined && res.success
+		return !!(_.isObject(res) && !_.isArray(res) && res.error === undefined && res.success)
 	}
 }

--- a/meteor/lib/api/playout.ts
+++ b/meteor/lib/api/playout.ts
@@ -35,7 +35,10 @@ export interface NewPlayoutAPI {
 		verticalDelta: number
 	): Promise<PartId | null>
 	rundownActivateHold(playlistId: RundownPlaylistId): Promise<void>
-	rundownDisableNextPiece(rundownPlaylistId: RundownPlaylistId, undo?: boolean): Promise<void>
+	rundownDisableNextPiece(
+		rundownPlaylistId: RundownPlaylistId,
+		undo?: boolean
+	): Promise<ClientAPI.ClientResponse<void>>
 	segmentAdLibPieceStart(
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -623,7 +623,11 @@ export namespace ServerPlayoutAPI {
 			}
 		)
 	}
-	export function disableNextPiece(context: MethodContext, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
+	export function disableNextPiece(
+		context: MethodContext,
+		rundownPlaylistId: RundownPlaylistId,
+		undo?: boolean
+	): ClientAPI.ClientResponse<void> {
 		// @TODO Check for a better solution to validate security methods
 		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 		check(rundownPlaylistId, String)
@@ -728,8 +732,10 @@ export namespace ServerPlayoutAPI {
 					updateTimeline(cache, playlist.studioId)
 
 					waitForPromise(cache.saveAllToDatabase())
+
+					return ClientAPI.responseSuccess(undefined)
 				} else {
-					throw new Meteor.Error(500, 'Found no future pieces')
+					return ClientAPI.responseError(404, 'Found no future pieces')
 				}
 			}
 		)

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -311,7 +311,7 @@ export function unsyncRundown(context: MethodContext, rundownId: RundownId) {
 	return ClientAPI.responseSuccess(ServerRundownAPI.unsyncRundown(context, rundownId))
 }
 export function disableNextPiece(context: MethodContext, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-	return ClientAPI.responseSuccess(ServerPlayoutAPI.disableNextPiece(context, rundownPlaylistId, undo))
+	return ServerPlayoutAPI.disableNextPiece(context, rundownPlaylistId, undo)
 }
 export function pieceTakeNow(
 	context: MethodContext,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

When no Piece can be found to be disabled/undo-disabled, the method will throw a Meteor.Error

* **What is the new behavior (if this is a feature change)?**

Instead of throwing an Error in a situation that can just regularly happen during normal operation, the method shall now return a `ClientResponseError` object and the GUI will check for that object and error code and show a custom message with just "Warning" level of criticality, instead of showing this as a Critical Error level of notification.

* **Other information**:

This PR also adds some tests for the ClientAPI functions to check that it doesn't mistake `Meteor.Errors` for `ClientResponseErrors`.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
