### PR TITLE
fix: Don't use NTP servers in tests

### DIFF
--- a/meteor/server/api/systemTime/systemTime.ts
+++ b/meteor/server/api/systemTime/systemTime.ts
@@ -5,6 +5,7 @@ import { systemTime, getCurrentTime } from '../../../lib/lib'
 import { StatusCode, setSystemStatus } from '../../systemStatus/systemStatus'
 import { logger } from '../../logging'
 import { TimeDiff, DiffTimeResult } from '../../../lib/api/peripheralDevice'
+import { env } from 'process'
 
 /** How often the system-time should be updated */
 const UPDATE_SYSTEM_TIME_INTERVAL = 3600 * 1000
@@ -191,11 +192,21 @@ function updateServerTime(retries: number = 0) {
 		})
 }
 Meteor.startup(() => {
-	setSystemStatus('systemTime', { statusCode: StatusCode.BAD, messages: ['Starting up...'] })
-	Meteor.setInterval(() => {
-		updateServerTime()
-	}, UPDATE_SYSTEM_TIME_INTERVAL)
-	updateServerTime(5)
+	if (!env.JEST_WORKER_ID) {
+		setSystemStatus('systemTime', { statusCode: StatusCode.BAD, messages: ['Starting up...'] })
+		Meteor.setInterval(() => {
+			updateServerTime()
+		}, UPDATE_SYSTEM_TIME_INTERVAL)
+		updateServerTime(5)
+	} else {
+		systemTime.hasBeenSet = true
+		systemTime.diff = 0
+		systemTime.stdDev = 0
+		setSystemStatus('systemTime', {
+			statusCode: StatusCode.GOOD,
+			messages: [`NTP-time accuracy (standard deviation): 0 ms`],
+		})
+	}
 })
 
 // Example usage:

--- a/meteor/server/coreSystem.ts
+++ b/meteor/server/coreSystem.ts
@@ -29,6 +29,7 @@ import Agent from 'meteor/kschingiz:meteor-elastic-apm'
 import { profiler } from './api/profiler'
 import * as path from 'path'
 import { TMP_TSR_VERSION } from '@sofie-automation/blueprints-integration'
+import { env } from 'process'
 
 export { PackageInfo }
 
@@ -459,6 +460,10 @@ function startupMessage() {
 }
 
 function startInstrumenting() {
+	if (!!env.JEST_WORKER_ID) {
+		return
+	}
+
 	// attempt init elastic APM
 	const system = getCoreSystem()
 	const { APM_HOST, APM_SECRET, KIBANA_INDEX, APP_HOST } = process.env

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -48,7 +48,7 @@ describe('systemStatus', () => {
 
 		const systemTimeCheck = result0.checks && result0.checks.find((p) => p.description === 'systemTime')
 		expect(systemTimeCheck).toMatchObject({
-			status: status2ExternalStatus(StatusCode.BAD),
+			status: status2ExternalStatus(StatusCode.GOOD),
 		})
 		const databaseVersionCheck = result0.checks && result0.checks.find((p) => p.description === 'databaseVersion')
 		expect(databaseVersionCheck).toMatchObject({


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Prevents the use of NTP servers in test environments.


* **What is the current behavior?** (You can also link to an open issue here)
A number of tests use the mock meteor module, which calls the Meteor.startup registered functions when it mocks startup. This means that a number of tests make calls to an NTP server, which can lead to the tests failing if these request get blocked due to rate limiting.


* **What is the new behavior (if this is a feature change)?**
Calls to NTP servers are disabled if the environment variable JEST_WORKER_ID is set, indicating that the code is being run in the test environment. The time diff is faked in this scenario.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
