### PR TITLE
feat: special timeline class for when the first part hasn't been taken

### DIFF
--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -425,7 +425,7 @@ function buildTimelineObjsForRundown(
 					? TimelineObjClassesCore.RundownRehearsal
 					: TimelineObjClassesCore.RundownActive,
 				!activePlaylist.currentPartInstanceId ? TimelineObjClassesCore.BeforeFirstPart : undefined,
-				!activePlaylist.nextPartInstanceId ? TimelineObjClassesCore.IsLastPart : undefined,
+				!activePlaylist.nextPartInstanceId ? TimelineObjClassesCore.NoNextPart : undefined,
 			].filter((v): v is TimelineObjClassesCore => v !== undefined),
 			partInstanceId: null,
 		})

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -56,6 +56,7 @@ import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { DEFINITELY_ENDED_FUTURE_DURATION } from './infinites'
 import { profiler } from '../profiler'
 import { getPartFirstObjectId, getPartGroupId, getPieceGroupId } from '../../../lib/rundown/timeline'
+import { TimelineObjClassesCore } from '@sofie-automation/blueprints-integration'
 
 /**
  * Updates the Timeline to reflect the state in the Rundown, Segments, Parts etc...
@@ -419,7 +420,13 @@ function buildTimelineObjsForRundown(
 			content: {
 				deviceType: TSR.DeviceType.ABSTRACT,
 			},
-			classes: [activePlaylist.rehearsal ? 'rundown_rehersal' : 'rundown_active'],
+			classes: [
+				activePlaylist.rehearsal
+					? TimelineObjClassesCore.RundownRehearsal
+					: TimelineObjClassesCore.RundownActive,
+				!activePlaylist.currentPartInstanceId ? TimelineObjClassesCore.BeforeFirstPart : undefined,
+				!activePlaylist.nextPartInstanceId ? TimelineObjClassesCore.IsLastPart : undefined,
+			].filter((v): v is TimelineObjClassesCore => v !== undefined),
 			partInstanceId: null,
 		})
 	)

--- a/packages/blueprints-integration/src/timeline.ts
+++ b/packages/blueprints-integration/src/timeline.ts
@@ -8,7 +8,7 @@ export enum TimelineObjClassesCore {
 	RundownRehearsal = 'rundown_rehersal',
 	RundownActive = 'rundown_active',
 	BeforeFirstPart = 'before_first_part',
-	IsLastPart = 'last_part',
+	NoNextPart = 'last_part',
 }
 
 export enum TimelineObjHoldMode {

--- a/packages/blueprints-integration/src/timeline.ts
+++ b/packages/blueprints-integration/src/timeline.ts
@@ -4,6 +4,13 @@ export { TSR }
 
 export { Timeline } from 'timeline-state-resolver-types'
 
+export enum TimelineObjClassesCore {
+	RundownRehearsal = 'rundown_rehersal',
+	RundownActive = 'rundown_active',
+	BeforeFirstPart = 'before_first_part',
+	IsLastPart = 'last_part',
+}
+
 export enum TimelineObjHoldMode {
 	NORMAL = 0,
 	ONLY = 1, // Only use when in HOLD


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Adds a timeline class that is added to the timeline when the rundown is active but no part has been taken yet. This allows blueprints developer to add special behavior for this state.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
