### PR TITLE
fix: blueprintConfig dropped when restoring a snapshot

### DIFF
--- a/meteor/server/migration/1_12_0.ts
+++ b/meteor/server/migration/1_12_0.ts
@@ -251,7 +251,7 @@ export function migrateConfigToBlueprintConfigOnObject<
 		blueprintConfig?: IBlueprintConfig
 	}
 >(document: DBInterface): DBInterface {
-	document.blueprintConfig = {}
+	document.blueprintConfig = document.blueprintConfig || {}
 	// @ts-ignore old typing
 	const oldConfig = document.config as any
 	if (oldConfig) {

--- a/meteor/server/migration/1_12_0.ts
+++ b/meteor/server/migration/1_12_0.ts
@@ -251,12 +251,14 @@ export function migrateConfigToBlueprintConfigOnObject<
 		blueprintConfig?: IBlueprintConfig
 	}
 >(document: DBInterface): DBInterface {
-	document.blueprintConfig = document.blueprintConfig || {}
-	// @ts-ignore old typing
-	const oldConfig = document.config as any
-	if (oldConfig) {
-		for (const item of oldConfig) {
-			objectPathSet(document.blueprintConfig, item._id, item.value)
+	if (!document.blueprintConfig) {
+		document.blueprintConfig = {}
+		// @ts-ignore old typing
+		const oldConfig = document.config as any
+		if (oldConfig) {
+			for (const item of oldConfig) {
+				objectPathSet(document.blueprintConfig, item._id, item.value)
+			}
 		}
 	}
 	// @ts-ignore old typing


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a bug causing the Blueprint Configuration on studios and showStyles to be lost when restoring a system snapshot.


* **What is the current behavior?** (You can also link to an open issue here)
When restoring a system snapshot, Blueprint Configuration on the studios and showStyles is dropped entirely instead of being restored from the snapshot. The cause is using `migrateConfigToBlueprintConfigOnObject`, which assumes that `blueprintConfig` is missing, when restoring snapshots.


* **What is the new behavior (if this is a feature change)?**
Blueprint Configuration is restored correctly. `migrateConfigToBlueprintConfigOnObject` handles both cases - when `blueprintConfig` is present and when it's missing.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
