### PR TITLE
Fix: graphics hover preview stays in viewport

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -2272,6 +2272,8 @@ body.no-overflow {
 	border: 1px black solid;
 	max-width: 26em;
 
+	--popdown: 2em;
+
 	&.segment-timeline__mini-inspector--sub-inspector {
 		transform: none;
 		bottom: 100%;
@@ -2346,7 +2348,7 @@ body.no-overflow {
 	}
 
 	&.segment-timeline__mini-inspector--pop-down {
-		transform: translate(-50%, 2em);
+		transform: translate(-50%, var(--popdown));
 	}
 
 	&.segment-timeline__mini-inspector--graphics {

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -186,11 +186,11 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		style.visibility = this.state.show ? 'visible' : 'hidden'
 
 		if (this.state.flip.x && this.state.flip.y) {
-			style.transform = 'translate(0, 2em)'
+			style.transform = 'translate(0, var(--popdown))'
 		} else if (this.state.flip.x) {
 			style.transform = 'translate(0, -100%)'
 		} else if (this.state.flip.y) {
-			style.transform = 'translate(-100%, 2em)'
+			style.transform = 'translate(-100%, var(--popdown))'
 		}
 
 		return style


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Adds checking of viewport boundaries for hover preview, and flips the preview location relative to the cursor to prevent going out of bounds.



* **What is the current behavior?** (You can also link to an open issue here)
Hover preview can be partially outside of the viewport and the graphics element is not on screen


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
