### PR TITLE
fix: resync missing rundown

### DIFF
--- a/meteor/client/ui/RundownList/util.ts
+++ b/meteor/client/ui/RundownList/util.ts
@@ -8,6 +8,7 @@ import { doModalDialog } from '../../lib/ModalDialog'
 import { doUserAction, UserAction } from '../../lib/userAction'
 import { MeteorCall } from '../../../lib/api/methods'
 import { TFunction } from 'i18next'
+import { handleRundownReloadResponse } from '../RundownView'
 
 export function getRundownPlaylistLink(rundownPlaylistId: RundownPlaylistId): string {
 	// double encoding so that "/" are handled correctly
@@ -67,7 +68,17 @@ export function confirmReSyncRundown(rundown: Rundown, t: TFunction): void {
 		yes: t('Re-Sync'),
 		no: t('Cancel'),
 		onAccept: (e) => {
-			doUserAction(t, e, UserAction.RESYNC_RUNDOWN, (e) => MeteorCall.userAction.resyncRundown(e, rundown._id))
+			doUserAction(
+				t,
+				e,
+				UserAction.RESYNC_RUNDOWN,
+				(e) => MeteorCall.userAction.resyncRundown(e, rundown._id),
+				(err, res) => {
+					if (!err && res) {
+						return handleRundownReloadResponse(t, rundown._id, res)
+					}
+				}
+			)
 		},
 		message: t('Are you sure you want to re-sync the "{{name}}" rundown?', {
 			name: rundown.name,

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2738,9 +2738,10 @@ function handleRundownPlaylistReloadResponse(t: i18next.TFunction, result: Reloa
 		const playlist = RundownPlaylists.findOne(firstRundown?.playlistId)
 		const allRundownIds = playlist?.getRundownUnorderedIDs() || []
 		if (
+			allRundownIds.length > 0 &&
 			_.difference(
-				rundownsInNeedOfHandling.map((r) => r.rundownId),
-				allRundownIds
+				allRundownIds,
+				rundownsInNeedOfHandling.map((r) => r.rundownId)
 			).length === 0
 		) {
 			allRundownsAffected = true

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2726,26 +2726,53 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 	}
 )
 
-export function handleRundownPlaylistReloadResponse(
-	t: i18next.TFunction,
-	result: ReloadRundownPlaylistResponse
-): boolean {
-	let possiblyBadResponse = _.first(result.rundownsResponses)
+function handleRundownPlaylistReloadResponse(t: i18next.TFunction, result: ReloadRundownPlaylistResponse): boolean {
+	const rundownsInNeedOfHandling = result.rundownsResponses.filter(
+		(r) => r.response === TriggerReloadDataResponse.MISSING
+	)
+	const firstRundownId = _.first(rundownsInNeedOfHandling)?.rundownId
+	let allRundownsAffected = false
 
-	result.rundownsResponses.forEach((r) => {
-		if (r.response === TriggerReloadDataResponse.MISSING) {
-			possiblyBadResponse = r
+	if (firstRundownId) {
+		const firstRundown = Rundowns.findOne(firstRundownId)
+		const playlist = RundownPlaylists.findOne(firstRundown?.playlistId)
+		const allRundownIds = playlist?.getRundownUnorderedIDs() || []
+		if (
+			_.difference(
+				rundownsInNeedOfHandling.map((r) => r.rundownId),
+				allRundownIds
+			).length === 0
+		) {
+			allRundownsAffected = true
 		}
-	})
-	// TODO: This is a hack, since it only handles the first error
-	return possiblyBadResponse
-		? handleRundownReloadResponse(t, possiblyBadResponse.rundownId, possiblyBadResponse.response)
-		: false
+	}
+
+	let actionsTaken: RundownReloadResponseUserAction[] = []
+	function onActionTaken(action: RundownReloadResponseUserAction): void {
+		actionsTaken.push(action)
+		if (actionsTaken.length === rundownsInNeedOfHandling.length) {
+			// the user has taken action on all of the missing rundowns
+			if (allRundownsAffected && actionsTaken.filter((actionTaken) => actionTaken !== 'removed').length === 0) {
+				// all rundowns in the playlist were affected and all of them were removed
+				// we redirect to the Lobby
+				window.location.assign('/')
+			}
+		}
+	}
+
+	const handled = rundownsInNeedOfHandling.map((r) =>
+		handleRundownReloadResponse(t, r.rundownId, r.response, onActionTaken)
+	)
+	return handled.reduce((previousValue, value) => previousValue || value, false)
 }
+
+type RundownReloadResponseUserAction = 'removed' | 'unsynced' | 'error'
+
 export function handleRundownReloadResponse(
 	t: i18next.TFunction,
 	rundownId: RundownId,
-	result: TriggerReloadDataResponse
+	result: TriggerReloadDataResponse,
+	clb?: (action: RundownReloadResponseUserAction) => void
 ): boolean {
 	let hasDoneSomething = false
 
@@ -2759,7 +2786,7 @@ export function handleRundownReloadResponse(
 				undefined,
 				NoticeLevel.CRITICAL,
 				t(
-					'Rundown {{rundownName}} in Playlist {{playlistName}} is missing in the data from {{nrcsName}}, what do you want to do?',
+					'Rundown {{rundownName}} in Playlist {{playlistName}} is missing in the data from {{nrcsName}}. You can either leave it in Sofie and mark it as Unsynced or remove the rundown from Sofie. What do you want to do?',
 					{
 						nrcsName: rundown?.externalNRCSName || 'NRCS',
 						rundownName: rundown?.name || 'N/A',
@@ -2772,7 +2799,7 @@ export function handleRundownReloadResponse(
 				[
 					// actions:
 					{
-						label: t('Leave it in Sofie (mark the rundown as unsynced)'),
+						label: t('Leave Unsynced'),
 						type: 'default',
 						disabled: !getAllowStudio(),
 						action: () => {
@@ -2784,13 +2811,16 @@ export function handleRundownReloadResponse(
 								(err) => {
 									if (!err) {
 										notification.stop()
+										clb && clb('unsynced')
+									} else {
+										clb && clb('error')
 									}
 								}
 							)
 						},
 					},
 					{
-						label: t('Remove just the rundown from Sofie'),
+						label: t('Remove'),
 						type: 'default',
 						action: () => {
 							doModalDialog({
@@ -2812,7 +2842,9 @@ export function handleRundownReloadResponse(
 										(err) => {
 											if (!err) {
 												notification.stop()
-												window.location.assign(`/`)
+												clb && clb('removed')
+											} else {
+												clb && clb('error')
 											}
 										}
 									)

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -768,7 +768,19 @@ export namespace ServerRundownAPI {
 
 		if (!rundown) throw new Meteor.Error(404, `Rundown "${segment.rundownId}" not found!`)
 
-		return IngestActions.reloadSegment(rundown, segment)
+		const result = IngestActions.reloadSegment(rundown, segment)
+
+		// If the rundown source says the segment is missing, we should set the unsynced flag back, since it
+		// is not going to be resynced.
+		if (result === TriggerReloadDataResponse.MISSING) {
+			Segments.update(segment._id, {
+				$set: {
+					unsynced: true,
+				},
+			})
+		}
+
+		return result
 	}
 	export function unsyncSegment(context: MethodContext, rundownId: RundownId, segmentId: SegmentId): void {
 		rundownContentAllowWrite(context.userId, { rundownId })

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -789,7 +789,19 @@ export namespace ServerRundownAPI {
 			},
 		})
 
-		return IngestActions.reloadRundown(rundown)
+		const result = IngestActions.reloadRundown(rundown)
+
+		// If the rundown source says the rundown is missing, we should set the unsynced flag back, since it
+		// is not going to be resynced.
+		if (result === TriggerReloadDataResponse.MISSING) {
+			Rundowns.update(rundown._id, {
+				$set: {
+					unsynced: true,
+				},
+			})
+		}
+
+		return result
 	}
 
 	export function unsyncSegmentInner(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR changes the behavior of how re-syncing a missing rundown is handled and some related UI changes.

* **What is the current behavior?** (You can also link to an open issue here)

If a Rundown/Segment is unsynced in Sofie, when user resyncs it, the Unsynced flag will be taken off and a request to the Ingest device will be fired off. If the device returns a "MISSING" state, the Rundown/Segment is left in the "fake synced" state and a message is shown through the notification center for the user to make a decision what to do about it, but only when doing "re-syncing" from the Rundown View. When doing it from the lobby, no message is shown.

* **What is the new behavior (if this is a feature change)?**

If the device returns a "MISSING" state, the Rundown/Segment's "unsynced" flag is turned back on. Also some of the UI handling of missing Rundowns was reworked so that these notifications are also shown when resyncing a missing Rundown in the Lobby.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
