### PR TITLE
fix: Restore shelf layout selection to lobby

### DIFF
--- a/meteor/client/styles/rundownList.scss
+++ b/meteor/client/styles/rundownList.scss
@@ -11,9 +11,10 @@
 	 * percentages do not add up to a perfect 100% (ie. 1.0)
 	 */
 	--nameColumnSize: 0.4;
-	--showStyleColumnSize: 0.22;
+	--showStyleColumnSize: 0.17;
 	--standardColumnSize: 0.11;
 	--actionsColumnSize: 0.05;
+	--layoutSelectionColumnSize: 0.05;
 
 	/* "column" width calculations */
 	--statusBarWidth: 2.1rem; //  the width of the floating right status bar
@@ -23,6 +24,7 @@
 	--airTimeColumnWidth: calc(var(--componentWidth) * var(--standardColumnSize));
 	--durationColumnWidth: calc(var(--componentWidth) * var(--standardColumnSize));
 	--lastModifiedColumnWidth: calc(var(--componentWidth) * var(--standardColumnSize));
+	--layoutSelectionColumnWidth: calc(var(--componentWidth) * var(--layoutSelectionColumnSize));
 	--actionsColumnWidth: calc(var(--componentWidth) * var(--actionsColumnSize));
 
 	background-color: transparent;
@@ -33,7 +35,7 @@
 		display: grid;
 		grid-template-columns:
 			var(--nameColumnWidth) var(--showStyleColumnWidth) var(--airTimeColumnWidth)
-			var(--durationColumnWidth) var(--lastModifiedColumnWidth) var(--actionsColumnWidth);
+			var(--durationColumnWidth) var(--lastModifiedColumnWidth) var(--layoutSelectionColumnWidth) var(--actionsColumnWidth);
 
 		background-color: #898989;
 		color: #fff;
@@ -254,7 +256,7 @@
 		display: grid;
 		grid-template-columns:
 			var(--nameColumnWidth) var(--showStyleColumnWidth) var(--airTimeColumnWidth)
-			var(--durationColumnWidth) var(--lastModifiedColumnWidth) var(--actionsColumnWidth);
+			var(--durationColumnWidth) var(--lastModifiedColumnWidth) var(--layoutSelectionColumnWidth) var(--actionsColumnWidth);
 
 		.rundown-list-item__text {
 			padding: 7px 0;

--- a/meteor/client/styles/splitDropdown.scss
+++ b/meteor/client/styles/splitDropdown.scss
@@ -86,8 +86,9 @@
 		&.action-btn {
 			padding: 5px 10px;
 			margin: 0px;
-			width: 100%;
+			width: 90%;
 			font-weight: 300;
+			overflow: hidden;
 
 			> span {
 				text-decoration: none;

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -297,6 +297,7 @@ export const RundownList = translateWithTracker(() => {
 											<span>{t('On Air Start Time')}</span>
 											<span>{t('Duration')}</span>
 											<span>{t('Last updated')}</span>
+											<span>{t('Shelf Layout')}</span>
 											<span>&nbsp;</span>
 										</header>
 										{this.renderRundownPlaylists(rundownPlaylists)}

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -297,7 +297,9 @@ export const RundownList = translateWithTracker(() => {
 											<span>{t('On Air Start Time')}</span>
 											<span>{t('Duration')}</span>
 											<span>{t('Last updated')}</span>
-											<span>{t('Shelf Layout')}</span>
+											{this.props.rundownLayouts.some((l) => l.exposeAsShelf || l.exposeAsStandalone) && (
+												<span>{t('Shelf Layout')}</span>
+											)}
 											<span>&nbsp;</span>
 										</header>
 										{this.renderRundownPlaylists(rundownPlaylists)}

--- a/meteor/client/ui/RundownList/DragAndDropTypes.ts
+++ b/meteor/client/ui/RundownList/DragAndDropTypes.ts
@@ -1,6 +1,7 @@
 import { RundownId } from '../../../lib/collections/Rundowns'
 import { isProtectedString } from '../../../lib/lib'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import { RundownLayoutBase } from '../../../lib/collections/RundownLayouts'
 
 enum RundownListDragDropTypes {
 	RUNDOWN = 'rundown',
@@ -9,6 +10,7 @@ enum RundownListDragDropTypes {
 
 interface IRundownDragObject {
 	id: RundownId
+	rundownLayouts: Array<RundownLayoutBase>
 }
 
 function isRundownDragObject(obj: any): obj is IRundownDragObject {

--- a/meteor/client/ui/RundownList/RundownListItem.tsx
+++ b/meteor/client/ui/RundownList/RundownListItem.tsx
@@ -38,6 +38,7 @@ import { Settings } from '../../../lib/Settings'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
 import { ShowStyleVariant } from '../../../lib/collections/ShowStyleVariants'
+import { RundownLayoutBase } from '../../../lib/collections/RundownLayouts'
 
 export const HTML_ID_PREFIX = 'rundown-'
 
@@ -45,6 +46,7 @@ export interface IRundownListItemProps {
 	isActive: boolean
 	rundown: Rundown
 	rundownViewUrl?: string
+	rundownLayouts: Array<RundownLayoutBase>
 	swapRundownOrder: (a: RundownId, b: RundownId) => void
 	playlistId: RundownPlaylistId
 	isOnlyRundownInPlaylist?: boolean
@@ -66,7 +68,7 @@ interface IRundownDragSourceProps {
 const dragSpec: DragSourceSpec<IRundownListItemProps, IRundownDragObject> = {
 	beginDrag: (props: IRundownListItemProps, monitor, component: React.Component) => {
 		const id = props.rundown._id
-		return { id }
+		return { id, rundownLayouts: props.rundownLayouts }
 	},
 	isDragging: (props, monitor) => {
 		return props.rundown._id === monitor.getItem().id
@@ -262,7 +264,16 @@ export const RundownListItem = translateWithTracker<IRundownListItemProps, {}, I
 				}
 
 				render() {
-					const { isActive, t, rundown, connectDragSource, connectDropTarget, isDragging, rundownViewUrl } = this.props
+					const {
+						isActive,
+						t,
+						rundown,
+						connectDragSource,
+						connectDropTarget,
+						isDragging,
+						rundownViewUrl,
+						rundownLayouts,
+					} = this.props
 					const userCanConfigure = getAllowConfigure()
 
 					const classNames: string[] = []
@@ -293,6 +304,7 @@ export const RundownListItem = translateWithTracker<IRundownListItemProps, {}, I
 							renderTooltips={isDragging !== true}
 							rundownViewUrl={rundownViewUrl}
 							rundown={rundown}
+							rundownLayouts={rundownLayouts}
 							showStyleName={showStyleLabel}
 							showStyleBaseURL={userCanConfigure ? getShowStyleBaseLink(rundown.showStyleBaseId) : undefined}
 							confirmDeleteRundownHandler={

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -11,6 +11,7 @@ import { iconDragHandle, iconRemove, iconResync } from './icons'
 import JonasFormattedTime from './JonasFormattedTime'
 import { EyeIcon } from '../../lib/ui/icons/rundownList'
 import { LoopingIcon } from '../../lib/ui/icons/looping'
+import { RundownShelfLayoutSelection } from './RundownShelfLayoutSelection'
 
 interface IRundownListItemViewProps {
 	isActive: boolean
@@ -109,6 +110,9 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 			</span>
 			<span className="rundown-list-item__text">
 				<JonasFormattedTime timestamp={rundown.modified} t={t} />
+			</span>
+			<span className="rundown-list-item__text">
+				<RundownShelfLayoutSelection rundown={props.rundown} />
 			</span>
 			<span className="rundown-list-item__actions">
 				{confirmReSyncRundownHandler ? (

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -12,6 +12,7 @@ import JonasFormattedTime from './JonasFormattedTime'
 import { EyeIcon } from '../../lib/ui/icons/rundownList'
 import { LoopingIcon } from '../../lib/ui/icons/looping'
 import { RundownShelfLayoutSelection } from './RundownShelfLayoutSelection'
+import { RundownLayoutBase } from '../../../lib/collections/RundownLayouts'
 
 interface IRundownListItemViewProps {
 	isActive: boolean
@@ -20,6 +21,7 @@ interface IRundownListItemViewProps {
 	connectDragSource: (content: ReactElement) => ReactElement | null
 	rundownViewUrl?: string
 	rundown: Rundown
+	rundownLayouts: Array<RundownLayoutBase>
 	showStyleBaseURL?: string
 	showStyleName: string | undefined
 	confirmReSyncRundownHandler?: () => void
@@ -40,6 +42,7 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 		showStyleBaseURL,
 		showStyleName,
 		rundown,
+		rundownLayouts,
 		confirmReSyncRundownHandler,
 		confirmDeleteRundownHandler,
 	} = props
@@ -111,9 +114,15 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 			<span className="rundown-list-item__text">
 				<JonasFormattedTime timestamp={rundown.modified} t={t} />
 			</span>
-			<span className="rundown-list-item__text">
-				<RundownShelfLayoutSelection rundown={props.rundown} />
-			</span>
+			{rundownLayouts.some((l) => l.exposeAsShelf || l.exposeAsStandalone) && (
+				<span className="rundown-list-item__text">
+					<RundownShelfLayoutSelection
+						rundowns={[rundown]}
+						rundownLayouts={rundownLayouts}
+						playlistId={rundown.playlistId}
+					/>
+				</span>
+			)}
 			<span className="rundown-list-item__actions">
 				{confirmReSyncRundownHandler ? (
 					<Tooltip

--- a/meteor/client/ui/RundownList/RundownPlaylistDragLayer.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistDragLayer.tsx
@@ -50,6 +50,7 @@ function RundownPlaylistDragLayer(props) {
 						isActive={false}
 						renderTooltips={false}
 						rundown={rundown!}
+						rundownLayouts={item.rundownLayouts}
 						classNames={classNames}
 						connectDragSource={(props) => props}
 						connectDropTarget={(props) => props}

--- a/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
+++ b/meteor/client/ui/RundownList/RundownPlaylistUi.tsx
@@ -35,6 +35,7 @@ import { RundownUtils } from '../../lib/rundown'
 import PlaylistRankMethodToggle from './PlaylistRankMethodToggle'
 import JonasFormattedTime from './JonasFormattedTime'
 import { getAllowConfigure, getAllowService, getAllowStudio } from '../../lib/localStorage'
+import { RundownShelfLayoutSelection } from './RundownShelfLayoutSelection'
 
 export interface RundownPlaylistUi extends RundownPlaylist {
 	rundowns: Rundown[]
@@ -238,7 +239,7 @@ export const RundownPlaylistUi = DropTarget(
 			}
 
 			render() {
-				const { playlist, connectDropTarget, t, isActiveDropZone } = this.props
+				const { playlist, connectDropTarget, t, isActiveDropZone, rundownLayouts } = this.props
 
 				if (playlist.rundowns.length === 0) {
 					console.debug(`Playlist ${playlist._id} has no rundowns, aborting render`)
@@ -265,6 +266,7 @@ export const RundownPlaylistUi = DropTarget(
 								key={unprotectString(playlist.rundowns[0]._id)}
 								rundown={playlist.rundowns[0]}
 								rundownViewUrl={playlistViewURL}
+								rundownLayouts={rundownLayouts}
 								swapRundownOrder={handleRundownSwap}
 								playlistId={playlist._id}
 							/>
@@ -281,6 +283,7 @@ export const RundownPlaylistUi = DropTarget(
 							isActive={!!playlist.activationId}
 							key={unprotectString(rundown._id)}
 							rundown={rundown}
+							rundownLayouts={rundownLayouts}
 							swapRundownOrder={handleRundownSwap}
 							playlistId={playlist._id}
 						/>
@@ -325,6 +328,15 @@ export const RundownPlaylistUi = DropTarget(
 							<span className="rundown-list-item__text">
 								<JonasFormattedTime timestamp={playlist.modified} t={t} />
 							</span>
+							{rundownLayouts.some((l) => l.exposeAsShelf || l.exposeAsStandalone) && (
+								<span className="rundown-list-item__text">
+									<RundownShelfLayoutSelection
+										rundowns={[playlist.rundowns]}
+										rundownLayouts={rundownLayouts}
+										playlistId={playlist._id}
+									/>
+								</span>
+							)}
 							<span className="rundown-list-item__actions"></span>
 						</header>
 						<ol className="rundown-playlist__rundowns">{rundownComponents}</ol>

--- a/meteor/client/ui/RundownList/RundownShelfLayoutSelection.tsx
+++ b/meteor/client/ui/RundownList/RundownShelfLayoutSelection.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react'
+import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { UIStateStorage } from '../../lib/UIStateStorage'
+import { Link } from 'react-router-dom'
+import { SplitDropdown } from '../../lib/SplitDropdown'
+import { getRundownPlaylistLink, getRundownWithLayoutLink, getShelfLink } from './util'
+import { Rundown } from '../../../lib/collections/Rundowns'
+import { RundownLayoutBase, RundownLayouts } from '../../../lib/collections/RundownLayouts'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import classNames from 'classnames'
+import { IconProp } from '@fortawesome/fontawesome-svg-core'
+
+interface IRundownShelfLayoutSelectionProps {
+	rundown: Rundown
+}
+
+interface IRundownShelfLayoutSelectionTrackedProps {
+	rundownLayouts: RundownLayoutBase[]
+}
+
+interface IRundownShelfLayoutSelectionState {
+	selectedView: string
+}
+
+export const RundownShelfLayoutSelection = translateWithTracker<
+	IRundownShelfLayoutSelectionProps,
+	IRundownShelfLayoutSelectionState,
+	IRundownShelfLayoutSelectionTrackedProps
+>((props: IRundownShelfLayoutSelectionProps) => {
+	const rundownLayouts = RundownLayouts.find({ showStyleBaseId: props.rundown.showStyleBaseId }).fetch()
+
+	return {
+		...props,
+		rundownLayouts,
+	}
+})(
+	class RundownShelfLayoutSelection extends React.Component<
+		Translated<IRundownShelfLayoutSelectionProps & IRundownShelfLayoutSelectionTrackedProps>,
+		IRundownShelfLayoutSelectionState
+	> {
+		constructor(props) {
+			super(props)
+
+			this.state = {
+				selectedView: UIStateStorage.getItemString(
+					`rundownList.${this.props.rundown.studioId}`,
+					'defaultView',
+					'default'
+				),
+			}
+		}
+
+		private saveViewChoice(key: string) {
+			UIStateStorage.setItem(`rundownList.${this.props.rundown.studioId}`, 'defaultView', key)
+		}
+
+		private renderLinkItem(layout: RundownLayoutBase, link: string, key: string) {
+			return (
+				<Link to={link} onClick={() => this.saveViewChoice(key)} key={key}>
+					<div className="action-btn expco-item">
+						<div
+							className={classNames('action-btn layout-icon', { small: !layout.icon })}
+							style={{ color: layout.iconColor || 'transparent' }}>
+							<FontAwesomeIcon icon={(layout.icon as IconProp) || 'circle'} />
+						</div>
+						{layout.name}
+					</div>
+				</Link>
+			)
+		}
+
+		render() {
+			const { t } = this.props
+
+			const standaloneLayouts = this.props.rundownLayouts
+				.filter((layout) => layout.exposeAsStandalone)
+				.map((layout) => {
+					return this.renderLinkItem(
+						layout,
+						getShelfLink(this.props.rundown.playlistId, layout._id),
+						`standalone${layout._id}`
+					)
+				})
+			const shelfLayouts = this.props.rundownLayouts
+				.filter((layout) => layout.exposeAsShelf)
+				.map((layout) => {
+					return this.renderLinkItem(
+						layout,
+						getRundownWithLayoutLink(this.props.rundown.playlistId, layout._id),
+						`shelf${layout._id}`
+					)
+				})
+			const allElements = [
+				<div className="expco-header" key={'separator0'}>
+					Standalone shelfs
+				</div>,
+				...standaloneLayouts,
+				<div className="expco-header" key={'separator1'}>
+					Rundown + Shelf
+				</div>,
+				...shelfLayouts,
+				<div className="expco-separator" key={'separator2'}></div>,
+				<Link
+					to={getRundownPlaylistLink(this.props.rundown.playlistId)}
+					onClick={() => this.saveViewChoice('default')}
+					key={'default'}>
+					<div className="action-btn expco-item">Default</div>
+				</Link>,
+			]
+			return shelfLayouts.length > 0 || standaloneLayouts.length > 0 ? (
+				<React.Fragment>
+					<SplitDropdown selectedKey={this.state.selectedView}>{allElements}</SplitDropdown>
+				</React.Fragment>
+			) : (
+				<span className="dimmed">{t('Default')}</span>
+			)
+		}
+	}
+)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Re-adds the "shelf layout" selection to the lobby (see https://github.com/nrkno/tv-automation-server-core/pull/256 for details).

![image](https://user-images.githubusercontent.com/10697525/106779726-30a49f80-663f-11eb-8921-4c75e296b77c.png)



* **What is the current behavior?** (You can also link to an open issue here)
Cannot select shelf layout from the lobby.


* **What is the new behavior (if this is a feature change)?**
Re-adds the dropdown to select shelf layout. If no shelf layouts have been marked as selectable options (the default behaviour) then the text "Default" will be displayed in this column (screenshot below). There is a limitation to this implementation, as it will only work for playlists containing a single rundown for now.

![image](https://user-images.githubusercontent.com/10697525/106780338-ca6c4c80-663f-11eb-9209-80f9312c8f9e.png)



* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
