### PR TITLE
fix: Reset partInstances for removed parts

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -134,14 +134,17 @@ registerIndex(PartInstances, {
 	rundownId: 1,
 	segmentId: 1,
 	takeCount: 1,
+	reset: 1,
 })
 registerIndex(PartInstances, {
 	rundownId: 1,
 	takeCount: 1,
+	reset: 1,
 })
 registerIndex(PartInstances, {
 	rundownId: 1,
 	// @ts-ignore deep property
 	'part._id': 1,
 	takeCount: 1,
+	reset: 1,
 })

--- a/meteor/server/DatabaseCaches.ts
+++ b/meteor/server/DatabaseCaches.ts
@@ -386,8 +386,12 @@ async function fillCacheForRundownPlaylistWithData(
 	ps.push(makePromise(() => cache.Pieces.prepareInit({ startRundownId: { $in: rundownIds } }, false)))
 
 	ps.push(
-		makePromise(() => cache.PartInstances.prepareInit({ rundownId: { $in: rundownIds } }, initializeImmediately))
-		// TODO - should this only load the non-reset?
+		makePromise(() =>
+			cache.PartInstances.prepareInit(
+				{ rundownId: { $in: rundownIds }, reset: { $ne: true } },
+				initializeImmediately
+			)
+		)
 	)
 
 	ps.push(

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -459,6 +459,8 @@ export function afterRemoveParts(cache: CacheForRundownPlaylist, rundownId: Rund
 		startPartId: { $in: removedPartIds },
 	})
 
+	cache.PartInstances.update({ 'part._id': { $in: _.map(removedParts, (p) => p._id) } }, { $set: { reset: true } })
+
 	cache.deferAfterSave(() => {
 		waitForPromiseAll([
 			asyncCollectionRemove(ExpectedPlayoutItems, {

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -459,7 +459,7 @@ export function afterRemoveParts(cache: CacheForRundownPlaylist, rundownId: Rund
 		startPartId: { $in: removedPartIds },
 	})
 
-	cache.PartInstances.update({ 'part._id': { $in: _.map(removedParts, (p) => p._id) } }, { $set: { reset: true } })
+	cache.PartInstances.update({ 'part._id': { $in: removedPartIds } }, { $set: { reset: true } })
 
 	cache.deferAfterSave(() => {
 		waitForPromiseAll([


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR improves performance by preventing too many partInstances from being fetched by the GUI and into the cache


* **What is the current behavior?** (You can also link to an open issue here)
When parts that were played back are removed, their partInstances stay in the database and are still fetched into the cache and by the GUI. In a workflow where one rundown is reused, and segments are inserted and removed multiple times, it causes the number of processed partInstances to unnecessarily grow over time and slow down server and client.

* **What is the new behavior (if this is a feature change)?**
1. When removing a part, mark its partInstances as reset.
2. Fetch only non-reset partInstances into the cache.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
