### PR TITLE
fix: display duration group display duration instability after a take

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -311,6 +311,8 @@ export const RundownTimingProvider = withTracker<
 
 					// This is where we actually calculate all the various variants of duration of a part
 					if (lastStartedPlayback && !partInstance.timings?.duration) {
+						// if duration isn't available, check if `takeOut` has already been set and use the difference
+						// between startedPlayback and takeOut as a temporary duration
 						const duration =
 							partInstance.timings?.duration ||
 							(partInstance.timings?.takeOut ? lastStartedPlayback - partInstance.timings?.takeOut : undefined)

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -311,23 +311,23 @@ export const RundownTimingProvider = withTracker<
 
 					// This is where we actually calculate all the various variants of duration of a part
 					if (lastStartedPlayback && !partInstance.timings?.duration) {
+						const duration =
+							partInstance.timings?.duration ||
+							(partInstance.timings?.takeOut ? lastStartedPlayback - partInstance.timings?.takeOut : undefined)
 						currentRemaining = Math.max(
 							0,
-							(partInstance.timings?.duration ||
+							(duration ||
 								(memberOfDisplayDurationGroup ? displayDurationFromGroup : partInstance.part.expectedDuration) ||
 								0) -
 								(now - lastStartedPlayback)
 						)
 						partDuration =
-							Math.max(
-								partInstance.timings?.duration || partInstance.part.expectedDuration || 0,
-								now - lastStartedPlayback
-							) - playOffset
+							Math.max(duration || partInstance.part.expectedDuration || 0, now - lastStartedPlayback) - playOffset
 						// because displayDurationGroups have no actual timing on them, we need to have a copy of the
 						// partDisplayDuration, but calculated as if it's not playing, so that the countdown can be
 						// calculated
 						partDisplayDurationNoPlayback =
-							partInstance.timings?.duration ||
+							duration ||
 							(memberOfDisplayDurationGroup ? displayDurationFromGroup : partInstance.part.expectedDuration) ||
 							this.props.defaultDuration ||
 							Settings.defaultDisplayDuration
@@ -390,7 +390,7 @@ export const RundownTimingProvider = withTracker<
 						partInstance.part.displayDurationGroup &&
 						!partInstance.part.floated &&
 						!partInstance.part.invalid &&
-						(partInstance.timings?.duration || partCounts)
+						(partInstance.timings?.duration || partInstance.timings?.takeOut || partCounts)
 					) {
 						this.displayDurationGroups[partInstance.part.displayDurationGroup] =
 							this.displayDurationGroups[partInstance.part.displayDurationGroup] - partDisplayDuration

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -26,7 +26,7 @@
 		"cov": "meteor npm run unitcov && meteor npm run cov-open",
 		"send-coverage": "codecov -p ..",
 		"test-i": "npm run integration-test",
-		"license-validate": "node ../scripts/checkLicenses.js --allowed='MIT,BSD,ISC,Apache,Unlicense,CC0,LGPL,CC BY 3.0,CC BY 4.0,MPL 2.0' --excludePackages=timecode,rxjs/ajax,rxjs/fetch,rxjs/internal-compatibility,nw-pre-gyp-module-test,rxjs/operators,rxjs/testing,rxjs/webSocket,undefined,i18next-conv,@fortawesome/fontawesome-common-types,argv,indexof",
+		"license-validate": "node ../scripts/checkLicenses.js --allowed=\"MIT,BSD,ISC,Apache,Unlicense,CC0,LGPL,CC BY 3.0,CC BY 4.0,MPL 2.0\" --excludePackages=timecode,rxjs/ajax,rxjs/fetch,rxjs/internal-compatibility,nw-pre-gyp-module-test,rxjs/operators,rxjs/testing,rxjs/webSocket,undefined,i18next-conv,@fortawesome/fontawesome-common-types,argv,indexof",
 		"lint": "tslint --project tsconfig.json --config tslint.json",
 		"lintfix": "npm run lint -- --fix",
 		"quickformat": "prettier \"__mocks__/**\" --write ; prettier \"lib/**\" --write ; prettier \"server/**\" --write ; prettier \"client/**\" --write ; prettier \"*.json\" --write ; prettier \"*.js\" --write ; prettier \"*.md\" --write",

--- a/scripts/checkLicenses.js
+++ b/scripts/checkLicenses.js
@@ -5,23 +5,22 @@ const legally = require('../meteor/node_modules/legally')
 let validLicenses = []
 let excludePackages = []
 
+process.argv.forEach((argString) => {
+	let m
+	m = argString.match(/--allowed=["']([^"']*)["']/)
+	if (!m) m = argString.match(/--allowed=(.*)/)
+	if (m) {
+		const strs = m[1].split(',')
+		console.log(`Valid licenses: ${strs.join(', ')}`)
+		validLicenses = strs.map(str => new RegExp(str), 'i')
+	}
 
-const argString = process.argv.join(' ')
-
-let m
-m = argString.match(/--allowed=['"]([^"']*)["']/)
-if (!m) m = argString.match(/--allowed=([^ ]*)/)
-if (m) {
-	const strs = m[1].split(',')
-	console.log(`Valid licenses: ${strs.join(', ')}`)
-	validLicenses = strs.map(str => new RegExp(str), 'i')
-}
-
-m = argString.match(/--excludePackages=(.*)/)
-if (m) {
-	excludePackages = m[1].split(',')
-	console.log(`Excluding packages: ${excludePackages.join(', ')}`)
-}
+	m = argString.match(/--excludePackages=(.*)/)
+	if (m) {
+		excludePackages = m[1].split(',')
+		console.log(`Excluding packages: ${excludePackages.join(', ')}`)
+	}
+})
 
 if (!validLicenses.length) {
 	throw 'usage: node checkLicenses.js --allowed=MIT,ISC --excludePackages=badPackageWhoDoesntSpeficyLicense'
@@ -30,40 +29,40 @@ if (!validLicenses.length) {
 console.log('Checking used licenses...')
 
 legally()
-.then((licenses) => {
-	let ok = true
+	.then((licenses) => {
+		let ok = true
 
-	for (const [package, info] of Object.entries(licenses)) {
-		let exclude = false
-		for (const excludePackage of excludePackages) {
-			if (package.match(new RegExp(`^${excludePackage}@`))) {
-				exclude = true
-			}
-		}
-		if (exclude) continue
-
-		let foundApproved = false
-		for (const license of info.package) {
-			for (const validLicense of validLicenses) {
-				if (license.match(validLicense) ) {
-					foundApproved = true
-					break
+		for (const [package, info] of Object.entries(licenses)) {
+			let exclude = false
+			for (const excludePackage of excludePackages) {
+				if (package.match(new RegExp(`^${excludePackage}@`))) {
+					exclude = true
 				}
 			}
-		}
-		if (!foundApproved) {
-			console.log(`Unapproved License: "${info.package}" in ${package}`)
-			ok = false
-		}
-	}
+			if (exclude) continue
 
-	if (ok) {
-		console.log('All is well :)')
-		process.exit(0)
-	} else {
+			let foundApproved = false
+			for (const license of info.package) {
+				for (const validLicense of validLicenses) {
+					if (license.match(validLicense)) {
+						foundApproved = true
+						break
+					}
+				}
+			}
+			if (!foundApproved) {
+				console.log(`Unapproved License: "${info.package}" in ${package}`)
+				ok = false
+			}
+		}
+
+		if (ok) {
+			console.log('All is well :)')
+			process.exit(0)
+		} else {
+			process.exit(100)
+		}
+	}).catch((e) => {
+		console.error(e)
 		process.exit(100)
-	}
-}).catch((e) => {
-	console.error(e)
-	process.exit(100)
-})
+	})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

During a take, the duration of the "previous" part is unstable, because `timings.duration` is set only once `stoppedPlayback` callback happens. As a result, the following "current" part, if a member of a display duration group will receive all of the "previous" part's `expectedDuration`, causing the part countdown to shift a bit.

* **What is the new behavior (if this is a feature change)?**

The `timings.takeOut` timestamp, which is being set by Core on user action is temporarily used as a duration. There still is a bit of a shift from the difference between `startedPlayback - takeOut` and `duration`, but it's not noticeable in the countdown.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
