### PR TITLE
Fix: Take after execute cache usage in takeNextPartInnerSync

### DIFF
--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -75,14 +75,17 @@ export function takeNextPartInnerSync(
 	existingCache?: CacheForRundownPlaylist
 ) {
 	const span = profiler.startSpan('takeNextPartInner')
-	const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-	if (!dbPlaylist.activationId) throw new Meteor.Error(501, `RundownPlaylist "${rundownPlaylistId}" is not active!`)
-	if (!dbPlaylist.nextPartInstanceId) throw new Meteor.Error(500, 'nextPartInstanceId is not set!')
-	const cache = existingCache ?? waitForPromise(initCacheForRundownPlaylist(dbPlaylist, undefined, true))
+	let cache: CacheForRundownPlaylist | undefined = existingCache
 
-	let playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+	if (!cache) {
+		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+		cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist, undefined, true))
+	}
+
+	let playlist = cache.RundownPlaylists.findOne(rundownPlaylistId)
 	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 	if (!playlist.activationId) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
+	if (!playlist.nextPartInstanceId) throw new Meteor.Error(500, 'nextPartInstanceId is not set!')
 	const playlistActivationId = playlist.activationId
 
 	let timeOffset: number | null = playlist.nextTimeOffset || null


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a bug where you could not have an adlib action queue and `takeAfterExecute` a part at the end of a rundown.


* **What is the current behavior?** (You can also link to an open issue here)
`takeNextPartInnerSync` will throw an error because `dbPlaylist` has no `nextPartInstanceId`


* **What is the new behavior (if this is a feature change)?**
The checks for `activationId` and `nextPartInstanceId` will happen on the playlist fetched from the cache, so in the case where we have an existing cache that we're operationg on we won't be checking this against the database copy.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
