### PR TITLE
feat: double click on AdLib in the Dashboard and Buckets to trigger

### DIFF
--- a/meteor/client/lib/lib.tsx
+++ b/meteor/client/lib/lib.tsx
@@ -99,6 +99,10 @@ export function ensureHasTrailingSlash(input: string | null): string | null {
 	}
 }
 
+/**
+ * This CSS Variable is used to indicate to the UI that it's being run on a Browser without ordinary pointers
+ * but one that emulates mouse-clicks using some other input method (like a Stream Deck).
+ */
 export const USER_AGENT_POINTER_PROPERTY = '--pointer'
 export enum UserAgentPointer {
 	NO_POINTER = 'no-pointer',

--- a/meteor/client/lib/lib.tsx
+++ b/meteor/client/lib/lib.tsx
@@ -98,3 +98,8 @@ export function ensureHasTrailingSlash(input: string | null): string | null {
 		return input
 	}
 }
+
+export const USER_AGENT_POINTER_PROPERTY = '--pointer'
+export enum UserAgentPointer {
+	NO_POINTER = 'no-pointer',
+}

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -6,6 +6,9 @@
 	/** Stream Deck Mini,
 	button size 80px */ screen and (width: 240px) and (height: 160px) {
 	:root {
+		// by setting the --pointer CSS variable, we indicate to the UI that it's being run on a Stream Deck and
+		// that it should run in a single-click-to-activate mode (like a touchscreen) even though the events emitted
+		// are mouse clicks
 		--pointer: 'no-pointer';
 	}
 

--- a/meteor/client/styles/shelf/dashboard-streamdeck.scss
+++ b/meteor/client/styles/shelf/dashboard-streamdeck.scss
@@ -5,6 +5,10 @@
 	button size 96px */ screen and (width: 768px) and (height: 384px),
 	/** Stream Deck Mini,
 	button size 80px */ screen and (width: 240px) and (height: 160px) {
+	:root {
+		--pointer: 'no-pointer';
+	}
+
 	#render-target > .container-fluid > .rundown-view {
 		background: #000;
 

--- a/meteor/client/styles/shelf/dashboard.scss
+++ b/meteor/client/styles/shelf/dashboard.scss
@@ -261,7 +261,7 @@ $dashboard-button-height: 5.625em;
 		border: none;
 		margin: 4px;
 		vertical-align: top;
-		cursor: pointer;
+		cursor: default;
 
 		@include item-type-colors();
 		@include invalid-overlay();
@@ -323,7 +323,8 @@ $dashboard-button-height: 5.625em;
 			box-shadow: none;
 		}
 
-		&:active {
+		&:active,
+		&.active {
 			&::before {
 				content: ' ';
 				display: block;

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -33,21 +33,23 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 
 	iframeElement: HTMLIFrameElement
 
-	private _intersections: {
-		boundingClientRect: {
-			top: number
-			right: number
-			bottom: number
-			left: number
-		}
-		intersectionRect: {
-			top: number
-			right: number
-			bottom: number
-			left: number
-		}
-	}
-	private _observer: IntersectionObserver
+	private _intersections:
+		| {
+				boundingClientRect: {
+					top: number
+					right: number
+					bottom: number
+					left: number
+				}
+				intersectionRect: {
+					top: number
+					right: number
+					bottom: number
+					left: number
+				}
+		  }
+		| undefined
+	private _observer: IntersectionObserver | undefined
 
 	static show(noraContent: NoraContent, style: React.CSSProperties) {
 		NoraPreviewRenderer._singletonRef._show(noraContent, style)
@@ -111,19 +113,21 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		let x = this.state.flip.x
 		let y = this.state.flip.y
 
-		if (y && this._intersections.intersectionRect.bottom < this._intersections.boundingClientRect.bottom) {
-			// flip to bottom
-			y = false
-		} else if (!y && this._intersections.intersectionRect.top > this._intersections.boundingClientRect.top) {
-			// flip to top
-			y = true
-		}
-		if (x && this._intersections.intersectionRect.right < this._intersections.boundingClientRect.right) {
-			// flip to bottom
-			x = false
-		} else if (!x && this._intersections.intersectionRect.left > this._intersections.boundingClientRect.left) {
-			// flip to top
-			x = true
+		if (this._intersections) {
+			if (y && this._intersections.intersectionRect.bottom < this._intersections.boundingClientRect.bottom) {
+				// flip to bottom
+				y = false
+			} else if (!y && this._intersections.intersectionRect.top > this._intersections.boundingClientRect.top) {
+				// flip to top
+				y = true
+			}
+			if (x && this._intersections.intersectionRect.right < this._intersections.boundingClientRect.right) {
+				// flip to bottom
+				x = false
+			} else if (!x && this._intersections.intersectionRect.left > this._intersections.boundingClientRect.left) {
+				// flip to top
+				x = true
+			}
 		}
 
 		this.setState({
@@ -178,7 +182,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	componentWillUnmount() {
-		this._observer.disconnect()
+		if (this._observer) this._observer.disconnect()
 	}
 
 	getElStyle() {

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -764,6 +764,19 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 									/>
 								</label>
 							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Toggle AdLibs on single mouse click')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.toggleOnSingleClick`}
+										obj={item}
+										type="checkbox"
+										collection={RundownLayouts}
+										className="mod mas"
+									/>
+								</label>
+							</div>
 						</React.Fragment>
 					)}
 				</React.Fragment>

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -724,6 +724,8 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 					this._panel = ref
 					if (this._panel) {
 						const style = window.getComputedStyle(this._panel)
+						// check if a special variable is set through CSS to indicate that we shouldn't expect
+						// double clicks to trigger AdLibs
 						const value = style.getPropertyValue(USER_AGENT_POINTER_PROPERTY)
 						if (this.state.singleClickMode !== (value === UserAgentPointer.NO_POINTER)) {
 							this.setState({

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -30,7 +30,12 @@ import { PubSub } from '../../../lib/api/pubsub'
 import { doUserAction, UserAction } from '../../lib/userAction'
 import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications'
 import { literal, unprotectString, partial, protectString } from '../../../lib/lib'
-import { ensureHasTrailingSlash, contextMenuHoldToDisplayTime } from '../../lib/lib'
+import {
+	ensureHasTrailingSlash,
+	contextMenuHoldToDisplayTime,
+	UserAgentPointer,
+	USER_AGENT_POINTER_PROPERTY,
+} from '../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
 import {
 	IDashboardPanelTrackedProps,
@@ -156,6 +161,7 @@ interface IState {
 	dropActive: boolean
 	bucketName: string
 	adLibPieces: BucketAdLibItem[]
+	singleClickMode: boolean
 }
 
 export function actionToAdLibPieceUi(
@@ -341,6 +347,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						dropActive: false,
 						bucketName: props.bucket.name,
 						adLibPieces: props.adLibPieces.slice(),
+						singleClickMode: false,
 					}
 				}
 
@@ -713,6 +720,19 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 					}
 				}
 
+				private setRef = (ref: HTMLDivElement) => {
+					this._panel = ref
+					if (this._panel) {
+						const style = window.getComputedStyle(this._panel)
+						const value = style.getPropertyValue(USER_AGENT_POINTER_PROPERTY)
+						if (this.state.singleClickMode !== (value === UserAgentPointer.NO_POINTER)) {
+							this.setState({
+								singleClickMode: value === UserAgentPointer.NO_POINTER,
+							})
+						}
+					}
+				}
+
 				render() {
 					const { isDragging, connectDragSource, connectDragPreview, connectDropTarget } = this.props
 					const opacity = isDragging ? 0 : 1
@@ -726,7 +746,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 										'dashboard-panel__panel--sort-dragging': this.props.isDragging,
 									})}
 									data-bucket-id={this.props.bucket._id}
-									ref={(el) => (this._panel = el)}>
+									ref={this.setRef}>
 									{this.props.editableName ? (
 										<input
 											className="h4 dashboard-panel__header"
@@ -797,6 +817,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 														RundownUtils.isAdLibPiece(this.props.selectedPiece) &&
 														adlib._id === this.props.selectedPiece._id
 													}
+													toggleOnSingleClick={this.state.singleClickMode}
 													displayStyle={PieceDisplayStyle.BUTTONS}>
 													{adlib.name}
 												</BucketPieceButton>

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -211,6 +211,7 @@ export interface IBucketPanelProps {
 	moveBucket: (id: BucketId, atIndex: number) => void
 	findBucket: (id: BucketId) => { bucket: Bucket | undefined; index: number }
 	onBucketReorder: (draggedId: BucketId, newIndex: number, oldIndex: number) => void
+	onSelectAdlib
 	onAdLibContext: (args: { contextBucket: Bucket; contextBucketAdLib: BucketAdLibItem }, callback: () => void) => void
 	onPieceNameRename: () => void
 }
@@ -449,6 +450,8 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						)
 					}
 				}
+
+				onSelectAdLib = (piece: BucketAdLibItem, e: any) => {}
 
 				onToggleAdLib = (piece: BucketAdLibItem, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => {
 					const { t } = this.props
@@ -774,6 +777,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 													layer={this.props.sourceLayers[adlib.sourceLayerId]}
 													outputLayer={this.props.outputLayers[adlib.outputLayerId]}
 													onToggleAdLib={this.onToggleAdLib as any}
+													onSelectAdLib={this.onSelectAdLib as any}
 													playlist={this.props.playlist}
 													isOnAir={this.isAdLibOnAir((adlib as any) as AdLibPieceUi)}
 													mediaPreviewUrl={

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -32,6 +32,7 @@ import { MeteorCall } from '../../../lib/api/methods'
 import { PartInstanceId } from '../../../lib/collections/PartInstances'
 import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import { setShelfContextMenuContext, ContextType } from './ShelfContextMenu'
+import { RundownUtils } from '../../lib/rundown'
 
 interface IState {
 	outputLayers: {
@@ -120,7 +121,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	static getDerivedStateFromProps(props: IAdLibPanelProps, state) {
+	static getDerivedStateFromProps(props: IAdLibPanelProps, state: IState): Partial<IState> | null {
 		let tOLayers: {
 			[key: string]: IOutputLayer
 		} = {}
@@ -192,11 +193,41 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.refreshKeyboardHotkeys()
 	}
 
-	componentDidUpdate(prevProps: IAdLibPanelProps & AdLibFetchAndFilterProps) {
+	componentDidUpdate(prevProps: IAdLibPanelProps & AdLibFetchAndFilterProps, prevState: IState) {
+		const { selectedAdLib } = this.state
+		const { selectedPiece } = this.props
 		mousetrapHelper.unbindAll(this.usedHotkeys, 'keyup', this.props.hotkeyGroup)
 		this.usedHotkeys.length = 0
 
+		const newState: Partial<IState> = {}
+
 		this.refreshKeyboardHotkeys()
+		if (
+			selectedAdLib &&
+			selectedAdLib !== prevState.selectedAdLib &&
+			!(
+				selectedPiece &&
+				RundownUtils.isAdLibPieceOrAdLibListItem(selectedPiece) &&
+				selectedPiece?._id === selectedAdLib._id
+			)
+		) {
+			this.props.onSelectPiece && this.props.onSelectPiece(selectedAdLib)
+		} else if (
+			selectedPiece &&
+			selectedPiece !== prevProps.selectedPiece &&
+			RundownUtils.isAdLibPieceOrAdLibListItem(selectedPiece)
+		) {
+			let memberAdLib = DashboardPanelInner.filterOutAdLibs(this.props, this.state).find(
+				(adLib) => adLib._id === selectedPiece._id
+			)
+			if (memberAdLib) {
+				newState.selectedAdLib = memberAdLib
+			}
+		}
+
+		if (Object.keys(newState).length > 0) {
+			this.setState(newState as IState)
+		}
 	}
 
 	componentWillUnmount() {
@@ -207,15 +238,21 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.usedHotkeys.length = 0
 	}
 
-	isAdLibOnAir(adLib: AdLibPieceUi) {
+	protected static filterOutAdLibs(props: IAdLibPanelProps & AdLibFetchAndFilterProps, state: IState): AdLibPieceUi[] {
+		return props.rundownBaselineAdLibs
+			.concat(props.uiSegments.map((seg) => seg.pieces).flat())
+			.filter((item) => matchFilter(item, props.showStyleBase, props.uiSegments, props.filter, state.searchFilter))
+	}
+
+	protected isAdLibOnAir(adLib: AdLibPieceUi) {
 		return isAdLibOnAir(this.props.unfinishedAdLibIds, this.props.unfinishedTags, adLib)
 	}
 
-	isAdLibNext(adLib: AdLibPieceUi) {
+	protected isAdLibNext(adLib: AdLibPieceUi) {
 		return isAdLibNext(this.props.nextAdLibIds, this.props.unfinishedTags, this.props.nextTags, adLib)
 	}
 
-	refreshKeyboardHotkeys() {
+	protected refreshKeyboardHotkeys() {
 		if (!this.props.studioMode) return
 		if (!this.props.registerHotkeys) return
 
@@ -319,7 +356,21 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onToggleAdLib = (adlibPiece: AdLibPieceUi, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => {
+	protected onToggleOrSelectAdLib = (
+		adlibPiece: AdLibPieceUi,
+		queue: boolean,
+		e: any,
+		mode?: IBlueprintActionTriggerMode
+	) => {
+		const filter = this.props.filter as DashboardLayoutFilter | undefined
+		if (filter?.displayTakeButtons) {
+			this.onSelectAdLib(adlibPiece, e)
+		} else {
+			this.onToggleAdLib(adlibPiece, queue, e, mode)
+		}
+	}
+
+	protected onToggleAdLib = (adlibPiece: AdLibPieceUi, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => {
 		const { t } = this.props
 
 		queue = queue || this.props.shouldQueue
@@ -398,7 +449,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onToggleSticky = (sourceLayerId: string, e: any) => {
+	protected onToggleSticky = (sourceLayerId: string, e: any) => {
 		if (this.props.playlist && this.props.playlist.currentPartInstanceId && this.props.playlist.active) {
 			const { t } = this.props
 			doUserAction(t, e, UserAction.START_STICKY_PIECE, (e) =>
@@ -407,7 +458,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onClearAllSourceLayers = (sourceLayers: ISourceLayer[], e: any) => {
+	protected onClearAllSourceLayers = (sourceLayers: ISourceLayer[], e: any) => {
 		const { t } = this.props
 		if (this.props.playlist && this.props.playlist.currentPartInstanceId) {
 			const playlistId = this.props.playlist._id
@@ -423,13 +474,13 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onFilterChange = (filter: string) => {
+	protected onFilterChange = (filter: string) => {
 		this.setState({
 			searchFilter: filter,
 		})
 	}
 
-	onIn = (e: any) => {
+	protected onIn = (e: any) => {
 		const { t } = this.props
 		if (this.state.selectedAdLib) {
 			const piece = this.state.selectedAdLib
@@ -469,7 +520,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onOut = (e: any, outButton?: boolean) => {
+	protected onOut = (e: any, outButton?: boolean) => {
 		const { t } = this.props
 		if (this.state.selectedAdLib) {
 			const piece = this.state.selectedAdLib
@@ -480,7 +531,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 	}
 
-	onSelectAdLib = (piece: AdLibPieceUi, queue: boolean, e: any) => {
+	protected onSelectAdLib = (piece: AdLibPieceUi, e: any) => {
 		this.setState({
 			selectedAdLib: piece,
 		})
@@ -488,6 +539,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 
 	render() {
 		const { t } = this.props
+		const filteredAdLibs = DashboardPanelInner.filterOutAdLibs(this.props, this.state)
 		if (this.props.visible && this.props.showStyleBase && this.props.filter) {
 			const filter = this.props.filter as DashboardLayoutFilter
 			if (!this.props.uiSegments || !this.props.playlist) {
@@ -505,57 +557,47 @@ export class DashboardPanelInner extends MeteorReactComponent<
 							className={ClassNames('dashboard-panel__panel', {
 								'dashboard-panel__panel--horizontal': filter.overflowHorizontally,
 							})}>
-							{this.props.rundownBaselineAdLibs
-								.concat(_.flatten(this.props.uiSegments.map((seg) => seg.pieces)))
-								.filter((item) =>
-									matchFilter(
-										item,
-										this.props.showStyleBase,
-										this.props.uiSegments,
-										this.props.filter,
-										this.state.searchFilter
-									)
-								)
-								.map((adLibPiece: AdLibPieceUi) => {
-									return (
-										<ContextMenuTrigger
-											id="shelf-context-menu"
-											collect={() =>
-												setShelfContextMenuContext({
-													type: ContextType.ADLIB,
-													details: {
-														adLib: adLibPiece,
-														onToggle: this.onToggleAdLib,
-													},
-												})
+							{filteredAdLibs.map((adLibPiece: AdLibPieceUi) => {
+								return (
+									<ContextMenuTrigger
+										id="shelf-context-menu"
+										collect={() =>
+											setShelfContextMenuContext({
+												type: ContextType.ADLIB,
+												details: {
+													adLib: adLibPiece,
+													onToggle: this.onToggleAdLib,
+												},
+											})
+										}
+										renderTag="span"
+										key={unprotectString(adLibPiece._id)}
+										holdToDisplay={contextMenuHoldToDisplayTime()}>
+										<DashboardPieceButton
+											piece={adLibPiece}
+											studio={this.props.studio}
+											layer={this.state.sourceLayers[adLibPiece.sourceLayerId]}
+											outputLayer={this.state.outputLayers[adLibPiece.outputLayerId]}
+											onToggleAdLib={this.onToggleOrSelectAdLib}
+											onSelectAdLib={this.onSelectAdLib}
+											playlist={this.props.playlist}
+											isOnAir={this.isAdLibOnAir(adLibPiece)}
+											isNext={this.isAdLibNext(adLibPiece)}
+											mediaPreviewUrl={
+												this.props.studio
+													? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || ''
+													: ''
 											}
-											renderTag="span"
-											key={unprotectString(adLibPiece._id)}
-											holdToDisplay={contextMenuHoldToDisplayTime()}>
-											<DashboardPieceButton
-												piece={adLibPiece}
-												studio={this.props.studio}
-												layer={this.state.sourceLayers[adLibPiece.sourceLayerId]}
-												outputLayer={this.state.outputLayers[adLibPiece.outputLayerId]}
-												onToggleAdLib={filter.displayTakeButtons ? this.onSelectAdLib : this.onToggleAdLib}
-												playlist={this.props.playlist}
-												isOnAir={this.isAdLibOnAir(adLibPiece)}
-												isNext={this.isAdLibNext(adLibPiece)}
-												mediaPreviewUrl={
-													this.props.studio
-														? ensureHasTrailingSlash(this.props.studio.settings.mediaPreviewsUrl + '' || '') || ''
-														: ''
-												}
-												widthScale={filter.buttonWidthScale}
-												heightScale={filter.buttonHeightScale}
-												displayStyle={filter.displayStyle}
-												showThumbnailsInList={filter.showThumbnailsInList}
-												isSelected={this.state.selectedAdLib && adLibPiece._id === this.state.selectedAdLib._id}>
-												{adLibPiece.name}
-											</DashboardPieceButton>
-										</ContextMenuTrigger>
-									)
-								})}
+											widthScale={filter.buttonWidthScale}
+											heightScale={filter.buttonHeightScale}
+											displayStyle={filter.displayStyle}
+											showThumbnailsInList={filter.showThumbnailsInList}
+											isSelected={this.state.selectedAdLib && adLibPiece._id === this.state.selectedAdLib._id}>
+											{adLibPiece.name}
+										</DashboardPieceButton>
+									</ContextMenuTrigger>
+								)
+							})}
 						</div>
 						{filter.displayTakeButtons && (
 							<div className="dashboard-panel__buttons">

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -209,6 +209,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		const newState: Partial<IState> = {}
 
 		this.refreshKeyboardHotkeys()
+		// Synchronize the internal selectedAdlib state with the outer selectedPiece
 		if (
 			selectedAdLib &&
 			selectedAdLib !== prevState.selectedAdLib &&
@@ -218,12 +219,17 @@ export class DashboardPanelInner extends MeteorReactComponent<
 				selectedPiece?._id === selectedAdLib._id
 			)
 		) {
+			// If the local selectedAdLib is changing, inform the application that the selection has changed
+			// (this will change the inspected AdLib in the inspector)
 			this.props.onSelectPiece && this.props.onSelectPiece(selectedAdLib)
 		} else if (
 			selectedPiece &&
 			selectedPiece !== prevProps.selectedPiece &&
 			RundownUtils.isAdLibPieceOrAdLibListItem(selectedPiece)
 		) {
+			// If the outer selectedPiece is changing, we should check if it's present in this Panel. If it is
+			// we should change our inner selectedAdLib state. If it isn't, we should leave it be, so that it
+			// doesn't affect any selections the user may have made when using "displayTakeButtons".
 			let memberAdLib = DashboardPanelInner.filterOutAdLibs(this.props, this.state).find(
 				(adLib) => adLib._id === selectedPiece._id
 			)
@@ -548,6 +554,8 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		const _panel = ref
 		if (_panel) {
 			const style = window.getComputedStyle(_panel)
+			// check if a special variable is set through CSS to indicate that we shouldn't expect
+			// double clicks to trigger AdLibs
 			const value = style.getPropertyValue(USER_AGENT_POINTER_PROPERTY)
 			if (this.state.singleClickMode !== (value === UserAgentPointer.NO_POINTER)) {
 				this.setState({

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -23,7 +23,12 @@ import {
 	AdLibPanelToolbar,
 } from './AdLibPanel'
 import { DashboardPieceButton } from './DashboardPieceButton'
-import { ensureHasTrailingSlash, contextMenuHoldToDisplayTime } from '../../lib/lib'
+import {
+	ensureHasTrailingSlash,
+	contextMenuHoldToDisplayTime,
+	UserAgentPointer,
+	USER_AGENT_POINTER_PROPERTY,
+} from '../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
 import { PieceId } from '../../../lib/collections/Pieces'
 import { invalidateAt } from '../../lib/invalidatingTime'
@@ -43,6 +48,7 @@ interface IState {
 	}
 	searchFilter: string | undefined
 	selectedAdLib?: AdLibPieceUi
+	singleClickMode: boolean
 }
 
 const BUTTON_GRID_WIDTH = 1
@@ -118,6 +124,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 			outputLayers: {},
 			sourceLayers: {},
 			searchFilter: undefined,
+			singleClickMode: false,
 		}
 	}
 
@@ -537,6 +544,19 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		})
 	}
 
+	protected setRef = (ref: HTMLDivElement) => {
+		const _panel = ref
+		if (_panel) {
+			const style = window.getComputedStyle(_panel)
+			const value = style.getPropertyValue(USER_AGENT_POINTER_PROPERTY)
+			if (this.state.singleClickMode !== (value === UserAgentPointer.NO_POINTER)) {
+				this.setState({
+					singleClickMode: value === UserAgentPointer.NO_POINTER,
+				})
+			}
+		}
+	}
+
 	render() {
 		const { t } = this.props
 		const filteredAdLibs = DashboardPanelInner.filterOutAdLibs(this.props, this.state)
@@ -550,6 +570,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 						className={ClassNames('dashboard-panel', {
 							'dashboard-panel--take': filter.displayTakeButtons,
 						})}
+						ref={this.setRef}
 						style={dashboardElementPosition(filter)}>
 						<h4 className="dashboard-panel__header">{this.props.filter.name}</h4>
 						{filter.enableSearch && <AdLibPanelToolbar onFilterChange={this.onFilterChange} />}
@@ -592,6 +613,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 											heightScale={filter.buttonHeightScale}
 											displayStyle={filter.displayStyle}
 											showThumbnailsInList={filter.showThumbnailsInList}
+											toggleOnSingleClick={filter.toggleOnSingleClick || this.state.singleClickMode}
 											isSelected={this.state.selectedAdLib && adLibPiece._id === this.state.selectedAdLib._id}>
 											{adLibPiece.name}
 										</DashboardPieceButton>

--- a/meteor/client/ui/Shelf/RundownViewBuckets.tsx
+++ b/meteor/client/ui/Shelf/RundownViewBuckets.tsx
@@ -599,6 +599,7 @@ export const RundownViewBuckets = withTranslation()(
 												findBucket={this.findBucket}
 												onBucketReorder={this.onBucketReorder}
 												onAdLibContext={this.onAdLibContext}
+												onSelectAdlib={this.props.onSelectPiece}
 												selectedPiece={this.props.selectedPiece}
 												hotkeyGroup={bucket.name.replace(/\W/, '_') + 'BucketPanel'}
 											/>

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -476,6 +476,8 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 										studioMode={this.props.studioMode}
 										rundownLayout={this.props.rundownLayout}
 										shouldQueue={this.state.shouldQueue}
+										selectedPiece={this.state.selectedPiece}
+										onSelectPiece={this.selectPiece}
 										onChangeQueueAdLib={this.changeQueueAdLib}
 										studio={this.props.studio}
 									/>

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -12,6 +12,10 @@ import { Bucket } from '../../../lib/collections/Buckets'
 import { unprotectString } from '../../../lib/lib'
 import { AdLibRegionPanel } from './AdLibRegionPanel'
 import { Studio } from '../../../lib/collections/Studios'
+import { BucketAdLibItem } from './RundownViewBuckets'
+import { IAdLibListItem } from './AdLibListItem'
+import { PieceUi } from '../SegmentTimeline/SegmentTimelineContainer'
+import { AdLibPieceUi } from './AdLibPanel'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -22,6 +26,9 @@ export interface IShelfDashboardLayoutProps {
 	shouldQueue: boolean
 	studio: Studio
 	onChangeQueueAdLib: (isQueue: boolean, e: any) => void
+
+	selectedPiece: BucketAdLibItem | IAdLibListItem | PieceUi | undefined
+	onSelectPiece: (piece: AdLibPieceUi | PieceUi) => void
 }
 
 export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
@@ -45,7 +52,8 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 								studioMode={props.studioMode}
 								shouldQueue={props.shouldQueue}
 								studio={props.studio}
-								selectedPiece={undefined}
+								selectedPiece={props.selectedPiece}
+								onSelectPiece={props.onSelectPiece}
 							/>
 						) : (
 							<DashboardPanel
@@ -60,7 +68,8 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 								studioMode={props.studioMode}
 								shouldQueue={props.shouldQueue}
 								studio={props.studio}
-								selectedPiece={undefined}
+								selectedPiece={props.selectedPiece}
+								onSelectPiece={props.onSelectPiece}
 							/>
 						)
 					) : RundownLayoutsAPI.isExternalFrame(panel) ? (
@@ -83,7 +92,8 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 							playlist={props.playlist}
 							showStyleBase={props.showStyleBase}
 							studioMode={props.studioMode}
-							selectedPiece={undefined}
+							selectedPiece={props.selectedPiece}
+							onSelectPiece={props.onSelectPiece}
 							studio={props.studio}
 							hotkeyGroup={panel.name.replace(/\W/, '_')}
 						/>

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -65,6 +65,7 @@ export const TimelineDashboardPanel = translateWithTracker<
 		scrollIntoViewTimeout: NodeJS.Timer | undefined = undefined
 		setRef = (el: HTMLDivElement) => {
 			this.liveLine = el
+			super.setRef(el)
 			this.ensureLiveLineVisible()
 		}
 		componentDidUpdate(prevProps, prevState) {
@@ -136,7 +137,8 @@ export const TimelineDashboardPanel = translateWithTracker<
 													widthScale={filter.buttonWidthScale}
 													heightScale={filter.buttonHeightScale}
 													displayStyle={PieceDisplayStyle.BUTTONS}
-													showThumbnailsInList={filter.showThumbnailsInList}>
+													showThumbnailsInList={filter.showThumbnailsInList}
+													toggleOnSingleClick={this.state.singleClickMode}>
 													{adLibListItem.name}
 												</DashboardPieceButton>
 											)

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -26,6 +26,7 @@ import {
 	getNextPieceInstancesGrouped,
 } from './DashboardPanel'
 import { unprotectString } from '../../../lib/lib'
+import { RundownUtils } from '../../lib/rundown'
 interface IState {
 	outputLayers: {
 		[key: string]: IOutputLayer
@@ -66,8 +67,8 @@ export const TimelineDashboardPanel = translateWithTracker<
 			this.liveLine = el
 			this.ensureLiveLineVisible()
 		}
-		componentDidUpdate(prevProps) {
-			super.componentDidUpdate(prevProps)
+		componentDidUpdate(prevProps, prevState) {
+			super.componentDidUpdate(prevProps, prevState)
 			this.ensureLiveLineVisible()
 		}
 		componentDidMount() {
@@ -117,7 +118,14 @@ export const TimelineDashboardPanel = translateWithTracker<
 													studio={this.props.studio}
 													layer={this.state.sourceLayers[adLibListItem.sourceLayerId]}
 													outputLayer={this.state.outputLayers[adLibListItem.outputLayerId]}
-													onToggleAdLib={this.onToggleAdLib}
+													onToggleAdLib={this.onToggleOrSelectAdLib}
+													onSelectAdLib={this.onSelectAdLib}
+													isSelected={
+														(this.props.selectedPiece &&
+															RundownUtils.isAdLibPiece(this.props.selectedPiece) &&
+															this.props.selectedPiece._id === adLibListItem._id) ||
+														false
+													}
 													playlist={this.props.playlist}
 													isOnAir={this.isAdLibOnAir(adLibListItem)}
 													mediaPreviewUrl={
@@ -167,7 +175,14 @@ export const TimelineDashboardPanel = translateWithTracker<
 														piece={adLibListItem}
 														layer={this.state.sourceLayers[adLibListItem.sourceLayerId]}
 														outputLayer={this.state.outputLayers[adLibListItem.outputLayerId]}
-														onToggleAdLib={this.onToggleAdLib}
+														onToggleAdLib={this.onToggleOrSelectAdLib}
+														onSelectAdLib={this.onSelectAdLib}
+														isSelected={
+															(this.props.selectedPiece &&
+																RundownUtils.isAdLibPiece(this.props.selectedPiece) &&
+																this.props.selectedPiece._id === adLibListItem._id) ||
+															false
+														}
 														playlist={this.props.playlist}
 														studio={this.props.studio}
 														isOnAir={this.isAdLibOnAir(adLibListItem)}

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -125,6 +125,7 @@ export interface DashboardLayoutFilter extends RundownLayoutFilterBase {
 	hide?: boolean
 	displayTakeButtons?: boolean
 	queueAllAdlibs?: boolean
+	toggleOnSingleClick?: boolean
 }
 
 /** A string, identifying a RundownLayout */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a feature/behavior change

* **What is the current behavior?** (You can also link to an open issue here)

Currently, AdLibs in the Dashboard and Buckets can be triggered by a single click, a tap on a touchscreen and they can be inspected using the context menu. Stream Deck requires a single button press (that is translated to a simulated mouse click)

* **What is the new behavior (if this is a feature change)?**

In order to make the behavior model the same for both the regular Shelf and the Bucket and Dashboard panels, when using a mouse, the user will single click on an AdLib to Select it, Double-click on an AdLib to trigger & single-tap (using a touchscreen) to trigger. A single button press on a Stream Deck should still work to trigger the AdLib (the UI should automatically detect that it's being displayed on a Stream Deck and switch to a single-click-to-trigger mode)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
