### PR TITLE
feat: change colors for live-speak, vt, graphics, lower-thirds

### DIFF
--- a/meteor/client/styles/_itemTypeColors.scss
+++ b/meteor/client/styles/_itemTypeColors.scss
@@ -3,14 +3,14 @@ $segment-timeline-background-color: #1f1f1f;
 $segment-layer-background-unknown: #4b4b4b;
 $segment-layer-background-camera: #18791c;
 $segment-layer-background-camera--second: darken($segment-layer-background-camera, 10%);
-$segment-layer-background-lower-third: #ff6f00;
+$segment-layer-background-lower-third: #ed7200;
 $segment-layer-background-lower-third--second: darken($segment-layer-background-lower-third, 10%);
-$segment-layer-background-graphics: #ef6800;
+$segment-layer-background-graphics: #dc5c00;
 $segment-layer-background-graphics--second: darken($segment-layer-background-graphics, 10%);
-$segment-layer-background-live-speak: #1e6820;
+$segment-layer-background-live-speak: #0085ff;
 $segment-layer-background-remote: #e80064;
 $segment-layer-background-remote--second: darken($segment-layer-background-remote, 10%);
-$segment-layer-background-vt: #1769ff;
+$segment-layer-background-vt: #0a20ed;
 $segment-layer-background-vt--second: darken($segment-layer-background-vt, 10%);
 $segment-layer-background-local: #8d1010;
 $segment-layer-background-local--second: darken($segment-layer-background-local, 10%);
@@ -77,9 +77,20 @@ $segment-layer-background-guest: #008a92;
 
 	&.live-speak {
 		#{$selectors} {
-			text-shadow: 1px -1px 1px var(--segment-layer-background-vt), -1px 1px 1px var(--segment-layer-background-vt),
-				-1px -1px 1px var(--segment-layer-background-vt), 1px 1px 1px var(--segment-layer-background-vt),
+			text-shadow: 1px -1px 1px var(--segment-layer-background-live-speak),
+				-1px 1px 1px var(--segment-layer-background-live-speak),
+				-1px -1px 1px var(--segment-layer-background-live-speak), 1px 1px 1px var(--segment-layer-background-live-speak),
 				1px 1px 3px rgba(0, 0, 0, 1), 1px 1px 8px rgba(0, 0, 0, 1);
+		}
+
+		&.second {
+			#{$selectors} {
+				text-shadow: 1px -1px 1px var(--segment-layer-background-live-speak--second),
+					-1px 1px 1px var(--segment-layer-background-live-speak--second),
+					-1px -1px 1px var(--segment-layer-background-live-speak--second),
+					1px 1px 1px var(--segment-layer-background-live-speak--second), 1px 1px 3px rgba(0, 0, 0, 1),
+					1px 1px 8px rgba(0, 0, 0, 1);
+			}
 		}
 	}
 
@@ -180,11 +191,11 @@ $segment-layer-background-guest: #008a92;
 	}
 
 	&.live-speak {
-		background: linear-gradient(
-			to bottom,
-			var(--segment-layer-background-vt) 50%,
-			var(--segment-layer-background-live-speak) 50.0001%
-		);
+		background: var(--segment-layer-background-live-speak);
+
+		&.second {
+			background: var(--segment-layer-background-live-speak--second);
+		}
 	}
 
 	&.vt {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a feature

* **What is the current behavior?** (You can also link to an open issue here)

Full screen Graphics and Lower Thirds are indistinguishable. LIVE_SPEAK items have a split background, that is similar to actual splits.

* **What is the new behavior (if this is a feature change)?**

![obraz](https://user-images.githubusercontent.com/3635991/110475432-2dd71780-80e1-11eb-8796-7374c5e611cc.png)

Full screen graphics use a darker shade of orange. LIVE_SPEAK items have a bright-blue background.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
