### PR TITLE
Added button overview, and adjusted the R joystick

### DIFF
--- a/meteor/client/styles/prompter.scss
+++ b/meteor/client/styles/prompter.scss
@@ -136,6 +136,11 @@ body.prompter-scrollbar {
 		line-height: 1.2em;
 		margin-bottom: 0.5em;
 		overflow-wrap: break-word;
+		hyphens: auto;
+
+		.add-blank {
+			margin-bottom: 1.5em;
+		}
 	}
 
 	.overlay-fix {

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -49,6 +49,7 @@ interface PrompterConfig {
 	showScroll: boolean
 	debug: boolean
 	showOverUnder: boolean
+	addBlankLine: boolean
 }
 
 export enum PrompterConfigMode {
@@ -148,6 +149,7 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 			showScroll: queryParams['showscroll'] === undefined ? true : queryParams['showscroll'] === '1',
 			debug: queryParams['debug'] === undefined ? false : queryParams['debug'] === '1',
 			showOverUnder: queryParams['showoverunder'] === undefined ? true : queryParams['showoverunder'] === '1',
+			addBlankLine: queryParams['addblanklinke'] === undefined ? true : queryParams['adblankline'] === '1',
 		}
 
 		this._controller = new PrompterControlManager(this)
@@ -709,7 +711,11 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 						lines.push(
 							<div
 								key={'line_' + part.id + '_' + segment.id + '_' + line.id}
-								className={ClassNames('prompter-line', !line.text ? 'empty' : undefined)}>
+								className={ClassNames(
+									'prompter-line',
+									this.props.config.addBlankLine ? 'add-blank' : undefined,
+									!line.text ? 'empty' : undefined
+								)}>
 								{line.text || ''}
 							</div>
 						)

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -31,6 +31,7 @@ interface PrompterConfig {
 	followTake?: boolean
 	fontSize?: number
 	margin?: number
+	joycon_invertJoystick: boolean
 	joycon_speedMap?: number[]
 	joycon_reverseSpeedMap?: number[]
 	joycon_rangeRevMin?: number
@@ -116,6 +117,8 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 			followTake: queryParams['followtake'] === undefined ? true : queryParams['followtake'] === '1',
 			fontSize: parseInt(firstIfArray(queryParams['fontsize']) as string, 10) || undefined,
 			margin: parseInt(firstIfArray(queryParams['margin']) as string, 10) || undefined,
+			joycon_invertJoystick:
+				queryParams['joycon_invertJoystick'] === undefined ? true : queryParams['joycon_invertJoystick'] === '1',
 			joycon_speedMap:
 				queryParams['joycon_speedMap'] === undefined
 					? undefined

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -44,6 +44,7 @@ interface PrompterConfig {
 	pedal_rangeNeutralMin?: number
 	pedal_rangeNeutralMax?: number
 	pedal_rangeFwdMax?: number
+	shuttle_speedMap?: number[]
 	marker?: 'center' | 'top' | 'bottom' | 'hide'
 	showMarker: boolean
 	showScroll: boolean

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -31,13 +31,18 @@ interface PrompterConfig {
 	followTake?: boolean
 	fontSize?: number
 	margin?: number
-	speedMap?: number[]
-	reverseSpeedMap?: number[]
-	rangeRevMin?: number
-	rangeNeutralMin?: number
-	rangeNeutralMax?: number
-	rangeFwdMax?: number
-
+	joycon_speedMap?: number[]
+	joycon_reverseSpeedMap?: number[]
+	joycon_rangeRevMin?: number
+	joycon_rangeNeutralMin?: number
+	joycon_rangeNeutralMax?: number
+	joycon_rangeFwdMax?: number
+	pedal_speedMap?: number[]
+	pedal_reverseSpeedMap?: number[]
+	pedal_rangeRevMin?: number
+	pedal_rangeNeutralMin?: number
+	pedal_rangeNeutralMax?: number
+	pedal_rangeFwdMax?: number
 	marker?: 'center' | 'top' | 'bottom' | 'hide'
 	showMarker: boolean
 	showScroll: boolean
@@ -111,18 +116,30 @@ export class PrompterViewInner extends MeteorReactComponent<Translated<IProps & 
 			followTake: queryParams['followtake'] === undefined ? true : queryParams['followtake'] === '1',
 			fontSize: parseInt(firstIfArray(queryParams['fontsize']) as string, 10) || undefined,
 			margin: parseInt(firstIfArray(queryParams['margin']) as string, 10) || undefined,
-			speedMap:
-				queryParams['speedMap'] === undefined
+			joycon_speedMap:
+				queryParams['joycon_speedMap'] === undefined
 					? undefined
-					: new Array().concat(queryParams['speedMap']).map((value) => parseInt(value, 10)),
-			reverseSpeedMap:
-				queryParams['reverseSpeedMap'] === undefined
+					: new Array().concat(queryParams['joycon_speedMap']).map((value) => parseInt(value, 10)),
+			joycon_reverseSpeedMap:
+				queryParams['joycon_reverseSpeedMap'] === undefined
 					? undefined
-					: new Array().concat(queryParams['reverseSpeedMap']).map((value) => parseInt(value, 10)),
-			rangeRevMin: parseInt(firstIfArray(queryParams['rangeRevMin']) as string, 10) || undefined,
-			rangeNeutralMin: parseInt(firstIfArray(queryParams['rangeNeutralMin']) as string, 10) || undefined,
-			rangeNeutralMax: parseInt(firstIfArray(queryParams['rangeNeutralMax']) as string, 10) || undefined,
-			rangeFwdMax: parseInt(firstIfArray(queryParams['rangeFwdMax']) as string, 10) || undefined,
+					: new Array().concat(queryParams['joycon_reverseSpeedMap']).map((value) => parseInt(value, 10)),
+			joycon_rangeRevMin: parseInt(firstIfArray(queryParams['joycon_rangeRevMin']) as string, 10) || undefined,
+			joycon_rangeNeutralMin: parseInt(firstIfArray(queryParams['joycon_rangeNeutralMin']) as string, 10) || undefined,
+			joycon_rangeNeutralMax: parseInt(firstIfArray(queryParams['joycon_rangeNeutralMax']) as string, 10) || undefined,
+			joycon_rangeFwdMax: parseInt(firstIfArray(queryParams['joycon_rangeFwdMax']) as string, 10) || undefined,
+			pedal_speedMap:
+				queryParams['pedal_speedMap'] === undefined
+					? undefined
+					: new Array().concat(queryParams['pedal_speedMap']).map((value) => parseInt(value, 10)),
+			pedal_reverseSpeedMap:
+				queryParams['pedal_reverseSpeedMap'] === undefined
+					? undefined
+					: new Array().concat(queryParams['pedal_reverseSpeedMap']).map((value) => parseInt(value, 10)),
+			pedal_rangeRevMin: parseInt(firstIfArray(queryParams['pedal_rangeRevMin']) as string, 10) || undefined,
+			pedal_rangeNeutralMin: parseInt(firstIfArray(queryParams['pedal_rangeNeutralMin']) as string, 10) || undefined,
+			pedal_rangeNeutralMax: parseInt(firstIfArray(queryParams['pedal_rangeNeutralMax']) as string, 10) || undefined,
+			pedal_rangeFwdMax: parseInt(firstIfArray(queryParams['pedal_rangeFwdMax']) as string, 10) || undefined,
 			marker: (firstIfArray(queryParams['marker']) as any) || undefined,
 			showMarker: queryParams['showmarker'] === undefined ? true : queryParams['showmarker'] === '1',
 			showScroll: queryParams['showscroll'] === undefined ? true : queryParams['showscroll'] === '1',

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -99,6 +99,9 @@ export class JoyConController extends ControllerAbstract {
 	private onButtonRelease(button: string, mode?: JoyconMode | null) {}
 	private onButtonPressed(button: string, mode?: JoyconMode | null) {
 		if (mode === 'L') {
+			// Button overview JoyCon L single mode
+			// Arrows: Left = '0', Down = '1', Up = '2', Right = '3'
+			// Others: SL = '4', SR = '5', ZL = '6', L = '8', - = '9', Joystick = '10', Snapshot = '16'
 			switch (button) {
 				case '6':
 					// go to air
@@ -122,6 +125,9 @@ export class JoyConController extends ControllerAbstract {
 					break
 			}
 		} else if (mode === 'R') {
+			// Button overview JoyCon R single mode
+			// "Arrows": A = '0', X = '1', B = '2', Y = '3'
+			// Others: SL = '4', SR = '5', ZR = '7', R = '8', + = '9', Joystick = '10', Home = '16'
 			switch (button) {
 				case '7':
 					// go to air
@@ -145,6 +151,11 @@ export class JoyConController extends ControllerAbstract {
 					break
 			}
 		} else if (mode === 'LR') {
+			// Button overview JoyCon L+R paired mode
+			// L JoyCon Arrows: B = '0', A = '1', Y = '2', X = '3'
+			// L JoyCon Others: L = '4', ZL = '6', - = '8', Joystick = '10', Snapshot = '17', SL = '18', SR = '19'
+			// R JoyCon "Arrows": B = '0', A = '1', Y = '2', X = '3'
+			// R JoyCon Others: R = '5', ZR = '7', + = '9', Joystick = '11', Home = '16', SL = '20', SR = '21'
 			switch (button) {
 				case '6':
 				case '7':
@@ -242,7 +253,8 @@ export class JoyConController extends ControllerAbstract {
 				if (this.lastUsedJoyconMode === 'L') {
 					return input.axes[0] * -1 // in this mode, L is "negative"
 				} else if (this.lastUsedJoyconMode === 'R') {
-					return input.axes[0] // in this mode, R is "positive"
+					return input.axes[0] * 1.4 // in this mode, R is "positive"
+					// factor increased by 1.4 to account for the R joystick being less sensitive than L
 				}
 			}
 		} else if (this.lastUsedJoyconMode === 'LR') {
@@ -252,7 +264,8 @@ export class JoyConController extends ControllerAbstract {
 				return input.axes[1] * -1 // in this mode, we are "negative" on both sticks....
 			}
 			if (Math.abs(input.axes[3]) > this.deadBand) {
-				return input.axes[3] * -1 // in this mode, we are "negative" on both sticks....
+				return input.axes[3] * -1.4 // in this mode, we are "negative" on both sticks....
+				// factor increased by 1.4 to account for the R joystick being less sensitive than L
 			}
 		}
 

--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -35,12 +35,12 @@ export class JoyConController extends ControllerAbstract {
 		this.prompterView = view
 
 		// assigns params from URL or falls back to the default
-		this.speedMap = view.configOptions.speedMap || this.speedMap
-		this.reverseSpeedMap = view.configOptions.reverseSpeedMap || this.reverseSpeedMap
-		this.rangeRevMin = view.configOptions.rangeRevMin || this.rangeRevMin
-		this.rangeNeutralMin = view.configOptions.rangeNeutralMin || this.rangeNeutralMin
-		this.rangeNeutralMax = view.configOptions.rangeNeutralMax || this.rangeNeutralMax
-		this.rangeFwdMax = view.configOptions.rangeFwdMax || this.rangeFwdMax
+		this.speedMap = view.configOptions.joycon_speedMap || this.speedMap
+		this.reverseSpeedMap = view.configOptions.joycon_reverseSpeedMap || this.reverseSpeedMap
+		this.rangeRevMin = view.configOptions.joycon_rangeRevMin || this.rangeRevMin
+		this.rangeNeutralMin = view.configOptions.joycon_rangeNeutralMin || this.rangeNeutralMin
+		this.rangeNeutralMax = view.configOptions.joycon_rangeNeutralMax || this.rangeNeutralMax
+		this.rangeFwdMax = view.configOptions.joycon_rangeFwdMax || this.rangeFwdMax
 		this.deadBand = Math.min(Math.abs(this.rangeNeutralMin), Math.abs(this.rangeNeutralMax))
 
 		// validate range settings, they need to be in sequence, or the logic will break

--- a/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
+++ b/meteor/client/ui/Prompter/controller/midi-pedal-device.ts
@@ -32,12 +32,12 @@ export class MidiPedalController extends ControllerAbstract {
 		this.prompterView = view
 
 		// assigns params from URL or falls back to the default
-		this.speedMap = view.configOptions.speedMap || this.speedMap
-		this.reverseSpeedMap = view.configOptions.reverseSpeedMap || this.reverseSpeedMap
-		this.rangeRevMin = view.configOptions.rangeRevMin || this.rangeRevMin
-		this.rangeNeutralMin = view.configOptions.rangeNeutralMin || this.rangeNeutralMin
-		this.rangeNeutralMax = view.configOptions.rangeNeutralMax || this.rangeNeutralMax
-		this.rangeFwdMax = view.configOptions.rangeFwdMax || this.rangeFwdMax
+		this.speedMap = view.configOptions.pedal_speedMap || this.speedMap
+		this.reverseSpeedMap = view.configOptions.pedal_reverseSpeedMap || this.reverseSpeedMap
+		this.rangeRevMin = view.configOptions.pedal_rangeRevMin || this.rangeRevMin
+		this.rangeNeutralMin = view.configOptions.pedal_rangeNeutralMin || this.rangeNeutralMin
+		this.rangeNeutralMax = view.configOptions.pedal_rangeNeutralMax || this.rangeNeutralMax
+		this.rangeFwdMax = view.configOptions.pedal_rangeFwdMax || this.rangeFwdMax
 
 		// validate range settings, they need to be in sequence, or the logic will break
 		if (this.rangeNeutralMin <= this.rangeRevMin) {

--- a/meteor/client/ui/Prompter/controller/shuttle-keyboard-device.ts
+++ b/meteor/client/ui/Prompter/controller/shuttle-keyboard-device.ts
@@ -25,7 +25,7 @@ export class ShuttleKeyboardController extends ControllerAbstract {
 		super(view)
 
 		this.prompterView = view
-		this.speedMap = view.configOptions.speedMap || this.speedMap
+		this.speedMap = view.configOptions.shuttle_speedMap || this.speedMap
 		this.speedStepMap = ShuttleKeyboardController.makeSpeedStepMap(this.speedMap)
 	}
 	private static makeSpeedStepMap(speedMap): number[] {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Listing of button id's for L, R, and L+R mode for JoyCon.
Adjusted the R JoyCon to take into account that it is less sensitive than the L JoyCon.

* **What is the current behavior?** (You can also link to an open issue here)
The R JoyCon never reaches full speed ahead / reverse, which L JoyCon does.


* **What is the new behavior (if this is a feature change)?**
L and R are now more equal in response / sensitivity for the joystick.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
