### PR TITLE
Show restart button only for device notifications >= WARNING_MAJOR

### DIFF
--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -310,7 +310,7 @@ class RundownViewNotifier extends WithManagedTracker {
 							'Devices',
 							getCurrentTime(),
 							true,
-							parent && parent.connected
+							parent && parent.connected && item.status.statusCode >= PeripheralDeviceAPI.StatusCode.WARNING_MAJOR
 								? [
 										{
 											label: t('Restart'),

--- a/packages/server-core-integration/src/lib/corePeripherals.ts
+++ b/packages/server-core-integration/src/lib/corePeripherals.ts
@@ -14,7 +14,7 @@ export enum StatusCode {
 	GOOD = 1,
 	/** Everything is not OK, but normal operation should not be affected. An optional/backup service might be offline, etc. */
 	WARNING_MINOR = 2,
-	/** Everything is not OK, operation might be affected. Like when having switched to a backup, or have taken action to fix an error. */
+	/** Everything is not OK, operation might be affected. Like when having switched to a backup, or have taken action to fix an error. Sofie will show a restart device button for this and all higher severity warnings. */
 	WARNING_MAJOR = 3,
 	/** Not good. Operation is affected. Will be able to recover on it's own when the situation changes. */
 	BAD = 4,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The "Restart Device" button will only be shown where a device has set its status to WARNING_MAJOR or anything more severe.


* **What is the current behavior?** (You can also link to an open issue here)
The "Restart Device" button is shown in notifications for all status messages that do not have the status code "GOOD".


* **What is the new behavior (if this is a feature change)?**
The "Restart Device" button will not be shown in a device status notification unless the status is >= WARNING_MAJOR. This allows WARNING_MINOR to be used to send device status updates to the user without making the user think that some intervention is required. An example use case is sending a notification to indicate that Viz graphics are loading; in this case there is no intervention required as it is just an indicator of the progress of the Viz device to let the user know that it may not be safe to take graphics on air yet.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
