### PR TITLE
feat: reset segments upon leaving

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -44,6 +44,9 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 	/** Rank of the take that this PartInstance belongs to */
 	takeCount: number
 
+	/** Whether this instance was created because of RundownPlaylist.nextSegmentId. This will cause it to clear that property as part of the take operation */
+	consumesNextSegmentId?: boolean
+
 	/** Temporarily track whether this PartInstance has been taken, so we can easily find and prune those which are only nexted */
 	isTaken?: boolean
 
@@ -81,6 +84,7 @@ export class PartInstance implements DBPartInstance {
 	/** Whether this instance has been finished with and reset (to restore the original part as the primary version) */
 	public reset?: boolean
 	public takeCount: number
+	public consumesNextSegmentId?: boolean
 	public previousPartEndState?: PartEndState
 
 	public timings?: PartInstanceTimings

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -484,7 +484,7 @@ export function handleUpdatedSegmentRanks(
 					},
 				})
 
-				if (changed === 0) {
+				if (changed.length === 0) {
 					logger.warn(`Failed to update rank of segment "${externalId}" (${rundownExternalId})`)
 				} else {
 					changedSegmentIds.push(segmentId)

--- a/meteor/server/api/playout/__tests__/api.test.ts
+++ b/meteor/server/api/playout/__tests__/api.test.ts
@@ -142,7 +142,9 @@ describe('Playout API', () => {
 		{
 			// Reset rundown:
 			Meteor.call(PlayoutAPI.methods.rundownResetRundown, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(1)
 			expect(instances[0].part._id).toEqual(parts[0]._id)
 			expect(getPlaylist0()).toMatchObject({
@@ -154,7 +156,9 @@ describe('Playout API', () => {
 		{
 			// Take the first Part:
 			Meteor.call(PlayoutAPI.methods.rundownTake, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(2)
 			expect(instances[0].part._id).toEqual(parts[0]._id)
 			expect(instances[1].part._id).toEqual(parts[1]._id)
@@ -167,7 +171,9 @@ describe('Playout API', () => {
 		{
 			// Take the second Part:
 			Meteor.call(PlayoutAPI.methods.rundownTake, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(3)
 			expect(instances[1].part._id).toEqual(parts[1]._id)
 			expect(instances[2].part._id).toEqual(parts[2]._id)
@@ -180,7 +186,9 @@ describe('Playout API', () => {
 		{
 			// Reset rundown:
 			Meteor.call(PlayoutAPI.methods.rundownResetRundown, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(1)
 			expect(instances[0].part._id).toEqual(parts[0]._id)
 			expect(getPlaylist0()).toMatchObject({
@@ -192,7 +200,9 @@ describe('Playout API', () => {
 		{
 			// Set Part as next:
 			Meteor.call(PlayoutAPI.methods.rundownSetNext, playlistId0, parts[parts.length - 2]._id)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(1)
 			expect(instances[0].part._id).toEqual(parts[parts.length - 2]._id)
 			expect(getPlaylist0()).toMatchObject({
@@ -204,7 +214,9 @@ describe('Playout API', () => {
 		{
 			// Take the Nexted Part:
 			Meteor.call(PlayoutAPI.methods.rundownTake, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(2)
 			expect(instances[0].part._id).toEqual(parts[parts.length - 2]._id)
 			expect(instances[1].part._id).toEqual(parts[parts.length - 1]._id)
@@ -217,7 +229,9 @@ describe('Playout API', () => {
 		{
 			// Take the last Part:
 			Meteor.call(PlayoutAPI.methods.rundownTake, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(2)
 			expect(instances[1].part._id).toEqual(parts[parts.length - 1]._id)
 			expect(getPlaylist0()).toMatchObject({
@@ -229,7 +243,9 @@ describe('Playout API', () => {
 		{
 			// Move the next-point backwards:
 			Meteor.call(PlayoutAPI.methods.rundownMoveNext, playlistId0, -1, 0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(3)
 			expect(instances[1].part._id).toEqual(parts[parts.length - 1]._id)
 			expect(instances[2].part._id).toEqual(parts[parts.length - 2]._id)
@@ -241,7 +257,9 @@ describe('Playout API', () => {
 		{
 			// Move the next-point backwards:
 			Meteor.call(PlayoutAPI.methods.rundownMoveNext, playlistId0, -1, 0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(3)
 			expect(instances[1].part._id).toEqual(parts[parts.length - 1]._id)
 			expect(instances[2].part._id).toEqual(parts[parts.length - 3]._id)
@@ -254,7 +272,9 @@ describe('Playout API', () => {
 		{
 			// Take the nexted Part:
 			Meteor.call(PlayoutAPI.methods.rundownTake, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
+			const activationId = getPlaylist0().activationId
+			expect(activationId).toBeTruthy()
+			const instances = PartInstances.find({ rundownId: rundownId0, playlistActivationId: activationId }).fetch()
 			expect(instances).toHaveLength(4)
 			expect(instances[2].part._id).toEqual(parts[parts.length - 3]._id)
 			expect(instances[3].part._id).toEqual(parts[parts.length - 2]._id)
@@ -267,8 +287,6 @@ describe('Playout API', () => {
 		{
 			// Deactivate rundown:
 			Meteor.call(PlayoutAPI.methods.rundownDeactivate, playlistId0)
-			const instances = PartInstances.find({ rundownId: rundownId0 }).fetch()
-			expect(instances).toHaveLength(3)
 			expect(getPlaylist0()).toMatchObject({
 				activationId: undefined,
 				currentPartInstanceId: null,

--- a/meteor/server/api/playout/__tests__/lib.test.ts
+++ b/meteor/server/api/playout/__tests__/lib.test.ts
@@ -1,10 +1,7 @@
-import { SegmentNote } from '../../../../lib/api/notes'
 import { PartInstance } from '../../../../lib/collections/PartInstances'
 import { Part } from '../../../../lib/collections/Parts'
-import { RundownId } from '../../../../lib/collections/Rundowns'
 import { DBSegment, SegmentId } from '../../../../lib/collections/Segments'
 import { protectString } from '../../../../lib/lib'
-import { defaultSegment } from '../../../../__mocks__/defaultCollectionObjects'
 import { PartsAndSegments, selectNextPart } from '../lib'
 
 class MockPart {
@@ -178,7 +175,7 @@ describe('selectNextPart', () => {
 			// no parts after
 			defaultParts = defaultParts.filter((p) => p.segmentId !== segment3)
 			const nextPart = selectNextPart(defaultPlaylist, previousPartInstance, getSegmentsAndParts())
-			expect(nextPart).toEqual(undefined)
+			expect(nextPart).toEqual(null)
 		}
 
 		{

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -33,7 +33,7 @@ export async function activateRundownPlaylist(cache: CacheForPlayout, rehearsal:
 		)
 	}
 
-	if (!!cache.Playlist.doc.activationId) {
+	if (!cache.Playlist.doc.activationId) {
 		// Reset the playlist if it wasnt already active
 		resetRundownPlaylist(cache)
 	}

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -6,7 +6,7 @@ import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { getCurrentTime, getRandomId, makePromise, waitForPromise } from '../../../lib/lib'
 import { loadShowStyleBlueprint } from '../blueprints/cache'
 import { RundownEventContext } from '../blueprints/context'
-import { setNextPart, onPartHasStoppedPlaying, selectNextPart, LOW_PRIO_DEFER_TIME } from './lib'
+import { setNextPart, onPartHasStoppedPlaying, selectNextPart, LOW_PRIO_DEFER_TIME, resetRundownPlaylist } from './lib'
 import { updateStudioTimeline, updateTimeline } from './timeline'
 import { IngestActions } from '../ingest/actions'
 import { getActiveRundownPlaylistsInStudioFromDb } from '../studio/lib'
@@ -31,6 +31,11 @@ export async function activateRundownPlaylist(cache: CacheForPlayout, rehearsal:
 			'Only one rundown can be active at the same time. Active rundown playlists: ' + otherActiveIds,
 			JSON.stringify(otherActiveIds)
 		)
+	}
+
+	if (!!cache.Playlist.doc.activationId) {
+		// Reset the playlist if it wasnt already active
+		resetRundownPlaylist(cache)
 	}
 
 	cache.Playlist.update({

--- a/meteor/server/api/playout/actions.ts
+++ b/meteor/server/api/playout/actions.ts
@@ -58,7 +58,7 @@ export async function activateRundownPlaylist(cache: CacheForPlayout, rehearsal:
 
 		// If we are not playing anything, then regenerate the next part
 		const firstPart = selectNextPart(cache.Playlist.doc, null, getOrderedSegmentsAndPartsFromPlayoutCache(cache))
-		setNextPart(cache, firstPart?.part ?? null)
+		setNextPart(cache, firstPart)
 	} else {
 		// Otherwise preserve the active partInstances
 		const partInstancesToPreserve = new Set(

--- a/meteor/server/api/playout/debug.ts
+++ b/meteor/server/api/playout/debug.ts
@@ -138,7 +138,7 @@ if (!Settings.enableUserAccounts) {
 						const part = nextPartInstance ? cache.Parts.findOne(nextPartInstance.part._id) : undefined
 						if (part) {
 							setNextPart(cache, null)
-							setNextPart(cache, part)
+							setNextPart(cache, { part: part })
 
 							updateTimeline(cache)
 						}

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -349,7 +349,7 @@ export namespace ServerPlayoutAPI {
 			if (!nextPart) throw new Meteor.Error(404, `Part "${nextPartId}" not found!`)
 		}
 
-		libsetNextPart(cache, nextPart, setManually, nextTimeOffset)
+		libsetNextPart(cache, nextPart ? { part: nextPart } : null, setManually, nextTimeOffset)
 
 		// update lookahead and the next part when we have an auto-next
 		updateTimeline(cache)
@@ -932,7 +932,7 @@ export namespace ServerPlayoutAPI {
 							playingPartInstance,
 							getOrderedSegmentsAndPartsFromPlayoutCache(cache)
 						)
-						libsetNextPart(cache, nextPart?.part ?? null)
+						libsetNextPart(cache, nextPart)
 					} else {
 						// a part is being played that has not been selected for playback by Core
 						// show must go on, so find next part and update the Rundown, but log an error
@@ -958,7 +958,7 @@ export namespace ServerPlayoutAPI {
 								playingPartInstance,
 								getOrderedSegmentsAndPartsFromPlayoutCache(cache)
 							)
-							libsetNextPart(cache, nextPart?.part ?? null)
+							libsetNextPart(cache, nextPart)
 						}
 
 						// TODO - should this even change the next?


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

PartInstances are only reset by an explicit reset operation for the whole playlist, or when the part is set as next. (Other rules apply for orphaned instances)

* **What is the new behavior (if this is a feature change)?**

When the segment has finished playback it is reset
When the next point is set earlier in the segment it will reset instances as appropriate to show what is planned

* **Other information**:

Additionally, the nextSegmentId has been tested a bit and fixed 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
