### PR TITLE
feat: piece freeze frame countdown

### DIFF
--- a/meteor/client/styles/countdown/overlay.scss
+++ b/meteor/client/styles/countdown/overlay.scss
@@ -63,6 +63,7 @@ body.transparent {
 		margin-left: 0.3em;
 	}
 
+	.clocks-next-rundown,
 	.clocks-part-title {
 		font-size: 1em;
 
@@ -74,6 +75,10 @@ body.transparent {
 		font-style: normal;
 		font-stretch: normal;
 		letter-spacing: normal;
+		font-weight: 300 !important;
+		//margin-left: 35px;
+		flex: 1 1;
+		padding-left: 0.1em;
 	}
 
 	.clocks-part-title.clocks-current-segment-title {
@@ -83,14 +88,7 @@ body.transparent {
 	.clocks-studio-name {
 		font-weight: 800;
 		transform-origin: 0 0;
-	}
-
-	.clocks-part-title,
-	.clocks-next-rundown {
-		font-weight: 300 !important;
-		//margin-left: 35px;
-		flex: 1 1;
-		padding-left: 0.1em;
+		padding: 0 0.2em;
 	}
 
 	.clocks-current-segment-title {

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -494,6 +494,8 @@ body.no-overflow {
 	-moz-box-shadow: 7px 6px 20px 0px rgba(0, 0, 0, 0.7);
 	box-shadow: 7px 6px 20px 0px rgba(0, 0, 0, 0.7);
 
+	--segment-layer-height: #{$segment-layer-height};
+
 	// padding has to be the same on both of these elements so that the layers and their controls line up
 	.segment-timeline__output-layers,
 	.segment-timeline__timeline {
@@ -1162,8 +1164,6 @@ body.no-overflow {
 
 			--invalid-reason-color-opaque: rgba(0, 0, 0, 1);
 			--invalid-reason-color-transparent: rgba(0, 0, 0, 0);
-
-			--segment-layer-height: #{$segment-layer-height};
 
 			* {
 				backface-visibility: hidden;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1116,12 +1116,12 @@ body.no-overflow {
 			}
 		}
 
-		.segment-timeline__liveline__apendage {
+		.segment-timeline__liveline__appendage {
 			position: absolute;
 			margin-left: 5px;
 			margin-top: 0.1em;
 
-			&.segment-timeline__liveline__apendage--piece-countdown {
+			&.segment-timeline__liveline__appendage--piece-countdown {
 				color: $liveline-timecode-color;
 				font-weight: 500;
 				text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000, 2px 2px 5px #000;

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1114,6 +1114,18 @@ body.no-overflow {
 			}
 		}
 
+		.segment-timeline__liveline__apendage {
+			position: absolute;
+			margin-left: 5px;
+			margin-top: 0.1em;
+
+			&.segment-timeline__liveline__apendage--piece-countdown {
+				color: $liveline-timecode-color;
+				font-weight: 500;
+				text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000, 2px 2px 5px #000;
+			}
+		}
+
 		.segment-timeline__liveline__status {
 			position: absolute;
 			border-radius: 2em;

--- a/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
+++ b/meteor/client/ui/ClockView/OverlayScreenSaver.tsx
@@ -93,7 +93,9 @@ export function OverlayScreenSaver({ studioId }: { studioId: StudioId }): JSX.El
 	return (
 		<div className="clocks-overlay">
 			<div className="clocks-half clocks-bottom">
-				<div className="clocks-current-segment-countdown clocks-segment-countdown"></div>
+				{data?.rundownPlaylist?.name && (
+					<div className="clocks-current-segment-countdown clocks-segment-countdown"></div>
+				)}
 				<div className="clocks-studio-name" ref={studioNameRef}>
 					{data?.studio?.name ?? null}
 				</div>

--- a/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -43,8 +43,6 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 		speak(displayTime: number) {
 			let text = '' // Say nothing
 
-			navigator.vibrate([400, 300, 400, 300, 400])
-
 			switch (displayTime) {
 				case -1:
 					text = 'One'
@@ -87,15 +85,15 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 		}
 
 		vibrate(displayTime: number) {
-			navigator.vibrate([400, 300, 400, 300, 400])
-
-			switch (displayTime) {
-				case 0:
-					navigator.vibrate([500])
-				case -1:
-				case -2:
-				case -3:
-					navigator.vibrate([250])
+			if ('vibrate' in navigator) {
+				switch (displayTime) {
+					case 0:
+						navigator.vibrate([500])
+					case -1:
+					case -2:
+					case -3:
+						navigator.vibrate([250])
+				}
 			}
 		}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/CustomLayerItemRenderer.tsx
@@ -15,7 +15,9 @@ export interface ICustomLayerItemProps {
 	outputLayer: IOutputLayerUi
 	outputGroupCollapsed: boolean
 	part: PartUi
+	isLiveLine: boolean
 	partDuration: number // 0 if unknown
+	partExpectedDuration: number
 	piece: PieceUi
 	timeScale: number
 	onFollowLiveLine?: (state: boolean, event: any) => void

--- a/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
@@ -100,8 +100,6 @@ export class SplitsSourceRenderer extends CustomLayerItemRenderer<IProps, IState
 		const leftLabelWidth = this.leftLabel ? Math.max(0, getElementWidth(this.leftLabel) - 2) : 0
 		const rightLabelWidth = this.rightLabel ? Math.max(0, getElementWidth(this.rightLabel) - 2) : 0
 
-		console.log(leftLabelWidth, rightLabelWidth)
-
 		this.setAnchoredElsWidths(leftLabelWidth, rightLabelWidth)
 	}
 

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -131,7 +131,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		newState: Partial<IState>,
 		itemElement: HTMLElement | null
 	): Partial<IState> {
-		const { relative: relativeRendering, isLiveLine, outputLayer } = props
+		const { relative: relativeRendering, isLiveLine, outputLayer, livePosition } = props
 		if (
 			this.countdownContainer &&
 			!this.state.sourceEndCountdownAppendage &&
@@ -140,7 +140,6 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			!outputLayer.collapsed &&
 			itemElement
 		) {
-			//  && (this.props.livePosition || 0) > 0
 			const liveLine = itemElement.parentElement?.parentElement?.parentElement?.parentElement?.parentElement?.querySelector(
 				'.segment-timeline__liveline'
 			)
@@ -165,7 +164,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			super.componentDidMount()
 		}
 
-		const { itemElement, relative: relativeRendering } = this.props
+		const { itemElement } = this.props
 
 		let newState: Partial<IState> = {}
 
@@ -445,6 +444,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			isLiveLine &&
 			this.countdownContainer &&
 			livePositionInPart >= (uiPiece.renderedInPoint || 0) &&
+			livePositionInPart < (uiPiece.renderedInPoint || 0) + (uiPiece.renderedDuration || Number.POSITIVE_INFINITY) &&
 			vtContent &&
 			vtContent.sourceDuration !== undefined &&
 			((part.instance.part.autoNext &&

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -16,6 +16,7 @@ import { VTContent } from '@sofie-automation/blueprints-integration'
 import { PieceStatusIcon } from '../PieceStatusIcon'
 import { NoticeLevel, getNoticeLevelForPieceStatus } from '../../../lib/notifications/notifications'
 import { VTFloatingInspector } from '../../FloatingInspectors/VTFloatingInspector'
+import { RundownUtils } from '../../../lib/rundown'
 
 interface IProps extends ICustomLayerItemProps {}
 interface IState {
@@ -27,9 +28,10 @@ interface IState {
 	noticeLevel: NoticeLevel | null
 	begin: string
 	end: string
+
+	sourceEndCountdownAppendage?: boolean
 }
 export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithTranslation, IState> {
-	private vPreview: HTMLVideoElement
 	private leftLabel: HTMLSpanElement
 	private rightLabel: HTMLSpanElement
 
@@ -38,7 +40,8 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 	private leftLabelNodes: JSX.Element
 	private rightLabelNodes: JSX.Element
 
-	private rightLabelContainer: HTMLSpanElement | null
+	private rightLabelContainer: HTMLSpanElement | null = null
+	private countdownContainer: HTMLSpanElement | null = null
 
 	private static readonly defaultLottieOptions = {
 		loop: true,
@@ -63,10 +66,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		}
 
 		this.rightLabelContainer = document.createElement('span')
-	}
-
-	setVideoRef = (e: HTMLVideoElement) => {
-		this.vPreview = e
+		this.countdownContainer = document.createElement('span')
 	}
 
 	setLeftLabelRef = (e: HTMLSpanElement) => {
@@ -86,41 +86,104 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		}
 	}
 
+	mountRightLabelContainer(
+		props: IProps,
+		prevProps: IProps | null,
+		newState: Partial<IState>,
+		itemElement: HTMLElement | null
+	): Partial<IState> {
+		if (this.rightLabelContainer && itemElement) {
+			const itemDuration = this.getItemDuration(true)
+			if (prevProps === null || itemElement !== prevProps.itemElement) {
+				if (itemDuration === Number.POSITIVE_INFINITY) {
+					itemElement.parentNode &&
+						itemElement.parentNode.parentNode &&
+						itemElement.parentNode.parentNode.parentNode &&
+						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
+
+					newState.rightLabelIsAppendage = true
+				} else {
+					this.rightLabelContainer?.remove()
+					itemElement.appendChild(this.rightLabelContainer)
+					newState.rightLabelIsAppendage = false
+				}
+			} else if (prevProps && prevProps.partDuration !== props.partDuration) {
+				if (itemDuration === Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage !== true) {
+					itemElement.parentNode &&
+						itemElement.parentNode.parentNode &&
+						itemElement.parentNode.parentNode.parentNode &&
+						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
+
+					newState.rightLabelIsAppendage = true
+				} else if (itemDuration !== Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage === true) {
+					this.rightLabelContainer?.remove()
+					itemElement.appendChild(this.rightLabelContainer)
+					newState.rightLabelIsAppendage = false
+				}
+			}
+		}
+
+		return newState
+	}
+
+	mountSourceEndedCountdownContainer(
+		props: IProps,
+		newState: Partial<IState>,
+		itemElement: HTMLElement | null
+	): Partial<IState> {
+		const { relative: relativeRendering, isLiveLine, outputLayer } = props
+		if (
+			this.countdownContainer &&
+			!this.state.sourceEndCountdownAppendage &&
+			!relativeRendering &&
+			isLiveLine &&
+			!outputLayer.collapsed &&
+			itemElement
+		) {
+			//  && (this.props.livePosition || 0) > 0
+			const liveLine = itemElement.parentElement?.parentElement?.parentElement?.parentElement?.parentElement?.querySelector(
+				'.segment-timeline__liveline'
+			)
+			if (liveLine) {
+				liveLine.appendChild(this.countdownContainer)
+				newState.sourceEndCountdownAppendage = true
+			}
+		} else if (
+			this.countdownContainer &&
+			this.state.sourceEndCountdownAppendage &&
+			!(!relativeRendering && isLiveLine && !outputLayer.collapsed && itemElement)
+		) {
+			this.countdownContainer.remove()
+			newState.sourceEndCountdownAppendage = false
+		}
+
+		return newState
+	}
+
 	componentDidMount() {
 		if (super.componentDidMount && typeof super.componentDidMount === 'function') {
 			super.componentDidMount()
 		}
 
-		const { itemElement } = this.props
+		const { itemElement, relative: relativeRendering } = this.props
+
+		let newState: Partial<IState> = {}
 
 		this.updateAnchoredElsWidths()
 		const metadata = this.props.piece.contentMetaData as MediaObject
 		if (metadata && metadata._rev) {
 			this.metadataRev = metadata._rev // update only if the metadata object changed
 
-			this.setState({
-				scenes: this.getScenes(),
-				freezes: this.getFreezes(),
-				blacks: this.getBlacks(),
-			})
+			newState.scenes = this.getScenes()
+			newState.freezes = this.getFreezes()
+			newState.blacks = this.getBlacks()
 		}
 
-		if (this.rightLabelContainer && itemElement) {
-			const itemDuration = this.getItemDuration(true)
-			if (itemDuration === Number.POSITIVE_INFINITY) {
-				itemElement.parentNode &&
-					itemElement.parentNode.parentNode &&
-					itemElement.parentNode.parentNode.parentNode &&
-					itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
+		newState = this.mountRightLabelContainer(this.props, null, newState, itemElement)
+		newState = this.mountSourceEndedCountdownContainer(this.props, newState, itemElement)
 
-				this.setState({
-					rightLabelIsAppendage: true,
-				})
-			} else {
-				itemElement.appendChild(this.rightLabelContainer)
-			}
-
-			// ReactDOM.render(this.rightLabelNodes, this.rightLabelContainer)
+		if (Object.keys(newState).length > 0) {
+			this.setState(newState as IState)
 		}
 	}
 
@@ -143,7 +206,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			this.updateAnchoredElsWidths()
 		}
 
-		const newState: Partial<IState> = {}
+		let newState: Partial<IState> = {}
 		if (
 			innerPiece.name !== prevProps.piece.instance.piece.name ||
 			innerPiece.status !== prevProps.piece.instance.piece.status
@@ -168,42 +231,12 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			newState.blacks = undefined
 		}
 
-		if (this.rightLabelContainer && itemElement) {
-			const itemDuration = this.getItemDuration(true)
-			if (itemElement !== prevProps.itemElement) {
-				if (itemDuration === Number.POSITIVE_INFINITY) {
-					itemElement.parentNode &&
-						itemElement.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
-
-					newState.rightLabelIsAppendage = true
-				} else {
-					this.rightLabelContainer?.remove()
-					itemElement.appendChild(this.rightLabelContainer)
-					newState.rightLabelIsAppendage = false
-				}
-			} else if (prevProps.partDuration !== this.props.partDuration) {
-				if (itemDuration === Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage === false) {
-					itemElement.parentNode &&
-						itemElement.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
-
-					newState.rightLabelIsAppendage = true
-				} else if (itemDuration !== Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage === true) {
-					this.rightLabelContainer?.remove()
-					itemElement.appendChild(this.rightLabelContainer)
-					newState.rightLabelIsAppendage = false
-				}
-			}
-		}
+		newState = this.mountRightLabelContainer(this.props, prevProps, newState, itemElement)
+		newState = this.mountSourceEndedCountdownContainer(this.props, newState, itemElement)
 
 		if (Object.keys(newState).length > 0) {
 			this.setState(newState as IState)
 		}
-
-		// ReactDOM.render(this.rightLabelNodes, this.rightLabelContainer!)
 	}
 
 	componentWillUnmount() {
@@ -212,9 +245,13 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		}
 
 		if (this.rightLabelContainer) {
-			// ReactDOM.unmountComponentAtNode(this.rightLabelContainer)
 			this.rightLabelContainer.remove()
 			this.rightLabelContainer = null
+		}
+
+		if (this.countdownContainer) {
+			this.countdownContainer.remove()
+			this.countdownContainer = null
 		}
 	}
 
@@ -366,6 +403,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 
 	renderRightLabel() {
 		const { begin, end } = this.state
+		const { isLiveLine, part } = this.props
 
 		const vtContent = this.props.piece.instance.piece.content as VTContent | undefined
 
@@ -389,9 +427,52 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 				)}
 				<span className="segment-timeline__piece__label last-words">{end}</span>
 				{this.renderInfiniteIcon()}
-				{this.renderOverflowTimeLabel()}
+				{(!isLiveLine || part.instance.part.autoNext) &&
+					this.renderOverflowTimeLabel() /* do not render the overflow time label if the part is live and will not autonext */}
 			</span>
 		)
+	}
+
+	renderContentEndCountdown() {
+		const { piece: uiPiece, part, isLiveLine, livePosition } = this.props
+		const innerPiece = uiPiece.instance.piece
+
+		const vtContent = innerPiece.content as VTContent | undefined
+		const seek = vtContent && vtContent.seek ? vtContent.seek : 0
+		let countdown: React.ReactNode = null
+		const livePositionInPart = (livePosition || 0) - part.startsAt
+		if (
+			isLiveLine &&
+			this.countdownContainer &&
+			livePositionInPart >= (uiPiece.renderedInPoint || 0) &&
+			vtContent &&
+			vtContent.sourceDuration !== undefined &&
+			((part.instance.part.autoNext &&
+				(uiPiece.renderedInPoint || 0) + (vtContent.sourceDuration - seek) < (this.props.partDuration || 0)) ||
+				(!part.instance.part.autoNext &&
+					Math.abs(
+						(this.props.piece.renderedInPoint || 0) +
+							(vtContent.sourceDuration - seek) -
+							(this.props.partExpectedDuration || 0)
+					) > 500))
+		) {
+			const endOfContentAt = (this.props.piece.renderedInPoint || 0) + (vtContent.sourceDuration - seek)
+			const counter = endOfContentAt - livePositionInPart
+
+			if (counter > 0) {
+				countdown = (
+					<div
+						className="segment-timeline__liveline__apendage segment-timeline__liveline__apendage--piece-countdown"
+						style={{
+							top: `calc(${this.props.layerIndex} * var(--segment-layer-height))`,
+						}}>
+						{RundownUtils.formatDiffToTimecode(counter || 0, true, false, true, false, true, '', false, false)}
+					</div>
+				)
+			}
+		}
+
+		return this.countdownContainer && ReactDOM.createPortal(countdown, this.countdownContainer)
 	}
 
 	render() {
@@ -409,6 +490,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 		return (
 			<React.Fragment>
 				{this.renderInfiniteItemContentEnded()}
+				{this.renderContentEndCountdown()}
 				{this.state.scenes &&
 					this.state.scenes.map(
 						(i) =>

--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -96,10 +96,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			const itemDuration = this.getItemDuration(true)
 			if (prevProps === null || itemElement !== prevProps.itemElement) {
 				if (itemDuration === Number.POSITIVE_INFINITY) {
-					itemElement.parentNode &&
-						itemElement.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
+					itemElement.parentElement?.parentElement?.parentElement?.appendChild(this.rightLabelContainer)
 
 					newState.rightLabelIsAppendage = true
 				} else {
@@ -107,12 +104,9 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 					itemElement.appendChild(this.rightLabelContainer)
 					newState.rightLabelIsAppendage = false
 				}
-			} else if (prevProps && prevProps.partDuration !== props.partDuration) {
+			} else if (prevProps?.partDuration !== props.partDuration) {
 				if (itemDuration === Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage !== true) {
-					itemElement.parentNode &&
-						itemElement.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode &&
-						itemElement.parentNode.parentNode.parentNode.appendChild(this.rightLabelContainer)
+					itemElement.parentElement?.parentElement?.parentElement?.appendChild(this.rightLabelContainer)
 
 					newState.rightLabelIsAppendage = true
 				} else if (itemDuration !== Number.POSITIVE_INFINITY && this.state.rightLabelIsAppendage === true) {
@@ -462,7 +456,7 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			if (counter > 0) {
 				countdown = (
 					<div
-						className="segment-timeline__liveline__apendage segment-timeline__liveline__apendage--piece-countdown"
+						className="segment-timeline__liveline__appendage segment-timeline__liveline__appendage--piece-countdown"
 						style={{
 							top: `calc(${this.props.layerIndex} * var(--segment-layer-height))`,
 						}}>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -40,6 +40,7 @@ interface ISourceLayerPropsBase {
 	mediaPreviewUrl: string
 	startsAt: number
 	duration: number
+	expectedDuration: number
 	timeScale: number
 	isLiveLine: boolean
 	isNextLine: boolean
@@ -117,6 +118,7 @@ class SourceLayer extends SourceLayerBase<ISourceLayerProps> {
 							part={this.props.part}
 							partStartsAt={this.props.startsAt}
 							partDuration={this.props.duration}
+							partExpectedDuration={this.props.expectedDuration}
 							timeScale={this.props.timeScale}
 							relative={this.props.relative}
 							autoNextPart={this.props.autoNextPart}
@@ -196,6 +198,7 @@ class FlattenedSourceLayers extends SourceLayerBase<IFlattenedSourceLayerProps> 
 								part={this.props.part}
 								partStartsAt={this.props.startsAt}
 								partDuration={this.props.duration}
+								partExpectedDuration={this.props.expectedDuration}
 								timeScale={this.props.timeScale}
 								relative={this.props.relative}
 								autoNextPart={this.props.autoNextPart}
@@ -236,6 +239,7 @@ interface IOutputGroupProps {
 	mediaPreviewUrl: string
 	startsAt: number
 	duration: number
+	expectedDuration: number
 	timeScale: number
 	collapsedOutputs: {
 		[key: string]: boolean
@@ -275,6 +279,7 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 							part={this.props.part}
 							startsAt={this.props.startsAt}
 							duration={this.props.duration}
+							expectedDuration={this.props.expectedDuration}
 							timeScale={this.props.timeScale}
 							autoNextPart={this.props.autoNextPart}
 							liveLinePadding={this.props.liveLinePadding}
@@ -308,6 +313,7 @@ class OutputGroup extends React.PureComponent<IOutputGroupProps> {
 						part={this.props.part}
 						startsAt={this.props.startsAt}
 						duration={this.props.duration}
+						expectedDuration={this.props.expectedDuration}
 						timeScale={this.props.timeScale}
 						autoNextPart={this.props.autoNextPart}
 						liveLinePadding={this.props.liveLinePadding}
@@ -628,6 +634,16 @@ export const SegmentTimelinePart = withTranslation()(
 				}
 			}
 
+			static getPartExpectedDuration(props: WithTiming<IProps>): number {
+				return (
+					props.part.instance.timings?.duration ||
+					(props.timingDurations.partDisplayDurations &&
+						props.timingDurations.partDisplayDurations[unprotectString(props.part.instance.part._id)]) ||
+					props.part.renderedDuration ||
+					0
+				)
+			}
+
 			static getPartDuration(props: WithTiming<IProps>, liveDuration: number): number {
 				// const part = this.props.part
 
@@ -639,10 +655,6 @@ export const SegmentTimelinePart = withTranslation()(
 						props.part.renderedDuration ||
 						0
 				)
-
-				/* return part.duration !== undefined ? part.duration : Math.max(
-			((this.props.timingDurations.partDurations && this.props.timingDurations.partDurations[unprotectString(part._id)]) || 0),
-			this.props.part.renderedDuration || 0, this.state.liveDuration, 0) */
 			}
 
 			static getPartStartsAt(props: WithTiming<IProps>): number {
@@ -697,6 +709,7 @@ export const SegmentTimelinePart = withTranslation()(
 										studio={this.props.studio}
 										startsAt={SegmentTimelinePart0.getPartStartsAt(this.props) || this.props.part.startsAt || 0}
 										duration={SegmentTimelinePart0.getPartDuration(this.props, this.state.liveDuration)}
+										expectedDuration={SegmentTimelinePart0.getPartExpectedDuration(this.props)}
 										isLiveLine={this.props.playlist.currentPartInstanceId === part.instance._id}
 										isNextLine={this.props.playlist.nextPartInstanceId === part.instance._id}
 										timeScale={this.props.timeScale}

--- a/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/meteor/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -30,6 +30,7 @@ export interface ISourceLayerItemProps {
 	part: PartUi
 	partStartsAt: number
 	partDuration: number
+	partExpectedDuration: number
 	piece: PieceUi
 	timeScale: number
 	isLiveLine: boolean


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature

* **What is the current behavior?** (You can also link to an open issue here)

There is no countdown displayed to the end of content (freeze frame for clips).

* **What is the new behavior (if this is a feature change)?**

This PR adds a feature where if:
* On a On Air Part (current part)
* A Piece is currently On Air (so it should have started and hasn't ended yet)
* Has a defined `content.sourceDuration` property (this info may also be injected from a MediaObject, if not set by the blueprints)
* And either: 
  * The Part will Auto-Next, but the end of Piece content is before the end of Part
  * The Part will not Auto-Next and the difference between expected end of Part (based on expectedDuration, displayDuration, etc.) and the end of Piece content is more than +/- 500ms

A countdown will be displayed attached to the On Air line, with a counter counting down to the end of content (freeze frame).

![Feature screenshot](https://user-images.githubusercontent.com/3635991/104474840-b55f4900-55be-11eb-8c27-54473b22dcec.png)

The feature is turned on automatically on all STK & VT-type pieces and requires no additional configuration.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
