### PR TITLE
fix: disable & undo disable doesn't work, hides Pieces from timeline or throws errors

### DIFF
--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -29,7 +29,7 @@ import { AdLibPieceUi } from '../ui/Shelf/AdLibPanel'
 import { PartId } from '../../lib/collections/Parts'
 import { processAndPrunePieceInstanceTimings } from '../../lib/rundown/infinites'
 import { createPieceGroupAndCap, PieceGroupMetadata } from '../../lib/rundown/pieces'
-import { PieceInstances } from '../../lib/collections/PieceInstances'
+import { PieceInstances, PieceInstance } from '../../lib/collections/PieceInstances'
 import { IAdLibListItem } from '../ui/Shelf/AdLibListItem'
 import { BucketAdLibItem, BucketAdLibUi } from '../ui/Shelf/RundownViewBuckets'
 import { FindOptions } from '../../lib/typings/meteor'
@@ -391,11 +391,10 @@ export namespace RundownUtils {
 					hasAlreadyPlayed = true
 				}
 
-				const pieceInstanceFieldOptions: FindOptions<PartInstance> = {
+				const pieceInstanceFieldOptions: FindOptions<PieceInstance> = {
 					fields: {
-						//@ts-ignore deep property
-						'piece.startedPlayback': 0,
-						'piece.timings': 0,
+						startedPlayback: 0,
+						stoppedPlayback: 0,
 					},
 				}
 

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -2,9 +2,7 @@ import * as React from 'react'
 import { withTiming, WithTiming } from './withTiming'
 import { unprotectString } from '../../../../lib/lib'
 import { RundownUtils } from '../../../lib/rundown'
-import { SegmentId } from '../../../../lib/collections/Segments'
 import { PartUi } from '../../SegmentTimeline/SegmentTimelineContainer'
-import { processAndPrunePieceInstanceTimings } from '../../../../lib/rundown/infinites'
 
 interface ISegmentDurationProps {
 	parts: PartUi[]

--- a/meteor/client/ui/SegmentTimeline/SegmentContextMenu.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentContextMenu.tsx
@@ -42,57 +42,57 @@ export const SegmentContextMenu = withTranslation()(
 			return this.props.studioMode && this.props.playlist && this.props.playlist.active ? (
 				<Escape to="document">
 					<ContextMenu id="segment-timeline-context-menu">
-						{part && !part.instance.part.invalid && timecode !== null && (
-							<React.Fragment>
-								{startsAt !== null && (
-									<MenuItem
-										onClick={(e) => this.props.onSetNext(part.instance.part, e)}
-										disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
-										<span dangerouslySetInnerHTML={{ __html: t('Set this part as <strong>Next</strong>') }}></span> (
-										{RundownUtils.formatTimeToShortTime(Math.floor(startsAt / 1000) * 1000)})
-									</MenuItem>
+						{this.props.playlist.active ? (
+							<>
+								{part && !part.instance.part.invalid && timecode !== null && (
+									<>
+										{startsAt !== null && (
+											<MenuItem
+												onClick={(e) => this.props.onSetNext(part.instance.part, e)}
+												disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
+												<span dangerouslySetInnerHTML={{ __html: t('Set this part as <strong>Next</strong>') }}></span>{' '}
+												({RundownUtils.formatTimeToShortTime(Math.floor(startsAt / 1000) * 1000)})
+											</MenuItem>
+										)}
+										{startsAt !== null && part && this.props.enablePlayFromAnywhere ? (
+											<>
+												<MenuItem
+													onClick={(e) => this.onSetAsNextFromHere(part.instance.part, e)}
+													disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
+													<span dangerouslySetInnerHTML={{ __html: t('Set <strong>Next</strong> Here') }}></span> (
+													{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
+												</MenuItem>
+												<MenuItem
+													onClick={(e) => this.onPlayFromHere(part.instance.part, e)}
+													disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
+													<span dangerouslySetInnerHTML={{ __html: t('Play from Here') }}></span> (
+													{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
+												</MenuItem>
+											</>
+										) : null}
+									</>
 								)}
-								{startsAt !== null && part && this.props.enablePlayFromAnywhere ? (
-									<React.Fragment>
-										<MenuItem
-											onClick={(e) => this.onSetAsNextFromHere(part.instance.part, e)}
-											disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
-											<span dangerouslySetInnerHTML={{ __html: t('Set <strong>Next</strong> Here') }}></span> (
-											{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
+								{part && timecode === null && (
+									<>
+										<MenuItem onClick={(e) => this.props.onSetNext(part.instance.part, e)} disabled={isCurrentPart}>
+											<span dangerouslySetInnerHTML={{ __html: t('Set segment as <strong>Next</strong>') }}></span>
 										</MenuItem>
-										<MenuItem
-											onClick={(e) => this.onPlayFromHere(part.instance.part, e)}
-											disabled={isCurrentPart || !!part.instance.part.dynamicallyInsertedAfterPartId}>
-											<span dangerouslySetInnerHTML={{ __html: t('Play from Here') }}></span> (
-											{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
-										</MenuItem>
-									</React.Fragment>
-								) : null}
-							</React.Fragment>
-						)}
-						{part && timecode === null && (
-							<React.Fragment>
-								<MenuItem onClick={(e) => this.props.onSetNext(part.instance.part, e)} disabled={isCurrentPart}>
-									<span dangerouslySetInnerHTML={{ __html: t('Set segment as <strong>Next</strong>') }}></span>
-								</MenuItem>
-								{part.instance.segmentId !== this.props.playlist.nextSegmentId ? (
-									<MenuItem onClick={(e) => this.props.onSetNextSegment(part.instance.segmentId, e)}>
-										<span>{t('Queue segment')}</span>
-									</MenuItem>
-								) : (
-									<MenuItem onClick={(e) => this.props.onSetNextSegment(null, e)}>
-										<span>{t('Clear queued segment')}</span>
-									</MenuItem>
+										{part.instance.segmentId !== this.props.playlist.nextSegmentId ? (
+											<MenuItem onClick={(e) => this.props.onSetNextSegment(part.instance.segmentId, e)}>
+												<span>{t('Queue segment')}</span>
+											</MenuItem>
+										) : (
+											<MenuItem onClick={(e) => this.props.onSetNextSegment(null, e)}>
+												<span>{t('Clear queued segment')}</span>
+											</MenuItem>
+										)}
+									</>
 								)}
 								{Settings.allowUnsyncedSegments && this.menuItemResyncSegment(t, segment)}
-							</React.Fragment>
+							</>
+						) : (
+							Settings.allowUnsyncedSegments && this.menuItemResyncSegment(t, segment)
 						)}
-					</ContextMenu>
-				</Escape>
-			) : Settings.allowUnsyncedSegments && segment && segment.unsynced ? (
-				<Escape to="document">
-					<ContextMenu id="segment-timeline-context-menu">
-						<React.Fragment>{this.menuItemResyncSegment(t, segment)}</React.Fragment>
 					</ContextMenu>
 				</Escape>
 			) : null

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -558,7 +558,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 	getSegmentContext = (props) => {
 		const ctx = literal<IContextMenuContext>({
 			segment: this.props.segment,
-			part: this.props.parts.find((p) => !p.instance.part.invalid) || null,
+			part: this.props.parts.find((p) => p.instance.part.isPlayable()) || null,
 		})
 
 		if (this.props.onContextMenu && typeof this.props.onContextMenu === 'function') {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -558,7 +558,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 	getSegmentContext = (props) => {
 		const ctx = literal<IContextMenuContext>({
 			segment: this.props.segment,
-			part: this.props.parts.length > 0 ? this.props.parts[0] : null,
+			part: this.props.parts.find((p) => !p.instance.part.invalid) || null,
 		})
 
 		if (this.props.onContextMenu && typeof this.props.onContextMenu === 'function') {

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -155,6 +155,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			segment,
 			props.segmentsIdsBefore,
 			props.orderedAllPartIds,
+			true,
 			true
 		)
 		let notes: Array<SegmentNote> = []

--- a/meteor/lib/Rundown.ts
+++ b/meteor/lib/Rundown.ts
@@ -136,7 +136,12 @@ export function getPieceInstancesForPartInstance(
 			partInstance.isTemporary
 		)
 	} else {
-		const results = PieceInstances.find({ partInstanceId: partInstance._id }, options).fetch()
+		const results =
+			// Check if the PartInstance we're currently looking for PieceInstances for is already the current one.
+			// If that's the case, we can sace ourselves a scan across the PieceInstances collection
+			partInstance._id === currentPartInstance?._id && currentPartInstancePieceInstances
+				? currentPartInstancePieceInstances
+				: PieceInstances.find({ partInstanceId: partInstance._id }, options).fetch()
 		// check if we can return the results immediately
 		if (results.length > 0 || !pieceInstanceSimulation) return results
 

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -399,7 +399,8 @@ function offsetFromStart(start: number | 'now', newPiece: PieceInstance): number
 export function processAndPrunePieceInstanceTimings(
 	showStyle: ShowStyleBase,
 	pieces: PieceInstance[],
-	nowInPart: number
+	nowInPart: number,
+	keepDisabledPieces?: boolean
 ): PieceInstanceWithTimings[] {
 	const result: PieceInstanceWithTimings[] = []
 
@@ -437,7 +438,7 @@ export function processAndPrunePieceInstanceTimings(
 	}
 
 	const groupedPieces = _.groupBy(
-		pieces.filter((p) => !p.disabled),
+		keepDisabledPieces ? pieces : pieces.filter((p) => !p.disabled),
 		(p) => exclusiveGroupMap.get(p.piece.sourceLayerId) || p.piece.sourceLayerId
 	)
 	for (const pieces of Object.values(groupedPieces)) {

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -439,7 +439,12 @@ export function processAndPrunePieceInstanceTimings(
 
 	const groupedPieces = _.groupBy(
 		keepDisabledPieces ? pieces : pieces.filter((p) => !p.disabled),
-		(p) => exclusiveGroupMap.get(p.piece.sourceLayerId) || p.piece.sourceLayerId
+		// At this stage, if a Piece is disabled, the `keepDisabledPieces` must be turned on. If that's the case
+		// we split out the disabled Pieces onto the sourceLayerId they actually exist on, instead of putting them
+		// onto the shared "exclusivityGroup" layer. This may cause it to not display "exactly" accurately
+		// while in the disabled state, but it should keep it from affecting any not-disabled Pieces.
+		(p) =>
+			p.disabled ? p.piece.sourceLayerId : exclusiveGroupMap.get(p.piece.sourceLayerId) || p.piece.sourceLayerId
 	)
 	for (const pieces of Object.values(groupedPieces)) {
 		// Group and sort the pieces so that we can step through each point in time

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4175,15 +4175,15 @@
 			}
 		},
 		"@slack/rtm-api": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@slack/rtm-api/-/rtm-api-5.0.4.tgz",
-			"integrity": "sha512-5xXOjLPb4H8a+URLrCjnFXA62Kf4IrvSfp9KtuOxv6vTtFVvxNW4WqhWgAcxwXolD43xRuB/pikxLu76vLDTfw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@slack/rtm-api/-/rtm-api-5.0.5.tgz",
+			"integrity": "sha512-x2B4hyoxjg62cxf4M5QRomx+xYp2XoajPKdd24SM2Sl4m+IrzwKzmcrysQuYmF6BMsm3IoTKymW5BBGckHGTIw==",
 			"requires": {
 				"@slack/logger": ">=1.0.0 <3.0.0",
 				"@slack/web-api": "^5.3.0",
 				"@types/node": ">=8.9.0",
 				"@types/p-queue": "^2.3.2",
-				"@types/ws": "^5.1.1",
+				"@types/ws": "^7.2.5",
 				"eventemitter3": "^3.1.0",
 				"finity": "^0.5.4",
 				"p-cancelable": "^1.1.0",
@@ -4197,38 +4197,73 @@
 			"integrity": "sha512-SrrAD/ZxDN4szQ35V/mY2TvKSyGsUWP8def1C8NMg9AvdYG0VyaL5f+Dd6jw8STosMFXd3zqjekMowT9LB9/IQ=="
 		},
 		"@slack/web-api": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz",
-			"integrity": "sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.15.0.tgz",
+			"integrity": "sha512-tjQ8Zqv/Fmj9SOL9yIEd7IpTiKfKHi9DKAkfRVeotoX0clMr3SqQtBqO+KZMX27gm7dmgJsQaDKlILyzdCO+IA==",
 			"requires": {
 				"@slack/logger": ">=1.0.0 <3.0.0",
-				"@slack/types": "^1.2.1",
+				"@slack/types": "^1.7.0",
 				"@types/is-stream": "^1.1.0",
 				"@types/node": ">=8.9.0",
-				"@types/p-queue": "^2.3.2",
-				"axios": "^0.19.0",
+				"axios": "^0.21.1",
 				"eventemitter3": "^3.1.0",
 				"form-data": "^2.5.0",
 				"is-stream": "^1.1.0",
-				"p-queue": "^2.4.2",
+				"p-queue": "^6.6.1",
 				"p-retry": "^4.0.0"
+			},
+			"dependencies": {
+				"@slack/types": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+					"integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
+				},
+				"axios": {
+					"version": "0.21.1",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+					"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+					"requires": {
+						"follow-redirects": "^1.10.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+					"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+				},
+				"p-queue": {
+					"version": "6.6.2",
+					"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+					"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+					"requires": {
+						"eventemitter3": "^4.0.4",
+						"p-timeout": "^3.2.0"
+					},
+					"dependencies": {
+						"eventemitter3": {
+							"version": "4.0.7",
+							"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+							"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+						}
+					}
+				}
 			}
 		},
 		"@slack/webhook": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.3.tgz",
-			"integrity": "sha512-51vnejJ2zABNumPVukOLyerpHQT39/Lt0TYFtOEz/N2X77bPofOgfPj2atB3etaM07mxWHLT9IRJ4Zuqx38DkQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.4.tgz",
+			"integrity": "sha512-IC1dpVSc2F/pmwCxOb0QzH2xnGKmyT7MofPGhNkeaoiMrLMU+Oc7xV/AxGnz40mURtCtaDchZSM3tDo9c9x6BA==",
 			"requires": {
 				"@slack/types": "^1.2.1",
 				"@types/node": ">=8.9.0",
-				"axios": "^0.19.0"
+				"axios": "^0.21.1"
 			}
 		},
 		"@sofie-automation/blueprints-integration": {
 			"version": "file:../packages/blueprints-integration",
 			"requires": {
 				"moment": "2.29.1",
-				"timeline-state-resolver-types": "5.3.0-nightly-release28-20201210-065724-684755fe.0",
+				"timeline-state-resolver-types": "5.3.0-nightly-release28-20201214-110646-441c431f.0",
 				"tslib": "^2.0.3",
 				"underscore": "1.11.0"
 			},
@@ -4254,9 +4289,9 @@
 					"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
 				},
 				"timeline-state-resolver-types": {
-					"version": "5.3.0-nightly-release28-20201210-065724-684755fe.0",
-					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.3.0-nightly-release28-20201210-065724-684755fe.0.tgz",
-					"integrity": "sha512-UqZ+p0VvdN2XP02Vc+sv6uAby+qTo5VW8KDJyX63V5zDQ5nAHK5wM1SPR4jf+1dY9MbzGqCaNSTj4341s7kpZg==",
+					"version": "5.3.0-nightly-release28-20201214-110646-441c431f.0",
+					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.3.0-nightly-release28-20201214-110646-441c431f.0.tgz",
+					"integrity": "sha512-EZ0CsNmr1RO1iW2uO3eEt2UzPOFTuuSpUHfBaDjC+N5xCpDzyYFVJej3hBLoG7/y0in6Ihi8L5uHZ1yWMTueew==",
 					"requires": {
 						"tslib": "^1.13.0"
 					},
@@ -4406,11 +4441,6 @@
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
 			"dev": true
-		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
 		},
 		"@types/fibers": {
 			"version": "3.1.0",
@@ -4686,11 +4716,10 @@
 			}
 		},
 		"@types/ws": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-5.1.2.tgz",
-			"integrity": "sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+			"integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
 			"requires": {
-				"@types/events": "*",
 				"@types/node": "*"
 			}
 		},
@@ -5151,11 +5180,11 @@
 			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
 		},
 		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"requires": {
-				"follow-redirects": "1.5.10"
+				"follow-redirects": "^1.10.0"
 			}
 		},
 		"babel-code-frame": {
@@ -8673,22 +8702,9 @@
 			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -14948,8 +14964,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "2.3.0",
@@ -14989,6 +15004,14 @@
 			"requires": {
 				"@types/retry": "^0.12.0",
 				"retry": "^0.12.0"
+			}
+		},
+		"p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"requires": {
+				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {
@@ -17376,7 +17399,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},

--- a/meteor/server/DatabaseCache.ts
+++ b/meteor/server/DatabaseCache.ts
@@ -396,6 +396,14 @@ export class DbCacheWriteCollection<
 			}
 		}
 	}
+	isModified(): boolean {
+		for (const doc of Object.values(this.documents)) {
+			if (doc.inserted || doc.removed || doc.updated) {
+				return true
+			}
+		}
+		return false
+	}
 }
 type SelectorFunction<DBInterface> = (doc: DBInterface) => boolean
 interface DbCacheCollectionDocument<Class> {

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -140,13 +140,13 @@ export class ReadOnlyCache {
 		if (this._deferredFunctions.length > 0)
 			throw new Meteor.Error(
 				500,
-				`Failed no changes in cache assertion, there were ${this._deferredFunctions} deferred functions`
+				`Failed no changes in cache assertion, there were ${this._deferredFunctions.length} deferred functions`
 			)
 
 		if (this._deferredAfterSaveFunctions.length > 0)
 			throw new Meteor.Error(
 				500,
-				`Failed no changes in cache assertion, there were ${this._deferredAfterSaveFunctions} after-save deferred functions`
+				`Failed no changes in cache assertion, there were ${this._deferredAfterSaveFunctions.length} after-save deferred functions`
 			)
 
 		_.map(allDBs, (db) => {

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -126,6 +126,11 @@ export class ReadOnlyCache {
 
 		if (span) span.end()
 	}
+	/**
+	 * Assert that no changes should have been made to the cache, will throw an Error otherwise. This can be used in
+	 * place of `saveAllToDatabase()`, when the code controlling the cache expects no changes to have been made and any
+	 * changes made are an error and will cause issues.
+	 */
 	assertNoChanges() {
 		const span = profiler.startSpan('Cache.assertNoChanges')
 

--- a/meteor/server/api/__tests__/DatabaseCaches.test.ts
+++ b/meteor/server/api/__tests__/DatabaseCaches.test.ts
@@ -87,70 +87,6 @@ describe('DatabaseCaches', () => {
 			removed.mockClear()
 			expect(RundownPlaylists.findOne(id)).toBeFalsy()
 		})
-		testInFiber('Assert no changes', async () => {
-			const studio = Studios.findOne() as Studio
-			expect(studio).toBeTruthy()
-
-			const added = jest.fn()
-			const changed = jest.fn()
-			const removed = jest.fn()
-			RundownPlaylists.find().observeChanges({
-				added,
-				changed,
-				removed,
-			})
-
-			{
-				const cache = await initCacheForStudio(studio._id)
-
-				const cachedStudio = cache.Studios.findOne(studio._id)
-				expect(cachedStudio).toMatchObject(studio)
-
-				cache.assertNoChanges() // this shouldn't throw
-				expect(true).toBeTruthy()
-			}
-
-			{
-				const cache = await initCacheForStudio(studio._id)
-				const id: RundownPlaylistId = protectString('myPlaylist0')
-
-				// Insert a document:
-				cache.RundownPlaylists.insert({
-					...defaultRundownPlaylist(id, studio._id, getRandomId()),
-					name: 'insert',
-				})
-				cache.RundownPlaylists.update(id, { $set: { name: 'insertthenupdate' } })
-
-				expect(cache.RundownPlaylists.findOne(id)).toBeTruthy()
-				expect(RundownPlaylists.findOne(id)).toBeFalsy()
-
-				expect(() => {
-					cache.assertNoChanges()
-				}).toThrowError(/failed .+ assertion,.+ was modified/gi)
-			}
-
-			{
-				const cache = await initCacheForStudio(studio._id)
-
-				// Insert a document:
-				cache.defer(() => {})
-
-				expect(() => {
-					cache.assertNoChanges()
-				}).toThrowError(/failed .+ assertion,.+ deferred/gi)
-			}
-
-			{
-				const cache = await initCacheForStudio(studio._id)
-
-				// Insert a document:
-				cache.deferAfterSave(() => {})
-
-				expect(() => {
-					cache.assertNoChanges()
-				}).toThrowError(/failed .+ assertion,.+ after-save deferred/gi)
-			}
-		})
 		testInFiber('Multiple saves', async () => {
 			const studio = Studios.findOne() as Studio
 			expect(studio).toBeTruthy()
@@ -243,6 +179,72 @@ describe('DatabaseCaches', () => {
 			expect(deferAfterSaveFcn0).toHaveReturnedTimes(0)
 			expect(deferFcn1).toHaveReturnedTimes(0)
 			expect(deferAfterSaveFcn1).toHaveReturnedTimes(0)
+		})
+	})
+	describe('CacheForStudio', () => {
+		testInFiber('Assert no changes', async () => {
+			const studio = Studios.findOne() as Studio
+			expect(studio).toBeTruthy()
+
+			const added = jest.fn()
+			const changed = jest.fn()
+			const removed = jest.fn()
+			RundownPlaylists.find().observeChanges({
+				added,
+				changed,
+				removed,
+			})
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				const cachedStudio = cache.Studios.findOne(studio._id)
+				expect(cachedStudio).toMatchObject(studio)
+
+				cache.assertNoChanges() // this shouldn't throw
+				expect(true).toBeTruthy()
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+				const id: RundownPlaylistId = protectString('myPlaylist0')
+
+				// Insert a document:
+				cache.RundownPlaylists.insert({
+					...defaultRundownPlaylist(id, studio._id, getRandomId()),
+					name: 'insert',
+				})
+				cache.RundownPlaylists.update(id, { $set: { name: 'insertthenupdate' } })
+
+				expect(cache.RundownPlaylists.findOne(id)).toBeTruthy()
+				expect(RundownPlaylists.findOne(id)).toBeFalsy()
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ was modified/gi)
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				// Insert a document:
+				cache.defer(() => {})
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ deferred/gi)
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				// Insert a document:
+				cache.deferAfterSave(() => {})
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ after-save deferred/gi)
+			}
 		})
 	})
 })

--- a/meteor/server/api/__tests__/DatabaseCaches.test.ts
+++ b/meteor/server/api/__tests__/DatabaseCaches.test.ts
@@ -1,6 +1,6 @@
 import { testInFiber } from '../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment } from '../../../__mocks__/helpers/database'
-import { initCacheForStudioBase } from '../../DatabaseCaches'
+import { initCacheForStudioBase, initCacheForStudio } from '../../DatabaseCaches'
 import { Studios, Studio } from '../../../lib/collections/Studios'
 import { getRandomId, waitTime, protectString } from '../../../lib/lib'
 import { RundownPlaylistId, RundownPlaylists, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
@@ -86,6 +86,70 @@ describe('DatabaseCaches', () => {
 			expect(removed).toHaveBeenCalledTimes(1)
 			removed.mockClear()
 			expect(RundownPlaylists.findOne(id)).toBeFalsy()
+		})
+		testInFiber('Assert no changes', async () => {
+			const studio = Studios.findOne() as Studio
+			expect(studio).toBeTruthy()
+
+			const added = jest.fn()
+			const changed = jest.fn()
+			const removed = jest.fn()
+			RundownPlaylists.find().observeChanges({
+				added,
+				changed,
+				removed,
+			})
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				const cachedStudio = cache.Studios.findOne(studio._id)
+				expect(cachedStudio).toMatchObject(studio)
+
+				cache.assertNoChanges() // this shouldn't throw
+				expect(true).toBeTruthy()
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+				const id: RundownPlaylistId = protectString('myPlaylist0')
+
+				// Insert a document:
+				cache.RundownPlaylists.insert({
+					...defaultRundownPlaylist(id, studio._id, getRandomId()),
+					name: 'insert',
+				})
+				cache.RundownPlaylists.update(id, { $set: { name: 'insertthenupdate' } })
+
+				expect(cache.RundownPlaylists.findOne(id)).toBeTruthy()
+				expect(RundownPlaylists.findOne(id)).toBeFalsy()
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ was modified/gi)
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				// Insert a document:
+				cache.defer(() => {})
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ deferred/gi)
+			}
+
+			{
+				const cache = await initCacheForStudio(studio._id)
+
+				// Insert a document:
+				cache.deferAfterSave(() => {})
+
+				expect(() => {
+					cache.assertNoChanges()
+				}).toThrowError(/failed .+ assertion,.+ after-save deferred/gi)
+			}
 		})
 		testInFiber('Multiple saves', async () => {
 			const studio = Studios.findOne() as Studio

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -717,7 +717,7 @@ export namespace ServerPlayoutAPI {
 				for (const [partInstance, ignoreStartedPlayback] of partInstances) {
 					if (partInstance) {
 						nextPieceInstance = getNextPiece(partInstance, !!undo, ignoreStartedPlayback)
-						break
+						if (nextPieceInstance) break
 					}
 				}
 
@@ -735,6 +735,8 @@ export namespace ServerPlayoutAPI {
 
 					return ClientAPI.responseSuccess(undefined)
 				} else {
+					cache.assertNoChanges()
+
 					return ClientAPI.responseError(404, 'Found no future pieces')
 				}
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

There have been a couple of issues with Disable/Undo Disable functionality:
1. First of all, the GUI would not show disabled pieces, because shared backend-fronted methods used by getResolvedSegment() for processing Piece Instances would filter them out, because backend doesn't care about disabled pieces. 
2. In some conditions, when trying to undo-disable a Piece, the Piece would not be found, because the method would end too early due to it breaking out of a loop too quickly.
3. An error was being printed out if no piece do be disabled/re-enabled was found, because a cache was created, but - since no modification was done - it wasn't saved back.
4. The order in which pieces were disabled/re-enabled was not the way users expect it to be. The order was: source layer rank first, time-order second. The users expect the time order to be first-rank, with source-layer rank going second. So for two layers, A & B, the disabling order should be: `A1` `B1` `A2` `A3` instead of `A1` `A2` `A3` `B1` (the way it was before).

* **What is the new behavior (if this is a feature change)?**

This PR fixes all of these issues. It also introduces a new method to the cache: `assertNoChanges()` so that `saveAllToDatabase()` can be explicitly _not_ called, when no changes should have been made to the database. It will throw an error, if changes were made, which should maintain cache integrity and indicate if there are any problems.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
