### PR TITLE
fix: Upload snapshots where part externalId is missing

### DIFF
--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -666,7 +666,9 @@ export function restoreFromRundownPlaylistSnapshot(
 	const partIdMap: { [key: string]: PartId } = {}
 	_.each(snapshot.parts, (part) => {
 		const oldId = part._id
-		partIdMap[unprotectString(oldId)] = part._id = getPartId(getNewRundownId(part.rundownId), part.externalId)
+		partIdMap[unprotectString(oldId)] = part._id = part.externalId
+			? getPartId(getNewRundownId(part.rundownId), part.externalId)
+			: getRandomId()
 	})
 	const partInstanceIdMap: { [key: string]: PartInstanceId } = {}
 	_.each(snapshot.partInstances, (partInstance) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allows snapshots to be uploaded if the externalId is missing on a part (e.g. dynamically inserted parts).


* **What is the current behavior?** (You can also link to an open issue here)
Trying to import a snapshot that contains a part that does not have an externalId will result in the snapshot being rejected. This happens in snapshots containing dynamically inserted (queued) parts as the externalId is set to an empty string https://github.com/nrkno/tv-automation-server-core/blob/f48a4aaae286423f2adda630f402e02c30a52f41/meteor/server/api/playout/adlib.ts#L276


* **What is the new behavior (if this is a feature change)?**
Rather than creating the the part id using the external Id, a new random Id will be generated.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
