### PR TITLE
fix: hoverscrub in shelf scrolls

### DIFF
--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -34,7 +34,6 @@ import { IAdLibListItem } from '../ui/Shelf/AdLibListItem'
 import { BucketAdLibItem, BucketAdLibUi } from '../ui/Shelf/RundownViewBuckets'
 import { Mongo } from 'meteor/mongo'
 import { FindOptions } from '../../lib/typings/meteor'
-import { Meteor } from 'meteor/meteor'
 
 interface PieceGroupMetadataExt extends PieceGroupMetadata {
 	id: PieceId

--- a/meteor/client/styles/countdown/overlay.scss
+++ b/meteor/client/styles/countdown/overlay.scss
@@ -71,7 +71,6 @@ body.transparent {
 		white-space: nowrap;
 		overflow: hidden;
 
-		font-weight: normal;
 		font-style: normal;
 		font-stretch: normal;
 		letter-spacing: normal;
@@ -127,9 +126,6 @@ body.transparent {
 
 	.clocks-counter-normal {
 		font-weight: 300;
-	}
-
-	.clocks-title-small {
 	}
 
 	.clocks-rundown-bottom-bar {

--- a/meteor/client/styles/countdown/presenter.scss
+++ b/meteor/client/styles/countdown/presenter.scss
@@ -50,23 +50,17 @@
 		white-space: nowrap;
 		overflow: hidden;
 
-		font-weight: normal;
 		font-style: normal;
 		font-stretch: normal;
 		letter-spacing: normal;
 
-		padding-top: 2vh;
+		margin-top: -2.778vh;
+		font-weight: 300 !important;
+		padding-top: 1vh;
 	}
 
 	.clocks-part-title.clocks-current-segment-title {
 		font-weight: 500;
-	}
-
-	.clocks-part-title {
-		margin-top: -2.778vh;
-		font-weight: 300 !important;
-		padding-top: 1vh;
-		//margin-left: 35px;
 	}
 
 	.clocks-current-segment-title {

--- a/meteor/client/ui/ClockView/ClockView.tsx
+++ b/meteor/client/ui/ClockView/ClockView.tsx
@@ -19,17 +19,17 @@ import { OverlayScreenSaver } from './OverlayScreenSaver'
 
 interface IPropsHeader {
 	key: string
-	playlist: RundownPlaylist
+	playlist: RundownPlaylist | undefined
 	studioId: StudioId
 }
 
 interface IStateHeader {}
 
 export const ClockView = withTracker(function(props: IPropsHeader) {
-	let studioId = objectPathGet(props, 'match.params.studioId')
+	const studioId = objectPathGet(props, 'match.params.studioId')
 	const playlist = RundownPlaylists.findOne({
 		activationId: { $exists: true },
-		studioId: studioId,
+		studioId,
 	})
 
 	return {
@@ -39,11 +39,11 @@ export const ClockView = withTracker(function(props: IPropsHeader) {
 })(
 	class ClockView extends MeteorReactComponent<WithTiming<IPropsHeader>, IStateHeader> {
 		componentDidMount() {
-			let studioId = this.props.studioId
+			const { studioId } = this.props
 			if (studioId) {
 				this.subscribe(PubSub.rundownPlaylists, {
-					activationId: { exists: true },
-					studioId: studioId,
+					activationId: { $exists: true },
+					studioId,
 				})
 			}
 		}

--- a/meteor/client/ui/ClockView/OverlayScreen.tsx
+++ b/meteor/client/ui/ClockView/OverlayScreen.tsx
@@ -44,12 +44,12 @@ export const OverlayScreen = withTranslation()(
 	)(
 		withTiming<RundownOverviewProps & RundownOverviewTrackedProps & WithTranslation, RundownOverviewState>()(
 			class OverlayScreen extends PresenterScreenBase {
-				protected bodyClassList: string[] = ['dark', 'xdark']
+				protected bodyClassList: string[] = ['transparent']
 
 				render() {
-					const { playlist, segments, showStyleBaseId, t } = this.props
+					const { playlist, segments, showStyleBaseId, t, playlistId } = this.props
 
-					if (playlist && this.props.playlistId && this.props.segments && showStyleBaseId) {
+					if (playlist && playlistId && segments && showStyleBaseId) {
 						let currentPart: PartUi | undefined
 						let currentSegment: SegmentUi | undefined
 						for (const segment of segments) {

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -183,9 +183,9 @@ export class PresenterScreenBase extends MeteorReactComponent<
 	}
 
 	render() {
-		const { playlist, segments, showStyleBaseId } = this.props
+		const { playlist, segments, showStyleBaseId, playlistId } = this.props
 
-		if (playlist && this.props.playlistId && this.props.segments && showStyleBaseId) {
+		if (playlist && playlistId && segments && showStyleBaseId) {
 			let currentPart: PartUi | undefined
 			let currentSegment: SegmentUi | undefined
 			for (const segment of segments) {

--- a/meteor/client/ui/FloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspector.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
+import React from 'react'
 import * as _ from 'underscore'
 import Escape from 'react-escape'
 
-interface IPropsHeader {
+interface IProps {
 	shown: boolean
+	displayOn?: 'document' | 'viewport'
+	children?: React.ReactNode
 }
 
-export class FloatingInspector extends React.Component<IPropsHeader> {
-	render() {
-		return this.props.shown ? <Escape to="document">{this.props.children}</Escape> : null
-	}
+export const FloatingInspector: React.FC<IProps> = function(props: IProps) {
+	return props.shown ? <Escape to={props.displayOn ?? 'document'}>{props.children}</Escape> : null
 }

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -21,6 +21,7 @@ interface IProps {
 	content: NoraContent | undefined
 	floatingInspectorStyle: React.CSSProperties
 	typeClass?: string
+	displayOn?: 'document' | 'viewport'
 }
 
 type KeyValue = { key: string; value: string }
@@ -34,6 +35,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 	pieceRenderedIn,
 	pieceRenderedDuration,
 	typeClass,
+	displayOn,
 }) => {
 	const { t } = useTranslation()
 	const innerPiece = piece
@@ -73,10 +75,10 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 
 	return noraContent && noraContent.payload && noraContent.previewRenderer ? (
 		showMiniInspector && !!itemElement ? (
-			<NoraFloatingInspector noraContent={noraContent} style={floatingInspectorStyle} />
+			<NoraFloatingInspector noraContent={noraContent} style={floatingInspectorStyle} displayOn={displayOn} />
 		) : null
 	) : (
-		<FloatingInspector shown={showMiniInspector && !!itemElement}>
+		<FloatingInspector shown={showMiniInspector && !!itemElement} displayOn={displayOn}>
 			<div className={'segment-timeline__mini-inspector ' + typeClass} style={floatingInspectorStyle}>
 				{templateName && (
 					<div className="mini-inspector__header">

--- a/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/MicFloatingInspector.tsx
@@ -11,6 +11,7 @@ interface IProps {
 	itemElement: HTMLDivElement | null
 	floatingInspectorStyle: React.CSSProperties
 	content: ScriptContent
+	displayOn?: 'document' | 'viewport'
 }
 
 const BREAK_SCRIPT_BREAKPOINT = 620
@@ -40,7 +41,7 @@ export function MicFloatingInspector(props: IProps) {
 	)
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className={
 					'segment-timeline__mini-inspector ' + props.typeClass + ' segment-timeline__mini-inspector--pop-down'

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -5,6 +5,7 @@ import Escape from 'react-escape'
 interface IPropsHeader {
 	noraContent: NoraContent | undefined
 	style: React.CSSProperties
+	displayOn?: 'document' | 'viewport'
 }
 
 interface IStateHeader extends IPropsHeader {
@@ -13,12 +14,13 @@ interface IStateHeader extends IPropsHeader {
 		x: boolean
 		y: boolean
 	}
+	displayOn: 'document' | 'viewport'
 }
 
 export const NoraFloatingInspector: React.FunctionComponent<IPropsHeader> = (props: IPropsHeader) => {
 	useEffect(() => {
 		if (props.noraContent) {
-			NoraPreviewRenderer.show(props.noraContent, props.style)
+			NoraPreviewRenderer.show(props.noraContent, props.style, props.displayOn || 'document')
 		}
 
 		return () => {
@@ -51,8 +53,8 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		| undefined
 	private _observer: IntersectionObserver | undefined
 
-	static show(noraContent: NoraContent, style: React.CSSProperties) {
-		NoraPreviewRenderer._singletonRef._show(noraContent, style)
+	static show(noraContent: NoraContent, style: React.CSSProperties, displayOn: 'document' | 'viewport') {
+		NoraPreviewRenderer._singletonRef._show(noraContent, style, displayOn)
 	}
 
 	static hide() {
@@ -70,6 +72,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 				x: false,
 				y: false,
 			},
+			displayOn: 'document',
 		}
 		NoraPreviewRenderer._singletonRef = this
 	}
@@ -103,7 +106,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 		)
 	}
 
-	private _show(noraContent: NoraContent, style: React.CSSProperties) {
+	private _show(noraContent: NoraContent, style: React.CSSProperties, displayOn?: 'document' | 'viewport') {
 		if (JSON.stringify(this.state.noraContent) !== JSON.stringify(noraContent)) {
 			if (this.iframeElement && this.iframeElement.contentWindow) {
 				this.postNoraEvent(this.iframeElement.contentWindow, noraContent)
@@ -138,6 +141,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 				x,
 				y,
 			},
+			displayOn: displayOn || 'document',
 		})
 	}
 
@@ -201,11 +205,9 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	render() {
-		if (!this.state) return null
-
 		return (
 			<React.Fragment>
-				<Escape to="document">
+				<Escape to={this.state.displayOn}>
 					<div
 						className="segment-timeline__mini-inspector segment-timeline__mini-inspector--graphics segment-timeline__mini-inspector--graphics--preview"
 						style={this.getElStyle()}>

--- a/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/SplitsFloatingInspector.tsx
@@ -12,6 +12,7 @@ interface IProps {
 	itemElement: HTMLDivElement | null
 	floatingInspectorStyle: React.CSSProperties
 	content: SplitsContent
+	displayOn?: 'document' | 'viewport'
 }
 
 const RenderSplitPreview = memo(function RenderSplitPreview({ subItems }: { subItems: SplitSubItem[] }) {
@@ -57,7 +58,7 @@ export const SplitsFloatingInspector: React.FunctionComponent<IProps> = (props) 
 	])
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			<div
 				className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"
 				style={props.floatingInspectorStyle}>

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -21,6 +21,7 @@ interface IProps {
 	noticeMessage: string | null
 	contentMetaData: MediaObject | null
 	renderedDuration?: number | undefined
+	displayOn?: 'document' | 'viewport'
 }
 
 function getPreviewUrl(contentMetaData: MediaObject | null, mediaPreviewUrl: string | undefined): string | undefined {
@@ -82,7 +83,7 @@ export const VTFloatingInspector: React.FunctionComponent<IProps> = (props: IPro
 	const showFrameMarker = offsetTimePosition === 0 || offsetTimePosition >= itemDuration
 
 	return (
-		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined}>
+		<FloatingInspector shown={props.showMiniInspector && props.itemElement !== undefined} displayOn={props.displayOn}>
 			{getPreviewUrl(props.contentMetaData, props.mediaPreviewUrl) ? (
 				<div
 					className="segment-timeline__mini-inspector segment-timeline__mini-inspector--video"

--- a/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
+++ b/meteor/client/ui/PieceIcons/Renderers/SplitInput.tsx
@@ -46,7 +46,7 @@ export default class SplitInputIcon extends React.Component<{
 	getLeftSourceType(piece: PieceGeneric | undefined): string {
 		if (piece && piece.content) {
 			let c = piece.content as SplitsContent
-			const left = (c.boxSourceConfiguration[0] || {}).type || SourceLayerType.CAMERA
+			const left = (c.boxSourceConfiguration && c.boxSourceConfiguration[0])?.type || SourceLayerType.CAMERA
 			return this.getSourceType(left)
 		}
 		return 'camera'
@@ -55,7 +55,7 @@ export default class SplitInputIcon extends React.Component<{
 	getRightSourceType(piece: PieceGeneric | undefined): string {
 		if (piece && piece.content) {
 			let c = piece.content as SplitsContent
-			const right = (c.boxSourceConfiguration[1] || {}).type || SourceLayerType.REMOTE
+			const right = (c.boxSourceConfiguration && c.boxSourceConfiguration[1])?.type || SourceLayerType.REMOTE
 			const sourceType = this.getSourceType(right)
 			return sourceType + (this.getLeftSourceType(piece) === sourceType ? ' second' : '')
 		}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -126,6 +126,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 					piece={{ ...adLib, enable: { start: 0 }, startPartId: protectString(''), invalid: false }}
 					pieceRenderedDuration={adLib.expectedDuration || null}
 					pieceRenderedIn={null}
+					displayOn="viewport"
 				/>
 			</>
 		)
@@ -169,6 +170,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 							: null
 					}
 					mediaPreviewUrl={this.props.mediaPreviewUrl}
+					displayOn="viewport"
 				/>
 			</>
 		)

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -5,17 +5,11 @@ import { Meteor } from 'meteor/meteor'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { withTranslation } from 'react-i18next'
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
-import { Segment } from '../../../lib/collections/Segments'
-import { Part, Parts } from '../../../lib/collections/Parts'
 import { Rundown } from '../../../lib/collections/Rundowns'
-import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBaselineAdLibPieces'
 import { AdLibListItem, IAdLibListItem } from './AdLibListItem'
 import ClassNames from 'classnames'
 import { mousetrapHelper } from '../../lib/mousetrapHelper'
-
-import { faTh, faList, faTimes } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { RundownViewKbdShortcuts } from '../RundownView'
 
@@ -24,17 +18,15 @@ import { literal, normalizeArray, unprotectString, protectString } from '../../.
 import { RundownAPI } from '../../../lib/api/rundown'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
-import { PieceGeneric } from '../../../lib/collections/Pieces'
 import {
 	IOutputLayer,
 	ISourceLayer,
-	SomeContent,
 	IBlueprintActionManifestDisplayContent,
 	PieceLifespan,
 	IBlueprintActionTriggerMode,
 	SomeTimelineContent,
 } from '@sofie-automation/blueprints-integration'
-import { PubSub, meteorSubscribe } from '../../../lib/api/pubsub'
+import { PubSub } from '../../../lib/api/pubsub'
 import { doUserAction, UserAction } from '../../lib/userAction'
 import { NotificationCenter, NoticeLevel, Notification } from '../../lib/notifications/notifications'
 import { PartInstances } from '../../../lib/collections/PartInstances'

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -1937,9 +1937,9 @@
 					"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
 				},
 				"timeline-state-resolver-types": {
-					"version": "5.3.0-nightly-release29-20210113-080756-7bae1d378.0",
-					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.3.0-nightly-release29-20210113-080756-7bae1d378.0.tgz",
-					"integrity": "sha512-f8wCWhYtDPLK+UErQ7+3nTJEDekBepS3sazNmL2W39OKJjKI5BxMSaXzx7POWr8GPc1x/32SqDlLN4d3mR9K4Q==",
+					"version": "5.4.0-nightly-release30-20210204-130045-e281f2b9b.0",
+					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-5.4.0-nightly-release30-20210204-130045-e281f2b9b.0.tgz",
+					"integrity": "sha512-VTE+TsG/YldAN5iF45FaZaQtldq3zugRo+xHOtNz9NZbUSJBlO0wtfyFox22dFcaG88AP4WogJ0BppJ32gx2Vg==",
 					"requires": {
 						"tslib": "^1.13.0"
 					},
@@ -8280,7 +8280,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -1926,8 +1926,8 @@
 			"version": "file:../packages/blueprints-integration",
 			"requires": {
 				"moment": "2.29.1",
-				"timeline-state-resolver-types": "5.3.0-nightly-release29-20210113-080756-7bae1d378.0",
-				"tslib": "^2.0.3",
+				"timeline-state-resolver-types": "5.4.0-nightly-release30-20210204-130045-e281f2b9b.0",
+				"tslib": "^2.1.0",
 				"underscore": "1.12.0"
 			},
 			"dependencies": {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a fix

* **What is the current behavior?** (You can also link to an open issue here)

The hoverscrub previews for graphics and clips in the Shelf scrolls with the Rundown.

* **What is the new behavior (if this is a feature change)?**

Hoverscrub previews in the Shelf should not scroll, but be attached to the list item/button they are related to.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
