### PR TITLE
Fix: looping playlists

### DIFF
--- a/meteor/client/lib/ui/icons/looping.tsx
+++ b/meteor/client/lib/ui/icons/looping.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export function LoopingIcon() {
+	return (
+		<svg version="1.1" viewBox="0 0 20.91 11.22" width="1em" height="1em" className="icon">
+			<path
+				fill="currentColor"
+				d="M16.48,1.17H8.9v1.7h7.58c0.32,0,0.59,0.26,0.59,0.59v4.09c0,0.32-0.26,0.58-0.59,0.58H6.43
+                c-0.32,0-0.59-0.26-0.59-0.59v-1.9H9.2L4.99,1.44L0.79,5.64h3.36v1.9c0,1.26,1.03,2.29,2.29,2.29h10.04c1.26,0,2.29-1.03,2.29-2.29
+                V3.45C18.76,2.19,17.74,1.17,16.48,1.17z"
+			/>
+		</svg>
+	)
+}

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -473,6 +473,11 @@ body.no-overflow {
 	width: auto;
 }
 
+svg.icon {
+	margin-top: -0.2em;
+	position: relative;
+}
+
 // A component for displaying the segments (ENPS Stories/NKR Titles)
 .segment-timeline {
 	display: grid;
@@ -1392,6 +1397,10 @@ body.no-overflow {
 					position: absolute;
 					top: 50%;
 					transform: translateY(calc(-50% - 6px));
+				}
+
+				&.loop {
+					border-left: 0;
 				}
 			}
 

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -10,6 +10,7 @@ import { RundownUtils } from '../../lib/rundown'
 import { iconDragHandle, iconRemove, iconResync } from './icons'
 import JonasFormattedTime from './JonasFormattedTime'
 import { EyeIcon } from '../../lib/ui/icons/rundownList'
+import { LoopingIcon } from '../../lib/ui/icons/looping'
 
 interface IRundownListItemViewProps {
 	isActive: boolean
@@ -104,6 +105,7 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 				) : (
 					<span className="dimmed">{t('Not set')}</span>
 				)}
+				{rundown.getRundownPlaylist().loop && <LoopingIcon />}
 			</span>
 			<span className="rundown-list-item__text">
 				<JonasFormattedTime timestamp={rundown.modified} t={t} />

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -6,6 +6,7 @@ import { withTiming, WithTiming } from './RundownTiming/withTiming'
 import { RundownUtils } from '../../lib/rundown'
 import { withTranslation } from 'react-i18next'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { LoopingIcon } from '../../lib/ui/icons/looping'
 
 interface IProps {
 	rundown: Rundown
@@ -107,6 +108,26 @@ export const RundownDividerHeader = withTranslation()(
 							<Moment interval={0} format="HH:mm:ss" date={rundown.expectedDuration} />
 						</div>
 					) : null}
+				</div>
+			)
+		}
+	}
+)
+
+interface ILoopingHeaderProps {
+	playlist: RundownPlaylist
+}
+export const RundownLoopingHeader = withTranslation()(
+	class RundownLoopingHeader extends React.Component<Translated<ILoopingHeaderProps>> {
+		render() {
+			const { t, playlist } = this.props
+			return (
+				<div className="rundown-divider-timeline">
+					<h3 className="rundown-divider-timeline__playlist-name">
+						<LoopingIcon />
+						&nbsp;
+						{t('Looping')}: {playlist.name}
+					</h3>
 				</div>
 			)
 		}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -26,6 +26,7 @@ import { IContextMenuContext } from '../RundownView'
 import { CSSProperties } from '../../styles/_cssVariables'
 import { ISourceLayerExtended } from '../../../lib/Rundown'
 import RundownViewEventBus, { RundownViewEvents, HighlightEvent } from '../RundownView/RundownViewEventBus'
+import { LoopingIcon } from '../../lib/ui/icons/looping'
 
 export const SegmentTimelineLineElementId = 'rundown__segment__line__'
 export const SegmentTimelinePartElementId = 'rundown__segment__part__'
@@ -760,6 +761,7 @@ export const SegmentTimelinePart = withTranslation()(
 					this.props.isLastSegment &&
 					this.props.isLastInSegment &&
 					(!this.state.isLive || (this.state.isLive && !this.props.playlist.nextPartInstanceId))
+				const isEndOfLoopingShow = this.props.isLastSegment && this.props.isLastInSegment && this.props.playlist.loop
 				let invalidReasonColorVars: CSSProperties | undefined = undefined
 				if (innerPart.invalidReason && innerPart.invalidReason.color) {
 					const invalidColor = SegmentTimelinePart0.convertHexToRgba(innerPart.invalidReason.color)
@@ -815,7 +817,8 @@ export const SegmentTimelinePart = withTranslation()(
 											{(this.state.isNext || this.props.isAfterLastValidInSegmentAndItsLive) && t('Next')}
 										</React.Fragment>
 									)}
-									{this.props.isAfterLastValidInSegmentAndItsLive && CARRIAGE_RETURN_ICON}
+									{this.props.isAfterLastValidInSegmentAndItsLive && !this.props.playlist.loop && CARRIAGE_RETURN_ICON}
+									{this.props.isAfterLastValidInSegmentAndItsLive && this.props.playlist.loop && <LoopingIcon />}
 								</div>
 								{!this.props.relative && this.props.part.instance.part.identifier && (
 									<div className="segment-timeline__identifier">{this.props.part.instance.part.identifier}</div>
@@ -887,13 +890,19 @@ export const SegmentTimelinePart = withTranslation()(
 										})}>
 										{innerPart.autoNext && t('Auto') + ' '}
 										{this.state.isLive && t('Next')}
-										{!isEndOfShow && CARRIAGE_RETURN_ICON}
+										{!isEndOfShow && !isEndOfLoopingShow && CARRIAGE_RETURN_ICON}
+										{isEndOfLoopingShow && <LoopingIcon />}
 									</div>
 								</div>
 							)}
-							{isEndOfShow && (
+							{isEndOfShow && !this.props.playlist.loop && (
 								<div className="segment-timeline__part__show-end">
 									<div className="segment-timeline__part__show-end__label">{t('Show End')}</div>
+								</div>
+							)}
+							{isEndOfShow && this.props.playlist.loop && (
+								<div className="segment-timeline__part__show-end loop">
+									<div className="segment-timeline__part__show-end__label">{t('Loops to top')}</div>
 								</div>
 							)}
 						</div>

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -180,10 +180,11 @@ export function selectNextPart(
 	const span = profiler.startSpan('selectNextPart')
 	const findFirstPlayablePart = (
 		offset: number,
-		condition?: (part: Part) => boolean
+		condition?: (part: Part) => boolean,
+		length?: number
 	): SelectNextPartResult | undefined => {
 		// Filter to after and find the first playabale
-		for (let index = offset; index < parts.length; index++) {
+		for (let index = offset; index < (length || parts.length); index++) {
 			const part = parts[index]
 			if (part.isPlayable() && (!condition || condition(part))) {
 				return { part, index }
@@ -221,7 +222,14 @@ export function selectNextPart(
 		}
 	}
 
-	// TODO - rundownPlaylist.loop
+	// if playlist should loop, check from 0 to currentPart
+	if (rundownPlaylist.loop && !nextPart && previousPartInstance) {
+		const currentIndex = parts.findIndex((p) => p._id === previousPartInstance.part._id)
+		// TODO - choose something better for next?
+		if (currentIndex !== -1) {
+			nextPart = findFirstPlayablePart(0, undefined, currentIndex)
+		}
+	}
 
 	// Filter to after and find the first playabale
 	const res = nextPart || findFirstPlayablePart(offset)

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -178,6 +178,12 @@ export function selectNextPart(
 	parts: Part[]
 ): SelectNextPartResult | undefined {
 	const span = profiler.startSpan('selectNextPart')
+	/**
+	 * Iterates over all the parts and searches for the first one to be playable
+	 * @param offset the index from where to start the search
+	 * @param condition whether the part will be returned
+	 * @param length the maximum index or where to stop the search
+	 */
 	const findFirstPlayablePart = (
 		offset: number,
 		condition?: (part: Part) => boolean,


### PR DESCRIPTION
This PR fixes the behaviour for looping rundown playlists. All that was missing was selecting the next part. Besides that it adds some markers in the UI to clarify that the current rundown playlist will loop.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
