### PR TITLE
fix: invalidReason translation

### DIFF
--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -65,8 +65,10 @@ export class Part implements DBPart {
 	public displayDuration?: number
 	public invalid?: boolean
 	public invalidReason?: {
-		title: string
-		description?: string
+		message: {
+			key: string
+			args?: { [key: string]: any }
+		}
 		color?: string
 	}
 	public floated?: boolean
@@ -133,11 +135,7 @@ export class Part implements DBPart {
 			? [
 					{
 						type: NoteType.ERROR,
-						message: {
-							key: `${this.invalidReason.title}${
-								this.invalidReason.description ? `: ${+this.invalidReason.description}` : ''
-							}`,
-						},
+						message: this.invalidReason.message,
 						origin: {
 							name: this.title,
 						},

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -19,6 +19,7 @@ import { createMongoCollection } from './lib'
 import { Studio } from './Studios'
 import { ShowStyleBase } from './ShowStyleBases'
 import { registerIndex } from '../database'
+import { ITranslatableMessage } from '../api/TranslatableMessage'
 
 /** A string, identifying a Part */
 export type PartId = ProtectedString<'PartId'>
@@ -37,6 +38,12 @@ export interface DBPart extends ProtectedStringProperties<IBlueprintPartDB, '_id
 
 	/** Holds notes (warnings / errors) thrown by the blueprints during creation */
 	notes?: Array<PartNote>
+
+	/** Holds the user-facing explanation for why the part is invalid */
+	invalidReason?: {
+		message: ITranslatableMessage
+		color?: string
+	}
 
 	/** Human readable unqiue identifier of the part */
 	identifier?: string
@@ -65,10 +72,7 @@ export class Part implements DBPart {
 	public displayDuration?: number
 	public invalid?: boolean
 	public invalidReason?: {
-		message: {
-			key: string
-			args?: { [key: string]: any }
-		}
+		message: ITranslatableMessage
 		color?: string
 	}
 	public floated?: boolean

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1751,6 +1751,15 @@ function generateSegmentContents(
 			segmentId: newSegment._id,
 			_rank: i, // This gets updated to a rank unique within its segment in a later step
 			notes: notes,
+			invalidReason: blueprintPart.part.invalidReason
+				? {
+						...blueprintPart.part.invalidReason,
+						message: {
+							...blueprintPart.part.invalidReason.message,
+							namespaces: [unprotectString(blueprintId)],
+						},
+				  }
+				: undefined,
 		})
 		parts.push(part)
 

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -142,15 +142,19 @@ export interface IBlueprintPart<TMetadata = unknown> extends IBlueprintMutatable
 	 * Color needs to be in #xxxxxx RGB hexadecimal format.
 	 *
 	 * @type {{
-	 * 		title: string,
-	 * 		description?: string
+	 * 		message: {
+	 * 			key: string,
+	 * 			args?: { [key: string]: any }
+	 * 		},
 	 * 		color?: string
 	 * 	}}
 	 * @memberof IBlueprintPart
 	 */
 	invalidReason?: {
-		title: string
-		description?: string
+		message: {
+			key: string
+			args?: { [key: string]: any }
+		}
 		color?: string
 	}
 

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -137,8 +137,10 @@ export interface IBlueprintPart<TMetadata = unknown> extends IBlueprintMutatable
 	 */
 	invalid?: boolean
 	/**
-	 * Provide additional information about the reason a part is invalid. The title should be a single, short sentence describing the reason. Additional
-	 * information can be provided in the description property. The blueprints can also provide a color hint that the UI can use when displaying the part.
+	 * Provide additional information about the reason a part is invalid. The `key` is the string key from blueprints
+	 * translations. Args will be used to replace placeholders within the translated file. If `key` is not found in the
+	 * translation, it will be interpollated using the `args` and used as the string to be displayed.
+	 * The blueprints can also provide a color hint that the UI can use when displaying the part.
 	 * Color needs to be in #xxxxxx RGB hexadecimal format.
 	 *
 	 * @type {{

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -1,6 +1,7 @@
 import { DeviceType as TSR_DeviceType, ExpectedPlayoutItemContentVizMSE } from 'timeline-state-resolver-types'
 import { Time } from './common'
 import { SomeTimelineContent } from './content'
+import { ITranslatableMessage } from './translations'
 
 export interface IBlueprintRundownPlaylistInfo {
 	/** Rundown playlist slug - user-presentable name */
@@ -144,19 +145,13 @@ export interface IBlueprintPart<TMetadata = unknown> extends IBlueprintMutatable
 	 * Color needs to be in #xxxxxx RGB hexadecimal format.
 	 *
 	 * @type {{
-	 * 		message: {
-	 * 			key: string,
-	 * 			args?: { [key: string]: any }
-	 * 		},
+	 * 		message: ITranslatableMessage,
 	 * 		color?: string
 	 * 	}}
 	 * @memberof IBlueprintPart
 	 */
 	invalidReason?: {
-		message: {
-			key: string
-			args?: { [key: string]: any }
-		}
+		message: ITranslatableMessage
 		color?: string
 	}
 

--- a/packages/blueprints-integration/src/translations.ts
+++ b/packages/blueprints-integration/src/translations.ts
@@ -1,4 +1,4 @@
-export { TranslationsBundle, TranslationsBundleType, I18NextData }
+export { TranslationsBundle, TranslationsBundleType, I18NextData, ITranslatableMessage }
 
 enum TranslationsBundleType {
 	/** i18next JSON data */
@@ -22,4 +22,9 @@ interface TranslationsBundle {
 	encoding?: string
 	/** the actual translations as key/value pairs */
 	data: I18NextData
+}
+
+interface ITranslatableMessage {
+	key: string
+	args?: { [key: string]: any }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

The `invalidReason` property can not be translated using the blueprint i18n feature.

* **What is the new behavior (if this is a feature change)?**

The `invalidReason` field on a Part is redesigned to make it possible to translate the message. Also, the property is simplified, since the previous structure of `title` and `description` wasn't really used anyway.

* **Other information**:
