### PR TITLE
fix: block the updateTimeline from triggerUpdateTimelineAfterIngestDa…

### DIFF
--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -268,6 +268,9 @@ export namespace ServerPeripheralDeviceAPI {
 					}
 				})
 
+				// TODO - we should do the same for the partInstance.
+				// Or we should we not update the now for them at all? as we should be getting the onPartPlaybackStarted immediately after
+
 				const objPieceId = (obj.metaData as Partial<PieceGroupMetadata> | undefined)?.pieceId
 				if (objPieceId && activePlaylist) {
 					logger.debug('Update PieceInstance: ', {

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1419,9 +1419,16 @@ export function triggerUpdateTimelineAfterIngestData(playlistId: RundownPlaylist
 
 					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
 
-					if (playlist.active && playlist.currentPartInstanceId) {
-						// If the playlist is active, then updateTimeline as lookahead could have been affected
-						updateTimeline(cache, playlist.studioId)
+					if (playlist.active && (playlist.currentPartInstanceId || playlist.nextPartInstanceId)) {
+						const { currentPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
+						if (!currentPartInstance?.timings?.startedPlayback) {
+							// HACK: The current PartInstance doesn't have a start time yet, so we know an updateTimeline is coming as part of onPartPlaybackStarted
+							// We mustn't run before that does, or we will get the timings in playout-gateway confused.
+						} else {
+							// It is safe enough (except adlibs) to update the timeline directly
+							// If the playlist is active, then updateTimeline as lookahead could have been affected
+							updateTimeline(cache, playlist.studioId)
+						}
 					}
 
 					waitForPromise(cache.saveAllToDatabase())


### PR DESCRIPTION
…ta firing before onPartPlaybackStarted has been executed for a partInstance

This is because if it executed in this window, then playout-gateway and core will be out of sync in timings and cause a weird loop

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If the updateTimeline fires, then core and playout-gateway will be misaligned and constantly flicking between two start times for the partInstance

* **What is the new behavior (if this is a feature change)?**

This 'fixes' it by ignoring the updateTimeline and assumes it will be run shortly by the onPartPlaybackStarted callback that is expected.

* **Other information**:

I would class this as a bit of a hack, as it is ignoring some edge conditions such as if onPartPlaybackStarted fails to do an updateTimeline for some reason, or if the updateTimeline is triggered in some other way (perhaps an adlib?)

But this catches the common case affecting rk7 that is most likely to happen due to their volume of mos updates.

I have not tested it at all, as I do not have a sufficient mos setup to do so.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
