### PR TITLE
fix: add IBlueprintPiece.hasSideEffects property to not prune 'definitely ended' piece (#456) [publish]

### DIFF
--- a/meteor/server/api/blueprints/context/lib.ts
+++ b/meteor/server/api/blueprints/context/lib.ts
@@ -26,6 +26,7 @@ const IBlueprintPieceSample: Required<IBlueprintPiece> = {
 	adlibAutoNextOverlap: 0,
 	adlibDisableOutTransition: false,
 	tags: [],
+	hasSideEffects: false,
 }
 // Compile a list of the keys which are allowed to be set
 export const IBlueprintPieceSampleKeys = Object.keys(IBlueprintPieceSample) as Array<keyof IBlueprintPiece>

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -797,6 +797,7 @@ export function hasPieceInstanceDefinitelyEnded(
 	nowInPart: number
 ): boolean {
 	if (nowInPart <= 0) return false
+	if (pieceInstance.piece.hasSideEffects) return false
 
 	let relativeEnd: number | undefined
 	if (typeof pieceInstance.resolvedEndCap === 'number') {

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -248,6 +248,9 @@ export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 	adlibDisableOutTransition?: boolean
 	/** User-defined tags that can be used for filtering adlibs in the shelf and identifying pieces by actions */
 	tags?: string[]
+
+	/** HACK: Some pieces have side effects on other pieces, and pruning them when they have finished playback will cause playout glitches. This will tell core to not always preserve it */
+	hasSideEffects?: boolean
 }
 
 export interface ExpectedPlayoutItemGeneric {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

Once a piece is determined to have definitely ended it is no longer added to the timeline, to minimise the size of the timeline as a performance improvment.

Some pieces can have side effects that cause state changes when they are removed. Any piece which sets a class does this, but most of the time this does not matter.
It is important when the class enables a clip, and we continue playback in the replacement piece. By removing some of the enable class usage, the clip will seek as its calculated current position changes

* **What is the new behavior (if this is a feature change)?**

The blueprints can tell core that a piece has side effects and to never prune its content with the definitely ended logic.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
