### PR TITLE
fix: add missing contexts to blueprint api methods [publish]

### DIFF
--- a/meteor/server/api/blueprints/config.ts
+++ b/meteor/server/api/blueprints/config.ts
@@ -96,11 +96,11 @@ export function preprocessStudioConfig(studio: Studio, blueprint?: StudioBluepri
 	res['SofieHostURL'] = studio.settings.sofieUrl
 
 	if (blueprint && blueprint.preprocessConfig) {
-		// const context = new CommonContext({
-		// 	name: `preprocessStudioConfig`,
-		// 	identifier: `studioId=${studio._id}`,
-		// })
-		res = blueprint.preprocessConfig(res)
+		const context = new CommonContext({
+			name: `preprocessStudioConfig`,
+			identifier: `studioId=${studio._id}`,
+		})
+		res = blueprint.preprocessConfig(context, res)
 	}
 	return res
 }

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -125,7 +125,8 @@ export function selectShowStyleVariant(
 
 	const variantId: ShowStyleVariantId | null = protectString(
 		showStyleBlueprint.blueprint.getShowStyleVariantId(
-			unprotectObjectArray(showStyleVariants) as any,
+			context,
+			unprotectObjectArray(showStyleVariants),
 			ingestRundown
 		)
 	)
@@ -203,14 +204,14 @@ export function produceRundownPlaylistRanks(
 
 	const playlistInfo: BlueprintResultRundownPlaylist | null = studioBlueprint.blueprint.getRundownPlaylistInfo
 		? studioBlueprint.blueprint.getRundownPlaylistInfo(
-				// new StudioUserContext(
-				// 	{
-				// 		name: 'produceRundownPlaylistRanks',
-				// 		identifier: `studioId=${studio._id},playlistId=${unprotectString(playlistId)}`,
-				// 		tempSendUserNotesIntoBlackHole: true,
-				// 	},
-				// 	studio
-				// ),
+				new StudioUserContext(
+					{
+						name: 'produceRundownPlaylistRanks',
+						identifier: `studioId=${studio._id},playlistId=${unprotectString(playlistId)}`,
+						tempSendUserNotesIntoBlackHole: true,
+					},
+					studio
+				),
 				unprotectObjectArray(rundowns)
 		  )
 		: null
@@ -269,16 +270,16 @@ export function produceRundownPlaylistInfoFromRundown(
 
 			const playlistInfo: BlueprintResultRundownPlaylist | null = studioBlueprint.blueprint.getRundownPlaylistInfo
 				? studioBlueprint.blueprint.getRundownPlaylistInfo(
-						// new StudioUserContext(
-						// 	{
-						// 		name: 'produceRundownPlaylistInfoFromRundown',
-						// 		identifier: `studioId=${studio._id},playlistId=${unprotectString(
-						// 			playlistId
-						// 		)},rundownId=${currentRundown._id}`,
-						// 		tempSendUserNotesIntoBlackHole: true,
-						// 	},
-						// 	studio
-						// ),
+						new StudioUserContext(
+							{
+								name: 'produceRundownPlaylistInfoFromRundown',
+								identifier: `studioId=${studio._id},playlistId=${unprotectString(
+									playlistId
+								)},rundownId=${currentRundown._id}`,
+								tempSendUserNotesIntoBlackHole: true,
+							},
+							studio
+						),
 						unprotectObjectArray(rundowns)
 				  )
 				: null

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -87,10 +87,13 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	) => string | null
 
 	/** Returns information about the playlist this rundown is a part of, return null to not make it a part of a playlist */
-	getRundownPlaylistInfo?: (rundowns: IBlueprintRundownDB[]) => BlueprintResultRundownPlaylist | null
+	getRundownPlaylistInfo?: (
+		context: IStudioUserContext,
+		rundowns: IBlueprintRundownDB[]
+	) => BlueprintResultRundownPlaylist | null
 
 	/** Preprocess config before storing it by core to later be returned by context's getStudioConfig. If not provided, getStudioConfig will return unprocessed blueprint config */
-	preprocessConfig?: (config: IBlueprintConfig) => unknown
+	preprocessConfig?: (context: ICommonContext, config: IBlueprintConfig) => unknown
 }
 
 export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
@@ -109,6 +112,7 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 
 	/** Returns the id of the show style variant to use for a rundown, return null to ignore that rundown */
 	getShowStyleVariantId: (
+		context: IStudioUserContext,
 		showStyleVariants: IBlueprintShowStyleVariant[],
 		ingestRundown: ExtendedIngestRundown
 	) => string | null


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

Ensures every blueprint method has a context parameter. Some got lost during conflicts in https://github.com/nrkno/tv-automation-server-core/pull/287

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
