### PR TITLE
Better activation ux

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -188,7 +188,7 @@ const WarningDisplay = withTranslation()(
 						}>
 						<p>
 							{t(
-								'You are in rehearsal mode, the broadcast starts in less than 1 minute. Do you want to reset the rundown and go into on-air mode?'
+								'You are in rehearsal mode, the broadcast starts in less than 1 minute. Do you want to reset the rundown and go into On-Air mode?'
 							)}
 						</p>
 					</ModalDialog>
@@ -473,19 +473,19 @@ const RundownHeader = withTranslation()(
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE,
 						up: this.keyActivate,
-						label: t('Activate (On-air)'),
+						label: t('Activate (On-Air)'),
 						global: true,
 					},
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE2,
 						up: this.keyActivate,
-						label: t('Activate (On-air)'),
+						label: t('Activate (On-Air)'),
 						global: true,
 					},
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE3,
 						up: this.keyActivate,
-						label: t('Activate (On-air)'),
+						label: t('Activate (On-Air)'),
 						global: true,
 					},
 					{
@@ -751,7 +751,7 @@ const RundownHeader = withTranslation()(
 						yes: t('Activate (Rehearsal)'),
 						actions: [
 							{
-								label: t('Activate (On-air)'),
+								label: t('Activate (On-Air)'),
 								classNames: 'btn-primary',
 								on: (e) => {
 									doUserAction(
@@ -881,7 +881,7 @@ const RundownHeader = withTranslation()(
 				no: t('Cancel'),
 				actions: [
 					{
-						label: t('Activate Anyway (On-air)'),
+						label: t('Activate Anyway (On-Air)'),
 						classNames: 'btn-primary',
 						on: (e) => {
 							doUserAction(
@@ -944,7 +944,7 @@ const RundownHeader = withTranslation()(
 					doModalDialog({
 						title: this.props.playlist.name,
 						message: t('Do you want to activate this Rundown?'),
-						yes: 'Activate (on-air)',
+						yes: 'Activate (On-Air)',
 						onAccept: () => {
 							this.rewindSegments()
 							doUserAction(
@@ -973,7 +973,7 @@ const RundownHeader = withTranslation()(
 					doModalDialog({
 						title: this.props.playlist.name,
 						message: t('The planned end time has passed, are you sure you want to activate this Rundown?'),
-						yes: 'Activate (on-air)',
+						yes: 'Activate (On-Air)',
 						onAccept: () => {
 							doActivate()
 						},
@@ -1232,7 +1232,7 @@ const RundownHeader = withTranslation()(
 											<MenuItem onClick={(e) => this.activateRehearsal(e)}>{t('Activate (Rehearsal)')}</MenuItem>
 										)
 									) : (
-										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-air)')}</MenuItem>
+										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-Air)')}</MenuItem>
 									)}
 									{this.rundownWillShortlyStart() && !this.props.playlist.active && (
 										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-Air)')}</MenuItem>

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -189,7 +189,7 @@ const WarningDisplay = withTranslation()(
 						}>
 						<p>
 							{t(
-								'You are in rehearsal mode, the broadcast starts in less than 1 minute. Do you want to reset the rundown and go into playout mode?'
+								'You are in rehearsal mode, the broadcast starts in less than 1 minute. Do you want to reset the rundown and go into on-air mode?'
 							)}
 						</p>
 					</ModalDialog>
@@ -474,19 +474,19 @@ const RundownHeader = withTranslation()(
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE,
 						up: this.keyActivate,
-						label: t('Activate'),
+						label: t('Activate (On-air)'),
 						global: true,
 					},
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE2,
 						up: this.keyActivate,
-						label: t('Activate'),
+						label: t('Activate (On-air)'),
 						global: true,
 					},
 					{
 						key: RundownViewKbdShortcuts.RUNDOWN_ACTIVATE3,
 						up: this.keyActivate,
-						label: t('Activate'),
+						label: t('Activate (On-air)'),
 						global: true,
 					},
 					{
@@ -873,11 +873,11 @@ const RundownHeader = withTranslation()(
 						rundownName: otherRundowns.map((i) => i.name).join(', '),
 					}
 				),
-				yes: t('Activate Anyway'),
+				yes: t('Activate Anyway (Rehearsal)'),
 				no: t('Cancel'),
 				actions: [
 					{
-						label: t('Activate Anyway (GO ON AIR)'),
+						label: t('Activate Anyway (On-air)'),
 						classNames: 'btn-primary',
 						on: (e) => {
 							doUserAction(
@@ -940,6 +940,7 @@ const RundownHeader = withTranslation()(
 					doModalDialog({
 						title: this.props.playlist.name,
 						message: t('Do you want to activate this Rundown?'),
+						yes: 'Activate (on-air)',
 						onAccept: () => {
 							this.rewindSegments()
 							doUserAction(
@@ -968,6 +969,7 @@ const RundownHeader = withTranslation()(
 					doModalDialog({
 						title: this.props.playlist.name,
 						message: t('The planned end time has passed, are you sure you want to activate this Rundown?'),
+						yes: 'Activate (on-air)',
 						onAccept: () => {
 							doActivate()
 						},
@@ -1029,6 +1031,7 @@ const RundownHeader = withTranslation()(
 						doModalDialog({
 							title: this.props.playlist.name,
 							message: t('Are you sure you want to activate Rehearsal Mode?'),
+							yes: 'Activate (Rehearsal)',
 							onAccept: (e) => {
 								doActivateRehersal()
 							},
@@ -1043,6 +1046,7 @@ const RundownHeader = withTranslation()(
 						doModalDialog({
 							title: this.props.playlist.name,
 							message: t('Are you sure you want to activate Rehearsal Mode?'),
+							yes: 'Activate (Rehearsal)',
 							onAccept: (e) => {
 								doActivateRehersal()
 							},
@@ -1224,7 +1228,7 @@ const RundownHeader = withTranslation()(
 											<MenuItem onClick={(e) => this.activateRehearsal(e)}>{t('Activate (Rehearsal)')}</MenuItem>
 										)
 									) : (
-										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate')}</MenuItem>
+										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-air)')}</MenuItem>
 									)}
 									{this.props.playlist.active ? (
 										<MenuItem onClick={(e) => this.deactivate(e)}>{t('Deactivate')}</MenuItem>

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -99,6 +99,7 @@ import { LoopingIcon } from '../lib/ui/icons/looping'
 
 export const MAGIC_TIME_SCALE_FACTOR = 0.03
 
+const REHEARSAL_MARGIN = 1 * 60 * 1000
 const HIDE_NOTIFICATIONS_AFTER_MOUNT: number | undefined = 5000
 
 type WrappedShelf = ShelfBase & { getWrappedInstance(): ShelfBase }
@@ -117,8 +118,6 @@ interface ITimingWarningState {
 const WarningDisplay = withTranslation()(
 	timer(5000)(
 		class WarningDisplay extends React.Component<Translated<ITimingWarningProps>, ITimingWarningState> {
-			private readonly REHEARSAL_MARGIN = 1 * 60 * 1000
-
 			constructor(props: Translated<ITimingWarningProps>) {
 				super(props)
 
@@ -140,7 +139,7 @@ const WarningDisplay = withTranslation()(
 					this.props.playlist.rehearsal &&
 					this.props.playlist.expectedStart &&
 					// the expectedStart is near
-					getCurrentTime() + this.REHEARSAL_MARGIN > this.props.playlist.expectedStart &&
+					getCurrentTime() + REHEARSAL_MARGIN > this.props.playlist.expectedStart &&
 					// but it's not horribly in the past
 					getCurrentTime() <
 						this.props.playlist.expectedStart + (this.props.playlist.expectedDuration || 60 * 60 * 1000) &&
@@ -834,6 +833,11 @@ const RundownHeader = withTranslation()(
 		rundownShouldHaveStarted() {
 			return getCurrentTime() > (this.props.playlist.expectedStart || 0)
 		}
+		rundownWillShortlyStart() {
+			return (
+				!this.rundownShouldHaveEnded() && getCurrentTime() > (this.props.playlist.expectedStart || 0) - REHEARSAL_MARGIN
+			)
+		}
 		rundownShouldHaveEnded() {
 			return getCurrentTime() > (this.props.playlist.expectedStart || 0) + (this.props.playlist.expectedDuration || 0)
 		}
@@ -1229,6 +1233,9 @@ const RundownHeader = withTranslation()(
 										)
 									) : (
 										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-air)')}</MenuItem>
+									)}
+									{this.rundownWillShortlyStart() && !this.props.playlist.active && (
+										<MenuItem onClick={(e) => this.activate(e)}>{t('Activate (On-Air)')}</MenuItem>
 									)}
 									{this.props.playlist.active ? (
 										<MenuItem onClick={(e) => this.deactivate(e)}>{t('Deactivate')}</MenuItem>


### PR DESCRIPTION
This PR contains the following changes:

- Fix: Clarify all uses of "activation" to contain either "rehearsal" or "on-air" such that it is clear to users what the system will do
- Feature: Add an option to directly activate to on-air mode when the planned start of the rundown is close or has passed
- Feature: When the users does a take on an inactive rundown we ask the user if they want to activate (the assumption here is that they think it is already active)
