### PR TITLE
feat: add getPartInstanceForPreviousPiece method to ActionExecutionContext

### DIFF
--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -88,6 +88,8 @@ export interface ActionExecutionContext extends ShowStyleContext {
 			pieceMetaDataFilter?: any // Mongo query against properties inside of piece.metaData
 		}
 	): IBlueprintPieceInstance | undefined
+	/** Gets the PartInstance for a PieceInstane retrieved from findLastPieceOnLayer. This primarily allows for accessing metadata of the PartInstance */
+	getPartInstanceForPreviousPiece(piece: IBlueprintPieceInstance): IBlueprintPartInstance
 	/** Fetch the showstyle config for the specified part */
 	// getNextShowStyleConfig(): Readonly<{ [key: string]: ConfigItemValue }>
 


### PR DESCRIPTION
Allows for getting the part metadata for a piece found via findLastPieceOnLayer

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

During an adlib-action, it is not possible to get the PartInstance for a PieceInstance returned from `findLastPieceOnLayer`. For the nrk case, this is a problem as any 'primary' piece simply states it was primary in its metadata, and the part metadata should be referenced for the properties needed to regenerate it.

This means it is not possible to regenerate the piece as a new piece for the current part (ie, a lazy generated adlib piece) without copying the same properties into the pieceMetadata causing the piece type to get even heavier

* **What is the new behavior (if this is a feature change)?**

It is possible to get this metadata.

* **Other information**:

Unit tests need to be written before this can be merged

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
