### PR TITLE
feat: translate segment ids on mos rundown ingest

### DIFF
--- a/meteor/__mocks__/helpers/snapshot.ts
+++ b/meteor/__mocks__/helpers/snapshot.ts
@@ -6,6 +6,7 @@ import { Part, DBPart } from '../../lib/collections/Parts'
 import { Piece } from '../../lib/collections/Pieces'
 import { DBRundownPlaylist } from '../../lib/collections/RundownPlaylists'
 import { PieceInstance } from '../../lib/collections/PieceInstances'
+import { PartInstance } from '../../lib/collections/PartInstances'
 const cloneOrg = require('fast-clone')
 
 // About snapshot testing: https://jestjs.io/docs/en/snapshot-testing
@@ -20,6 +21,7 @@ type Data =
 	| DBPart
 	| Piece
 	| PieceInstance
+	| PartInstance
 /**
  * Remove certain fields from data that change often, so that it can be used in snapshots
  * @param data

--- a/meteor/server/DatabaseCache.ts
+++ b/meteor/server/DatabaseCache.ts
@@ -183,7 +183,8 @@ export class DbCacheWriteCollection<
 		}
 		if (!doc._id) doc._id = getRandomId()
 		this.documents.set(doc._id, {
-			inserted: true,
+			inserted: existing !== null,
+			updated: existing === null,
 			document: this._transform(clone(doc)), // Unlinke a normal collection, this class stores the transformed objects
 		})
 		if (span) span.end()
@@ -389,9 +390,7 @@ export class DbCacheWriteCollection<
 				otherCache.remove(id)
 				this.documents.delete(id)
 			} else {
-				if (doc.inserted) {
-					otherCache.insert(doc.document)
-				} else if (doc.updated) {
+				if (doc.inserted || doc.updated) {
 					otherCache.upsert(id, doc.document, true)
 				}
 				delete doc.inserted

--- a/meteor/server/api/ingest/mosDevice/__tests__/__snapshots__/mosIngest.test.ts.snap
+++ b/meteor/server/api/ingest/mosDevice/__tests__/__snapshots__/mosIngest.test.ts.snap
@@ -2563,6 +2563,7 @@ Array [
     "notes": Array [],
     "rundownId": "5meLdE_m5k28xXw1vtX2JX8mSYQ_",
     "segmentId": "MCxHIjO7_t3PRHpLiX0vbzwx4gg_",
+    "status": "BUSY",
     "title": "SEGMENT1;PART1",
   },
   Object {
@@ -2852,6 +2853,7 @@ Array [
     "notes": Array [],
     "rundownId": "5meLdE_m5k28xXw1vtX2JX8mSYQ_",
     "segmentId": "MCxHIjO7_t3PRHpLiX0vbzwx4gg_",
+    "status": "BUSY",
     "title": "SEGMENT1;PART1",
   },
   Object {
@@ -3696,6 +3698,7 @@ Array [
     "notes": Array [],
     "rundownId": "5meLdE_m5k28xXw1vtX2JX8mSYQ_",
     "segmentId": "MCxHIjO7_t3PRHpLiX0vbzwx4gg_",
+    "status": "BUSY",
     "title": "SEGMENT1;PART1",
   },
   Object {
@@ -4009,6 +4012,7 @@ Array [
     "notes": Array [],
     "rundownId": "5meLdE_m5k28xXw1vtX2JX8mSYQ_",
     "segmentId": "MCxHIjO7_t3PRHpLiX0vbzwx4gg_",
+    "status": "BUSY",
     "title": "SEGMENT1;PART1",
   },
   Object {

--- a/meteor/server/api/ingest/mosDevice/__tests__/diffSegmentEntries.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/diffSegmentEntries.test.ts
@@ -340,7 +340,7 @@ describe('Ingest: MOS', () => {
 			expect(_.keys(diff.removed)).toEqual(['first'])
 			expect(_.keys(diff.unchanged)).toEqual(['second', 'third', 'fourth'])
 			expect(_.keys(diff.onlyRankChanged)).toHaveLength(0)
-			expect(diff.onlyExternalIdChanged).toEqual({
+			expect(diff.externalIdChanged).toEqual({
 				first: 'NEW',
 			})
 
@@ -355,7 +355,7 @@ describe('Ingest: MOS', () => {
 			expect(_.keys(diff2.removed)).toEqual(['second'])
 			expect(_.keys(diff2.unchanged)).toEqual(['first', 'third', 'fourth'])
 			expect(_.keys(diff2.onlyRankChanged)).toHaveLength(0)
-			expect(diff2.onlyExternalIdChanged).toEqual({
+			expect(diff2.externalIdChanged).toEqual({
 				second: 'NEW',
 			})
 
@@ -370,7 +370,7 @@ describe('Ingest: MOS', () => {
 			expect(_.keys(diff3.removed)).toEqual(['fourth'])
 			expect(_.keys(diff3.unchanged)).toEqual(['first', 'second', 'third'])
 			expect(_.keys(diff3.onlyRankChanged)).toHaveLength(0)
-			expect(diff3.onlyExternalIdChanged).toEqual({
+			expect(diff3.externalIdChanged).toEqual({
 				fourth: 'NEW',
 			})
 		})

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor'
 import * as MOS from 'mos-connection'
 import * as _ from 'underscore'
 import { setupDefaultStudioEnvironment } from '../../../../../__mocks__/helpers/database'
@@ -17,8 +16,7 @@ import { RundownPlaylists, RundownPlaylist } from '../../../../../lib/collection
 import { MeteorCall } from '../../../../../lib/api/methods'
 import { IngestDataCache, IngestCacheType } from '../../../../../lib/collections/IngestDataCache'
 import { getPartId } from '../../lib'
-import { PartInstance, PartInstances } from '../../../../../lib/collections/PartInstances'
-import { stringify } from 'query-string'
+import { PartInstance } from '../../../../../lib/collections/PartInstances'
 
 jest.mock('../../updateNext')
 

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -1013,7 +1013,12 @@ describe('Test recieved mos ingest payloads', () => {
 		expect(partsInSegmentAfter[1]).toMatchObject(_.omit(partsInSegmentBefore[2], ['segmentId', '_rank']))
 	})
 
-	function replaceStory(runningOrderId: string, oldStoryId: string, newStoryId: string, newStoryName: string) {
+	function mosReplaceBasicStory(
+		runningOrderId: string,
+		oldStoryId: string,
+		newStoryId: string,
+		newStoryName: string
+	) {
 		waitForPromise(
 			MeteorCall.peripheralDevice.mosRoStoryReplace(
 				device._id,
@@ -1033,7 +1038,7 @@ describe('Test recieved mos ingest payloads', () => {
 		)
 	}
 
-	function applySegmentChanges(
+	function applySegmentRenameToContents(
 		oldName: string,
 		newName: string,
 		oldSegments: Segment[],
@@ -1090,14 +1095,14 @@ describe('Test recieved mos ingest payloads', () => {
 		const partInstances0 = rundown.getAllPartInstances()
 		const { segments: segments0, parts: parts0 } = waitForPromise(rundown.getSegmentsAndParts())
 
-		replaceStory(rundown.externalId, 'ro1;s2;p1', 'ro1;s2;p1', 'SEGMENT2b;PART1')
-		replaceStory(rundown.externalId, 'ro1;s2;p2', 'ro1;s2;p2', 'SEGMENT2b;PART2')
+		mosReplaceBasicStory(rundown.externalId, 'ro1;s2;p1', 'ro1;s2;p1', 'SEGMENT2b;PART1')
+		mosReplaceBasicStory(rundown.externalId, 'ro1;s2;p2', 'ro1;s2;p2', 'SEGMENT2b;PART2')
 
 		const partInstances = rundown.getAllPartInstances()
 		const { segments, parts } = waitForPromise(rundown.getSegmentsAndParts())
 
 		// Update expected data, for just the segment name and ids changing
-		applySegmentChanges('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
+		applySegmentRenameToContents('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
 
 		expect(fixSnapshot(segments)).toMatchObject(fixSnapshot(segments0))
 		expect(fixSnapshot(parts)).toMatchObject(fixSnapshot(parts0))
@@ -1144,7 +1149,7 @@ describe('Test recieved mos ingest payloads', () => {
 		const { segments, parts } = waitForPromise(rundown.getSegmentsAndParts())
 
 		// Update expected data, for just the segment name and ids changing
-		applySegmentChanges('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
+		applySegmentRenameToContents('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
 
 		expect(fixSnapshot(segments)).toMatchObject(fixSnapshot(segments0))
 		expect(fixSnapshot(parts)).toMatchObject(fixSnapshot(parts0))

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor'
 import * as MOS from 'mos-connection'
 import * as _ from 'underscore'
 import { setupDefaultStudioEnvironment } from '../../../../../__mocks__/helpers/database'
-import { testInFiber, testInFiberOnly } from '../../../../../__mocks__/helpers/jest'
+import { testInFiber } from '../../../../../__mocks__/helpers/jest'
 import { Rundowns, Rundown, DBRundown } from '../../../../../lib/collections/Rundowns'
 import { Segments, DBSegment, Segment, SegmentId } from '../../../../../lib/collections/Segments'
 import { Parts, DBPart, Part } from '../../../../../lib/collections/Parts'
@@ -1077,7 +1077,7 @@ describe('Test recieved mos ingest payloads', () => {
 		}
 	}
 
-	testInFiberOnly('Rename segment during update while on air', () => {
+	testInFiber('Rename segment during update while on air', () => {
 		// Reset RO
 		waitForPromise(MeteorCall.peripheralDevice.mosRoCreate(device._id, device.token, mockRO.roCreate()))
 
@@ -1106,7 +1106,7 @@ describe('Test recieved mos ingest payloads', () => {
 		expect(fixSnapshot(partInstances)).toMatchObject(fixSnapshot(partInstances0))
 	})
 
-	testInFiberOnly('Rename segment during resync while on air', () => {
+	testInFiber('Rename segment during resync while on air', () => {
 		const mosRO = mockRO.roCreate()
 
 		// Reset RO

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -38,6 +38,7 @@ import {
 	LocalIngestSegment,
 	LocalIngestPart,
 	updateIngestRundownWithData,
+	tryLoadCachedRundownData,
 } from '../ingestCache'
 import { Rundown, RundownId, Rundowns } from '../../../../lib/collections/Rundowns'
 import { Studio } from '../../../../lib/collections/Studios'
@@ -54,6 +55,7 @@ import { initCacheForRundownPlaylist, CacheForRundownPlaylist } from '../../../D
 import { getSelectedPartInstancesFromCache } from '../../playout/lib'
 import { Settings } from '../../../../lib/Settings'
 import { profiler } from '../../profiler'
+import { Pieces } from '../../../../lib/collections/Pieces'
 
 interface AnnotatedIngestPart {
 	externalId: string
@@ -150,28 +152,23 @@ export function handleMosRundownData(
 		const parts = _.compact(storiesToIngestParts(rundownId, mosRunningOrder.Stories || [], !createFresh, []))
 		const groupedStories = groupIngestParts(parts)
 
+		const oldRundownData = tryLoadCachedRundownData(rundownId)
+
 		// If this is a reload of a RO, then use cached data to make the change more seamless
-		if (!createFresh) {
-			const partIds = _.map(parts, (p) => p.partId)
-			const partCache = IngestDataCache.find({
-				rundownId: rundownId,
-				partId: { $in: partIds },
-				type: IngestCacheType.PART,
-			}).fetch()
-
-			const partCacheMap: { [id: string]: IngestPart } = {}
-			_.each(partCache, (p) => {
-				if (p.partId) {
-					partCacheMap[unprotectString(p.partId)] = p.data as IngestPart
+		if (!createFresh && oldRundownData) {
+			const partCacheMap = new Map<PartId, IngestPart>()
+			for (const segment of oldRundownData.segments) {
+				for (const part of segment.parts) {
+					partCacheMap.set(getPartId(rundownId, part.externalId), part)
 				}
-			})
+			}
 
-			_.each(parts, (s) => {
-				const cached = partCacheMap[unprotectString(s.partId)]
-				if (cached) {
-					s.ingest.payload = cached.payload
+			for (const annotatedPart of parts) {
+				const cached = partCacheMap.get(annotatedPart.partId)
+				if (cached && !annotatedPart.ingest.payload) {
+					annotatedPart.ingest.payload = cached.payload
 				}
-			})
+			}
 		}
 
 		const ingestSegments = groupedPartsToSegments(rundownId, groupedStories)
@@ -184,6 +181,11 @@ export function handleMosRundownData(
 			payload: mosRunningOrder,
 			modified: getCurrentTime(),
 		})
+
+		if (rundown && oldRundownData) {
+			// If we already have a rundown, update any modified segment ids
+			diffAndUpdateSegmentIds(rundown, oldRundownData, ingestSegments)
+		}
 
 		handleUpdatedRundownInner(
 			studio,
@@ -223,7 +225,6 @@ export function handleMosRundownMetadata(
 					`Failed to ShowStyleBase "${rundown.showStyleBaseId}" for rundown "${rundown._id}"`
 				)
 			}
-			const showStyleBlueprint = loadShowStyleBlueprint(showStyleBase)
 
 			// Load the cached RO Data
 			const ingestRundown = loadCachedRundownData(rundown._id, rundown.externalId)
@@ -601,6 +602,85 @@ function groupPartsIntoIngestSegments(rundown: Rundown, newIngestParts: Annotate
 	return newIngestSegments
 }
 
+function diffAndUpdateSegmentIds(
+	rundown: Rundown,
+	oldIngestRundown: LocalIngestRundown,
+	newIngestSegments: LocalIngestSegment[]
+): DiffSegmentEntries {
+	const span = profiler.startSpan('mosDevice.ingest.diffAndApplyChanges')
+
+	// TODO this is a duplicate of a loop found in diffAndApplyChanges but modified to not run against a cache.
+	// This should be improved once the caches change, and we have access to one in time for this
+
+	// Fetch all existing segments:
+	const oldSegments = Segments.find({ rundownId: rundown._id }).fetch()
+
+	const oldSegmentEntries = compileSegmentEntries(oldIngestRundown.segments)
+	const newSegmentEntries = compileSegmentEntries(newIngestSegments)
+	const segmentDiff = diffSegmentEntries(oldSegmentEntries, newSegmentEntries, oldSegments)
+
+	const ps: Array<Promise<any>> = []
+
+	// Updated segments that has had their segment.externalId changed:
+	_.each(segmentDiff.externalIdChanged, (newSegmentExternalId, oldSegmentExternalId) => {
+		const oldSegmentId = getSegmentId(rundown._id, oldSegmentExternalId)
+		const newSegmentId = getSegmentId(rundown._id, newSegmentExternalId)
+
+		ps.push(asyncCollectionUpdate(Segments, oldSegmentId, { $set: { segmentId: newSegmentId } }))
+
+		ps.push(
+			asyncCollectionUpdate(
+				Parts,
+				{
+					rundownId: rundown._id,
+					segmentId: oldSegmentId,
+				},
+				{
+					$set: {
+						segmentId: newSegmentId,
+					},
+				}
+			)
+		)
+
+		ps.push(
+			asyncCollectionUpdate(
+				Pieces,
+				{
+					startRundownId: rundown._id,
+					startSegmentId: oldSegmentId,
+				},
+				{
+					$set: {
+						startSegmentId: newSegmentId,
+					},
+				}
+			)
+		)
+
+		ps.push(
+			asyncCollectionUpdate(
+				PartInstances,
+				{
+					rundownId: rundown._id,
+					segmentId: oldSegmentId,
+				},
+				{
+					$set: {
+						segmentId: newSegmentId,
+						'part.segmentId': newSegmentId,
+					},
+				}
+			)
+		)
+	})
+
+	waitForPromiseAll(ps)
+
+	span?.end()
+	return segmentDiff
+}
+
 function diffAndApplyChanges(
 	cache: CacheForRundownPlaylist,
 	studio: Studio,
@@ -611,13 +691,6 @@ function diffAndApplyChanges(
 	// newIngestParts: AnnotatedIngestPart[]
 ) {
 	const span = profiler.startSpan('mosDevice.ingest.diffAndApplyChanges')
-
-	// Fetch all existing segments:
-	const oldSegments = cache.Segments.findFetch({ rundownId: rundown._id })
-
-	const oldSegmentEntries = compileSegmentEntries(oldIngestRundown.segments)
-	const newSegmentEntries = compileSegmentEntries(newIngestSegments)
-	const segmentDiff = diffSegmentEntries(oldSegmentEntries, newSegmentEntries, oldSegments)
 
 	// Check if operation affect currently playing Part:
 	const { currentPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
@@ -657,6 +730,13 @@ function diffAndApplyChanges(
 		span?.end()
 	}
 
+	// Fetch all existing segments:
+	const oldSegments = cache.Segments.findFetch({ rundownId: rundown._id })
+
+	const oldSegmentEntries = compileSegmentEntries(oldIngestRundown.segments)
+	const newSegmentEntries = compileSegmentEntries(newIngestSegments)
+	const segmentDiff = diffSegmentEntries(oldSegmentEntries, newSegmentEntries, oldSegments)
+
 	// Save new cache
 	const newIngestRundown = updateIngestRundownWithData(oldIngestRundown, newIngestSegments)
 	saveRundownCache(rundown._id, newIngestRundown)
@@ -675,8 +755,9 @@ function diffAndApplyChanges(
 			}
 		)
 	})
+
 	// Updated segments that has had their segment.externalId changed:
-	_.each(segmentDiff.onlyExternalIdChanged, (newSegmentExternalId, oldSegmentExternalId) => {
+	_.each(segmentDiff.externalIdChanged, (newSegmentExternalId, oldSegmentExternalId) => {
 		const oldSegmentId = getSegmentId(rundown._id, oldSegmentExternalId)
 		const newSegmentId = getSegmentId(rundown._id, newSegmentExternalId)
 
@@ -693,6 +774,12 @@ function diffAndApplyChanges(
 				},
 			}
 		)
+
+		cache.Pieces.update((p) => p.startRundownId === rundown._id && p.startSegmentId === oldSegmentId, {
+			$set: {
+				startSegmentId: newSegmentId,
+			},
+		})
 
 		cache.PartInstances.update(
 			{
@@ -754,7 +841,7 @@ export interface DiffSegmentEntries {
 	onlyRankChanged: { [segmentExternalId: string]: number } // contains the new rank
 
 	/** Reference to segments which has been REMOVED, but it looks like there is an ADDED segment that is closely related to the removed one */
-	onlyExternalIdChanged: { [removedSegmentExternalId: string]: string } // contains the added segment's externalId
+	externalIdChanged: { [removedSegmentExternalId: string]: string } // contains the added segment's externalId
 }
 export function diffSegmentEntries(
 	oldSegmentEntries: SegmentEntries,
@@ -768,7 +855,7 @@ export function diffSegmentEntries(
 		unchanged: {},
 
 		onlyRankChanged: {},
-		onlyExternalIdChanged: {},
+		externalIdChanged: {},
 	}
 	const oldSegmentMap: { [externalId: string]: Segment } | null =
 		oldSegments === null ? null : normalizeArray(oldSegments, 'externalId')
@@ -834,7 +921,7 @@ export function diffSegmentEntries(
 			})
 		}
 		if (newSegmentEntry) {
-			diff.onlyExternalIdChanged[segmentExternalId] = newSegmentEntry.externalId
+			diff.externalIdChanged[segmentExternalId] = newSegmentEntry.externalId
 		}
 	})
 

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -758,6 +758,9 @@ function diffAndApplyChanges(
 	const newIngestRundown = updateIngestRundownWithData(oldIngestRundown, newIngestSegments)
 	saveRundownCache(rundown._id, newIngestRundown)
 
+	// TODO - do we need to do these 'clever' updates anymore? As we don't store any playout properties on the Parts, destroying and recreating won't have negative impacts?
+	// The one exception is PartInstances when the segmentId changes, so we can try and preserve their position as well as possible.
+
 	// Update segment ranks:
 	_.each(segmentDiff.onlyRankChanged, (newRank, segmentExternalId) => {
 		cache.Segments.update(

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -759,7 +759,7 @@ function diffAndApplyChanges(
 	saveRundownCache(rundown._id, newIngestRundown)
 
 	// TODO - do we need to do these 'clever' updates anymore? As we don't store any playout properties on the Parts, destroying and recreating won't have negative impacts?
-	// The one exception is PartInstances when the segmentId changes, so we can try and preserve their position as well as possible.
+	// The one exception is PartInstances when the segmentId changes, but that is handled by `updatePartInstancesBasicProperties()` as a general data integrity enforcement step
 
 	// Update segment ranks:
 	_.each(segmentDiff.onlyRankChanged, (newRank, segmentExternalId) => {

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -35,7 +35,6 @@ import { logger } from '../../../lib/logging'
 import { Studio, Studios } from '../../../lib/collections/Studios'
 import {
 	selectShowStyleVariant,
-	afterRemoveSegments,
 	afterRemoveParts,
 	ServerRundownAPI,
 	removeSegments,
@@ -45,6 +44,7 @@ import {
 	getAllRundownsInPlaylist,
 	sortDefaultRundownInPlaylistOrder,
 	ChangedSegmentsRankInfo,
+	updatePartInstancesBasicProperties,
 } from '../rundown'
 import { loadShowStyleBlueprint, WrappedShowStyleBlueprint } from '../blueprints/cache'
 import {
@@ -996,13 +996,6 @@ function updateRundownFromIngestData(
 			afterRemove(segment) {
 				logger.info('removed segment ' + segment._id)
 			},
-			afterRemoveAll(segments) {
-				afterRemoveSegments(
-					cache,
-					rundownId,
-					_.map(segments, (s) => s._id)
-				)
-			},
 		})
 	)
 
@@ -1504,6 +1497,8 @@ function afterIngestChangedData(
 	// To be called after rundown has been changed
 	updateExpectedMediaItemsOnRundown(cache, rundown._id)
 	updateExpectedPlayoutItemsOnRundown(cache, rundown._id)
+
+	updatePartInstancesBasicProperties(cache, playlist, rundown._id)
 
 	updatePartInstanceRanks(cache, playlist, changedSegments)
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a mos segment name changes as part of a resync operation, this will cause the segment to be treated as a new segment.
This will cause it to lose the PartInstances (as-played state), and if it is currently playing will cause it to become unsynced

* **What is the new behavior (if this is a feature change)?**

The same logic used for determining segmentId changes on smaller mos operations is applied, so that segments are preserved as much as possible.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
