### PR TITLE
fix(Presenter screen): BTS countdown on presenter screen

### DIFF
--- a/meteor/client/styles/countdown/overlay.scss
+++ b/meteor/client/styles/countdown/overlay.scss
@@ -138,6 +138,7 @@ body.transparent {
 	.clocks-rundown-total {
 		color: #f8e71c;
 		font-weight: bold;
+		white-space: nowrap;
 
 		&.over {
 			color: $general-late-color;

--- a/meteor/client/styles/countdown/presenter.scss
+++ b/meteor/client/styles/countdown/presenter.scss
@@ -129,6 +129,7 @@
 		color: #f8e71c;
 		font-weight: bold;
 		margin-top: -2vh;
+		white-space: nowrap;
 
 		&.over {
 			color: $general-late-color;

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -142,7 +142,8 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
 		const partInstance = currentPartInstance || nextPartInstance
 		if (partInstance) {
-			const infinitesEndingPieces = PieceInstances.find({
+			// This is to register a reactive dependency on Rundown-spanning PieceInstances, that we may miss otherwise.
+			PieceInstances.find({
 				rundownId: {
 					$in: rundownIds,
 				},

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -262,12 +262,12 @@ const TimingDisplay = withTranslation()(
 								<span className="timing-clock-label left">{t('Started')}</span>
 								<Moment interval={0} format="HH:mm:ss" date={rundownPlaylist.startedPlayback} />
 							</span>
-						) : (
+						) : rundownPlaylist.expectedStart ? (
 							<span className="timing-clock plan-start left">
 								<span className="timing-clock-label left">{t('Planned Start')}</span>
 								<Moment interval={0} format="HH:mm:ss" date={rundownPlaylist.expectedStart} />
 							</span>
-						)}
+						) : null}
 						{rundownPlaylist.startedPlayback && rundownPlaylist.activationId && !rundownPlaylist.rehearsal ? (
 							rundownPlaylist.expectedStart ? (
 								<span className="timing-clock countdown playback-started left">
@@ -373,7 +373,7 @@ const TimingDisplay = withTranslation()(
 										<Moment
 											interval={0}
 											format="HH:mm:ss"
-											date={getCurrentTime() + (this.props.timingDurations.totalRundownDuration || 0)}
+											date={getCurrentTime() + (this.props.timingDurations.remainingRundownDuration || 0)}
 										/>
 									</span>
 								) : null}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

The countdown for ad-lib parts is not shown on the presenters' screen. When an ad-lib part (such as a BTS) is played, the display is blank.

* **What is the new behavior (if this is a feature change)?**

Ad-Lib parts (PartInstances without a backing Part) are displayed in the same way as other Parts.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
