### PR TITLE
chore: declarationMap

### DIFF
--- a/packages/blueprints-integration/tsconfig.build.json
+++ b/packages/blueprints-integration/tsconfig.build.json
@@ -10,6 +10,7 @@
 			"@sofie-automation/blueprints-integration": ["./src/index.ts"]
 		},
 		"resolveJsonModule": true,
+		"declarationMap": true,
 		"types": ["node"]
 	}
 }

--- a/packages/server-core-integration/tsconfig.build.json
+++ b/packages/server-core-integration/tsconfig.build.json
@@ -4,5 +4,8 @@
     "node_modules/**",
     "src/**/*spec.ts",
     "src/**/__mocks__/*"
-  ]
+  ],
+  "compilerOptions": {
+    "declarationMap": true
+  }
 }


### PR DESCRIPTION
This PR adds the property `declarationMap` to the build-tsconfig of the packages.
This enables VSCode to jump to the actual source files instead of the compiled declaration files. This increases productivity by at least 2.3%.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
