### PR TITLE
feat(Midi): Adds support for multiple midi inputs

### DIFF
--- a/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
+++ b/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
@@ -99,11 +99,11 @@ export class MidiPedalController extends ControllerAbstract {
 		}
 
 		console.log('WebMIDI enabled')
-		webmidi.addListener('connected', (e) => {
+		webmidi.addListener('connected', () => {
 			this.updateMidiInputs()
 		})
 		webmidi.addListener('disconnected', () => {
-			this.updateMidiInputs()		
+			this.updateMidiInputs()
 		})
 	}
 
@@ -120,7 +120,6 @@ export class MidiPedalController extends ControllerAbstract {
 
 		this.midiInputs.forEach((i) => i.addListener('controlchange', 8, this.onMidiInputCC))
 	}
-
 
 	private onMidiInputCC = (e: InputEventControlchange) => {
 		const { rangeRevMin, rangeNeutralMin, rangeNeutralMax, rangeFwdMax } = this

--- a/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
+++ b/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
@@ -118,11 +118,11 @@ export class MidiPedalController extends ControllerAbstract {
 			return i.type === 'input' && i.connection === 'open' && i.state === 'connected'
 		})
 
-		this.midiInputs.forEach((i) => i.addListener('controlchange', 8, this.onMidiInputCC.bind(this)))
+		this.midiInputs.forEach((i) => i.addListener('controlchange', 8, this.onMidiInputCC))
 	}
 
 
-	private onMidiInputCC(e: InputEventControlchange) {
+	private onMidiInputCC = (e: InputEventControlchange) => {
 		const { rangeRevMin, rangeNeutralMin, rangeNeutralMax, rangeFwdMax } = this
 		let inputValue = e.value || 0
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to have multiple midi devices (pedals) connected to the prompter at the same time.


* **What is the current behavior?** (You can also link to an open issue here)
Only allows for a single device at the time.


* **What is the new behavior (if this is a feature change)?**
Listens to all connected inputs. Accepts CC notes on channel 8 from all active inputs.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
