### PR TITLE
fix: prompter generic gamepad

### DIFF
--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -198,7 +198,7 @@ export class JoyConController extends ControllerAbstract {
 							? 'L'
 							: o.id.match('(R)') || o.id.match('Vendor: 057e Product: 2007')
 							? 'R'
-							: null // we are setting this as a member as opposed to returning it functional-style, to avoid doing this calculation pr. tick
+							: null // we are setting lastUsedJoyconId as a member as opposed to returning it functional-style, to avoid doing this calculation pr. tick
 					// for documentation: L+R mode is also identified as Vendor: 057e Product: 200e
 					return { axes: o.axes, buttons: o.buttons }
 				}

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -188,7 +188,13 @@ export class JoyConController extends ControllerAbstract {
 
 			// falls back to searching for compatible gamepad
 			for (const o of gamepads) {
-				if (o && o.connected && o.id && typeof o.id === 'string' && o.id.match('STANDARD GAMEPAD Vendor: 057e')) {
+				if (
+					o &&
+					o.connected &&
+					o.id &&
+					typeof o.id === 'string' &&
+					o.id.match('STANDARD GAMEPAD Vendor: 057e')
+				) {
 					this.lastUsedJoyconIndex = o.index
 					this.lastUsedJoyconId = o.id
 					this.lastUsedJoyconMode =

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -188,15 +188,15 @@ export class JoyConController extends ControllerAbstract {
 
 			// falls back to searching for compatible gamepad
 			for (const o of gamepads) {
-				if (o && o.connected && o.id && typeof o.id === 'string' && o.id.match('Joy-Con')) {
+				if (o && o.connected && o.id && typeof o.id === 'string' && o.id.match('STANDARD GAMEPAD Vendor: 057e')) {
 					this.lastUsedJoyconIndex = o.index
 					this.lastUsedJoyconId = o.id
 					this.lastUsedJoyconMode =
 						o.axes.length === 4
 							? 'LR'
-							: o.id.match('(L)') || o.id.match('Vendor: 057e Product: 2006')
+							: o.id.match('Product: 2006')
 							? 'L'
-							: o.id.match('(R)') || o.id.match('Vendor: 057e Product: 2007')
+							: o.id.match('Product: 2007')
 							? 'R'
 							: null // we are setting lastUsedJoyconId as a member as opposed to returning it functional-style, to avoid doing this calculation pr. tick
 					// for documentation: L+R mode is also identified as Vendor: 057e Product: 200e

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -192,7 +192,14 @@ export class JoyConController extends ControllerAbstract {
 					this.lastUsedJoyconIndex = o.index
 					this.lastUsedJoyconId = o.id
 					this.lastUsedJoyconMode =
-						o.axes.length === 4 ? 'LR' : o.id.match('(L)') ? 'L' : o.id.match('(R)') ? 'R' : null // we are setting this as a member as opposed to returning it functional-style, to avoid doing this calculation pr. tick
+						o.axes.length === 4
+							? 'LR'
+							: o.id.match('(L)') || o.id.match('Vendor: 057e Product: 2006')
+							? 'L'
+							: o.id.match('(R)') || o.id.match('Vendor: 057e Product: 2007')
+							? 'R'
+							: null // we are setting this as a member as opposed to returning it functional-style, to avoid doing this calculation pr. tick
+					// for documentation: L+R mode is also identified as Vendor: 057e Product: 200e
 					return { axes: o.axes, buttons: o.buttons }
 				}
 			}

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4228,7 +4228,7 @@
 			"version": "file:../packages/blueprints-integration",
 			"requires": {
 				"moment": "2.29.1",
-				"timeline-state-resolver-types": "5.3.0-nightly-release28-20201210-065724-684755fe.0",
+				"timeline-state-resolver-types": "5.3.0-nightly-release28-20201214-110646-441c431f.0",
 				"tslib": "^2.0.3",
 				"underscore": "1.11.0"
 			},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Better parsing of gamepad names, to match a broader set of indicators.

* **What is the current behavior?** (You can also link to an open issue here)

Only matches a specific ID, which turns out to not be the only possible outcome when connecting.

* **What is the new behavior (if this is a feature change)?**

Matches a broader and more common part of the ID, which will catch both variants that we have experienced.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
