### PR TITLE
Feat: Local source layer type

### DIFF
--- a/meteor/client/styles/_itemTypeColors.scss
+++ b/meteor/client/styles/_itemTypeColors.scss
@@ -12,6 +12,8 @@ $segment-layer-background-remote: #e80064;
 $segment-layer-background-remote--second: darken($segment-layer-background-remote, 10%);
 $segment-layer-background-vt: #1769ff;
 $segment-layer-background-vt--second: darken($segment-layer-background-vt, 10%);
+$segment-layer-background-local: #8d1010;
+$segment-layer-background-local--second: darken($segment-layer-background-local, 10%);
 $segment-layer-background-script: #005a25;
 $segment-layer-background-mic: #1e6820;
 $segment-layer-background-guest: #008a92;
@@ -117,6 +119,24 @@ $segment-layer-background-guest: #008a92;
 		}
 	}
 
+	&.local {
+		#{$selectors} {
+			text-shadow: 1px -1px 1px var(--segment-layer-background-local),
+				-1px 1px 1px var(--segment-layer-background-local), -1px -1px 1px var(--segment-layer-background-local),
+				1px 1px 1px var(--segment-layer-background-local), 1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-local--second),
+					-1px 1px 1px var(--segment-layer-background-local--second),
+					-1px -1px 1px var(--segment-layer-background-local--second),
+					1px 1px 1px var(--segment-layer-background-local--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
+		}
+	}
+
 	&.script {
 		#{$selectors} {
 			text-shadow: 1px -1px 1px var(--segment-layer-background-script),
@@ -183,6 +203,14 @@ $segment-layer-background-guest: #008a92;
 		}
 	}
 
+	&.local {
+		background: var(--segment-layer-background-local);
+
+		&.second {
+			background: var(--segment-layer-background-local--second);
+		}
+	}
+
 	&.script {
 		background: var(--segment-layer-background-script);
 	}
@@ -215,6 +243,10 @@ $segment-layer-background-guest: #008a92;
 
 	&.remote {
 		border-color: var(--segment-layer-background-remote);
+	}
+
+	&.local {
+		border-color: var(--segment-layer-background-local);
 	}
 
 	&.script {
@@ -298,6 +330,14 @@ $segment-layer-background-guest: #008a92;
 
 		&.second {
 			fill: var(--segment-layer-background-remote--second);
+		}
+	}
+
+	&.local {
+		fill: var(--segment-layer-background-local);
+
+		&.second {
+			fill: var(--segment-layer-background-local--second);
 		}
 	}
 

--- a/meteor/client/styles/defaultColors.scss
+++ b/meteor/client/styles/defaultColors.scss
@@ -48,6 +48,8 @@
 	--segment-layer-background-live-speak: #{$segment-layer-background-live-speak};
 	--segment-layer-background-remote: #{$segment-layer-background-remote};
 	--segment-layer-background-remote--second: #{$segment-layer-background-remote--second};
+	--segment-layer-background-local: #{$segment-layer-background-local};
+	--segment-layer-background-local--second: #{$segment-layer-background-local--second};
 	--segment-layer-background-vt: #{$segment-layer-background-vt};
 	--segment-layer-background-vt--second: #{$segment-layer-background-vt--second};
 	--segment-layer-background-script: #{$segment-layer-background-script};

--- a/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
+++ b/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
@@ -37,6 +37,8 @@ export default class SplitInputIcon extends React.Component<{
 				return 'remote'
 			case SourceLayerType.VT:
 				return 'vt'
+			case SourceLayerType.LOCAL:
+				return 'local'
 		}
 		return ''
 	}

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -339,6 +339,8 @@ const SourceLayerSettings = withTranslation()(
 					return t('Transition')
 				case SourceLayerType.LIGHTS:
 					return t('Lights')
+				case SourceLayerType.LOCAL:
+					return t('Local')
 				default:
 					return SourceLayerType[type]
 			}

--- a/packages/blueprints-integration/src/content.ts
+++ b/packages/blueprints-integration/src/content.ts
@@ -20,6 +20,7 @@ export enum SourceLayerType {
 	MIC = 12,
 	TRANSITION = 13,
 	LIGHTS = 14,
+	LOCAL = 15,
 }
 
 export interface MetadataElement {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds the "LOCAL" source layer type, which can be used to represent sources that are not controlled by Sofie but are available and controlled within the gallery e.g. delayed playback (EVS in this case), telestrator etc. This creates a visual distinction for sources that are often treated like cameras / live inputs but don't fit into either of those categories and may be controlled by an operator within the gallery. Below is a screenshot of what the current colour chosen for this layer looks like.

![image](https://user-images.githubusercontent.com/10697525/101638390-e976a580-3a25-11eb-82d4-a2b9c2567bb4.png)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
