### PR TITLE
feat: split security check out of lock functions

### DIFF
--- a/meteor/lib/api/playout.ts
+++ b/meteor/lib/api/playout.ts
@@ -1,89 +1,11 @@
-import { RundownPlaylistId } from '../collections/RundownPlaylists'
-import { PartInstanceId } from '../collections/PartInstances'
-import { PieceInstanceId } from '../collections/PieceInstances'
-import { PieceId } from '../collections/Pieces'
-import { PartId } from '../collections/Parts'
 import { StudioId } from '../collections/Studios'
-import { ClientAPI } from './client'
-import { ReloadRundownPlaylistResponse } from './userActions'
-import { SegmentId } from '../collections/Segments'
 
 export interface NewPlayoutAPI {
-	// rundownPrepareForBroadcast(playlistId: RundownPlaylistId): Promise<void>
-	// rundownResetRundown(playlistId: RundownPlaylistId): Promise<void>
-	// rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean): Promise<void>
-	// rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean): Promise<void>
-	// rundownDeactivate(playlistId: RundownPlaylistId): Promise<void>
-	// pieceTakeNow(
-	// 	playlistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
-	// ): Promise<void>
-	// rundownTake(playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
-	// rundownSetNext(
-	// 	playlistId: RundownPlaylistId,
-	// 	partId: PartId,
-	// 	timeOffset?: number | undefined
-	// ): Promise<ClientAPI.ClientResponse<void>>
-	// rundownSetNextSegment(
-	// 	playlistId: RundownPlaylistId,
-	// 	segmentId: SegmentId | null
-	// ): Promise<ClientAPI.ClientResponse<void>>
-	// rundownMoveNext(
-	// 	playlistId: RundownPlaylistId,
-	// 	horisontalDelta: number,
-	// 	verticalDelta: number
-	// ): Promise<PartId | null>
-	// rundownActivateHold(playlistId: RundownPlaylistId): Promise<void>
-	// rundownDisableNextPiece(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	undo?: boolean
-	// ): Promise<ClientAPI.ClientResponse<void>>
-	// segmentAdLibPieceStart(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceId: PieceId,
-	// 	queue: boolean
-	// ): Promise<void>
-	// rundownBaselineAdLibPieceStart(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceId: PieceId,
-	// 	queue: boolean
-	// ): Promise<void>
-	// sourceLayerOnPartStop(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	sourceLayerIds: string[]
-	// ): Promise<void>
-	// sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string): Promise<void>
 	updateStudioBaseline(studioId: StudioId): Promise<string | false>
 	shouldUpdateStudioBaseline(studioId: StudioId): Promise<string | false>
-	// switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean): Promise<ClientAPI.ClientResponse<void>>
 }
 
 export enum PlayoutAPIMethods {
-	// 'rundownPrepareForBroadcast' = 'playout.rundownPrepareForBroadcast',
-	// 'rundownResetRundown' = 'playout.rundownResetRundownt',
-	// 'rundownResetAndActivate' = 'playout.rundownResetAndActivate',
-	// 'rundownActivate' = 'playout.rundownActivate',
-	// 'rundownDeactivate' = 'playout.rundownDeactivate',
-
 	'updateStudioBaseline' = 'playout.updateStudioBaseline',
 	'shouldUpdateStudioBaseline' = 'playout.shouldUpdateStudioBaseline',
-
-	// 'rundownTake' = 'playout.rundownTake',
-	// 'rundownSetNext' = 'playout.rundownSetNext',
-	// 'rundownSetNextSegment' = 'playout.rundownSetNextSegment',
-	// 'rundownMoveNext' = 'playout.rundownMoveNext',
-	// 'rundownActivateHold' = 'playout.rundownActivateHold',
-	// 'rundownDisableNextPiece' = 'playout.rundownDisableNextPiece',
-
-	// 'pieceTakeNow' = 'playout.pieceTakeNow',
-	// 'segmentAdLibPieceStart' = 'playout.segmentAdLibPieceStart',
-	// 'rundownBaselineAdLibPieceStart' = 'playout.rundownBaselineAdLibPieceStart',
-	// 'sourceLayerOnPartStop' = 'playout.sourceLayerOnPartStop',
-	// 'sourceLayerStickyPieceStart' = 'playout.sourceLayerStickyPieceStart',
-
-	// 'switchRouteSet' = 'playout.switchRouteSet',
 }

--- a/meteor/lib/api/playout.ts
+++ b/meteor/lib/api/playout.ts
@@ -9,81 +9,81 @@ import { ReloadRundownPlaylistResponse } from './userActions'
 import { SegmentId } from '../collections/Segments'
 
 export interface NewPlayoutAPI {
-	rundownPrepareForBroadcast(playlistId: RundownPlaylistId): Promise<void>
-	rundownResetRundown(playlistId: RundownPlaylistId): Promise<void>
-	rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean): Promise<void>
-	rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean): Promise<void>
-	rundownDeactivate(playlistId: RundownPlaylistId): Promise<void>
-	pieceTakeNow(
-		playlistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
-	): Promise<void>
-	rundownTake(playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
-	rundownSetNext(
-		playlistId: RundownPlaylistId,
-		partId: PartId,
-		timeOffset?: number | undefined
-	): Promise<ClientAPI.ClientResponse<void>>
-	rundownSetNextSegment(
-		playlistId: RundownPlaylistId,
-		segmentId: SegmentId | null
-	): Promise<ClientAPI.ClientResponse<void>>
-	rundownMoveNext(
-		playlistId: RundownPlaylistId,
-		horisontalDelta: number,
-		verticalDelta: number
-	): Promise<PartId | null>
-	rundownActivateHold(playlistId: RundownPlaylistId): Promise<void>
-	rundownDisableNextPiece(
-		rundownPlaylistId: RundownPlaylistId,
-		undo?: boolean
-	): Promise<ClientAPI.ClientResponse<void>>
-	segmentAdLibPieceStart(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceId: PieceId,
-		queue: boolean
-	): Promise<void>
-	rundownBaselineAdLibPieceStart(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceId: PieceId,
-		queue: boolean
-	): Promise<void>
-	sourceLayerOnPartStop(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		sourceLayerIds: string[]
-	): Promise<void>
-	sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string): Promise<void>
+	// rundownPrepareForBroadcast(playlistId: RundownPlaylistId): Promise<void>
+	// rundownResetRundown(playlistId: RundownPlaylistId): Promise<void>
+	// rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean): Promise<void>
+	// rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean): Promise<void>
+	// rundownDeactivate(playlistId: RundownPlaylistId): Promise<void>
+	// pieceTakeNow(
+	// 	playlistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
+	// ): Promise<void>
+	// rundownTake(playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
+	// rundownSetNext(
+	// 	playlistId: RundownPlaylistId,
+	// 	partId: PartId,
+	// 	timeOffset?: number | undefined
+	// ): Promise<ClientAPI.ClientResponse<void>>
+	// rundownSetNextSegment(
+	// 	playlistId: RundownPlaylistId,
+	// 	segmentId: SegmentId | null
+	// ): Promise<ClientAPI.ClientResponse<void>>
+	// rundownMoveNext(
+	// 	playlistId: RundownPlaylistId,
+	// 	horisontalDelta: number,
+	// 	verticalDelta: number
+	// ): Promise<PartId | null>
+	// rundownActivateHold(playlistId: RundownPlaylistId): Promise<void>
+	// rundownDisableNextPiece(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	undo?: boolean
+	// ): Promise<ClientAPI.ClientResponse<void>>
+	// segmentAdLibPieceStart(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceId: PieceId,
+	// 	queue: boolean
+	// ): Promise<void>
+	// rundownBaselineAdLibPieceStart(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceId: PieceId,
+	// 	queue: boolean
+	// ): Promise<void>
+	// sourceLayerOnPartStop(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	sourceLayerIds: string[]
+	// ): Promise<void>
+	// sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string): Promise<void>
 	updateStudioBaseline(studioId: StudioId): Promise<string | false>
 	shouldUpdateStudioBaseline(studioId: StudioId): Promise<string | false>
-	switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean): Promise<ClientAPI.ClientResponse<void>>
+	// switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean): Promise<ClientAPI.ClientResponse<void>>
 }
 
 export enum PlayoutAPIMethods {
-	'rundownPrepareForBroadcast' = 'playout.rundownPrepareForBroadcast',
-	'rundownResetRundown' = 'playout.rundownResetRundownt',
-	'rundownResetAndActivate' = 'playout.rundownResetAndActivate',
-	'rundownActivate' = 'playout.rundownActivate',
-	'rundownDeactivate' = 'playout.rundownDeactivate',
+	// 'rundownPrepareForBroadcast' = 'playout.rundownPrepareForBroadcast',
+	// 'rundownResetRundown' = 'playout.rundownResetRundownt',
+	// 'rundownResetAndActivate' = 'playout.rundownResetAndActivate',
+	// 'rundownActivate' = 'playout.rundownActivate',
+	// 'rundownDeactivate' = 'playout.rundownDeactivate',
 
 	'updateStudioBaseline' = 'playout.updateStudioBaseline',
 	'shouldUpdateStudioBaseline' = 'playout.shouldUpdateStudioBaseline',
 
-	'rundownTake' = 'playout.rundownTake',
-	'rundownSetNext' = 'playout.rundownSetNext',
-	'rundownSetNextSegment' = 'playout.rundownSetNextSegment',
-	'rundownMoveNext' = 'playout.rundownMoveNext',
-	'rundownActivateHold' = 'playout.rundownActivateHold',
-	'rundownDisableNextPiece' = 'playout.rundownDisableNextPiece',
+	// 'rundownTake' = 'playout.rundownTake',
+	// 'rundownSetNext' = 'playout.rundownSetNext',
+	// 'rundownSetNextSegment' = 'playout.rundownSetNextSegment',
+	// 'rundownMoveNext' = 'playout.rundownMoveNext',
+	// 'rundownActivateHold' = 'playout.rundownActivateHold',
+	// 'rundownDisableNextPiece' = 'playout.rundownDisableNextPiece',
 
-	'pieceTakeNow' = 'playout.pieceTakeNow',
-	'segmentAdLibPieceStart' = 'playout.segmentAdLibPieceStart',
-	'rundownBaselineAdLibPieceStart' = 'playout.rundownBaselineAdLibPieceStart',
-	'sourceLayerOnPartStop' = 'playout.sourceLayerOnPartStop',
-	'sourceLayerStickyPieceStart' = 'playout.sourceLayerStickyPieceStart',
+	// 'pieceTakeNow' = 'playout.pieceTakeNow',
+	// 'segmentAdLibPieceStart' = 'playout.segmentAdLibPieceStart',
+	// 'rundownBaselineAdLibPieceStart' = 'playout.rundownBaselineAdLibPieceStart',
+	// 'sourceLayerOnPartStop' = 'playout.sourceLayerOnPartStop',
+	// 'sourceLayerStickyPieceStart' = 'playout.sourceLayerStickyPieceStart',
 
-	'switchRouteSet' = 'playout.switchRouteSet',
+	// 'switchRouteSet' = 'playout.switchRouteSet',
 }

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -2,20 +2,20 @@ import { Meteor } from 'meteor/meteor'
 import { Random } from 'meteor/random'
 
 import { PeripheralDevice, PeripheralDevices } from '../../../lib/collections/PeripheralDevices'
-import { PeripheralDeviceCommand, PeripheralDeviceCommands } from '../../../lib/collections/PeripheralDeviceCommands'
-import { Rundown, Rundowns, RundownId } from '../../../lib/collections/Rundowns'
-import { Segment, Segments, SegmentId } from '../../../lib/collections/Segments'
-import { Part, Parts } from '../../../lib/collections/Parts'
-import { Piece, Pieces } from '../../../lib/collections/Pieces'
+import { PeripheralDeviceCommands } from '../../../lib/collections/PeripheralDeviceCommands'
+import { Rundowns, RundownId } from '../../../lib/collections/Rundowns'
+import { Segments, SegmentId } from '../../../lib/collections/Segments'
+import { Parts } from '../../../lib/collections/Parts'
+import { Pieces } from '../../../lib/collections/Pieces'
 
 import { PeripheralDeviceAPI, PeripheralDeviceAPIMethods } from '../../../lib/api/peripheralDevice'
 
-import { getCurrentTime, literal, protectString, unprotectString, ProtectedString, waitTime } from '../../../lib/lib'
+import { getCurrentTime, literal, protectString, ProtectedString, waitTime } from '../../../lib/lib'
 import * as MOS from 'mos-connection'
-import { testInFiber, testInFiberOnly } from '../../../__mocks__/helpers/jest'
+import { testInFiber } from '../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment, DefaultEnvironment } from '../../../__mocks__/helpers/database'
 import { setLoggerLevel } from '../../../server/api/logger'
-import { RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylists, RundownPlaylistId, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import {
 	IngestDeviceSettings,
 	IngestDeviceSecretSettings,
@@ -32,27 +32,17 @@ import { MediaWorkFlows } from '../../../lib/collections/MediaWorkFlows'
 import { MediaWorkFlowSteps } from '../../../lib/collections/MediaWorkFlowSteps'
 import { MediaManagerAPI } from '../../../lib/api/mediaManager'
 import { MediaObjects } from '../../../lib/collections/MediaObjects'
-import { PeripheralDevicesAPI } from '../../../client/lib/clientAPI'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
-import { MethodContext } from '../../../lib/api/methods'
-import { time } from 'console'
+import { VerifiedRundownPlaylistContentAccess } from '../lib'
 
 const DEBUG = false
 
 const ActualServerPlayoutAPI: typeof ServerPlayoutAPI = _ActualServerPlayoutAPI
 
-const DEFAULT_CONTEXT: MethodContext = {
-	userId: null,
-	isSimulation: false,
-	connection: {
-		id: 'mockConnectionId',
-		close: () => {},
-		onClose: () => {},
-		clientAddress: '127.0.0.1',
-		httpHeaders: {},
-	},
-	setUserId: () => {},
-	unblock: () => {},
+function DEFAULT_ACCESS(rundownPlaylistID: RundownPlaylistId): VerifiedRundownPlaylistContentAccess {
+	const playlist = RundownPlaylists.findOne(rundownPlaylistID) as RundownPlaylist
+	expect(playlist).toBeTruthy()
+	return { userId: null, organizationId: null, studioId: null, playlist: playlist, cred: {} }
 }
 
 describe('test peripheralDevice general API methods', () => {
@@ -291,8 +281,8 @@ describe('test peripheralDevice general API methods', () => {
 	})
 
 	testInFiber('partPlaybackStarted', () => {
-		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID, false)
-		ActualServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, false)
+		ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 
 		if (DEBUG) setLoggerLevel('debug')
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -307,12 +297,12 @@ describe('test peripheralDevice general API methods', () => {
 
 		expect(ServerPlayoutAPI.onPartPlaybackStarted).toHaveBeenCalled()
 
-		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 	})
 
 	testInFiber('partPlaybackStopped', () => {
-		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID, false)
-		ActualServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, false)
+		ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 
 		if (DEBUG) setLoggerLevel('debug')
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -328,12 +318,12 @@ describe('test peripheralDevice general API methods', () => {
 
 		expect(ServerPlayoutAPI.onPartPlaybackStopped).toHaveBeenCalled()
 
-		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 	})
 
 	testInFiber('piecePlaybackStarted', () => {
-		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID, false)
-		ActualServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, false)
+		ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 
 		if (DEBUG) setLoggerLevel('debug')
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -357,12 +347,12 @@ describe('test peripheralDevice general API methods', () => {
 
 		expect(ServerPlayoutAPI.onPiecePlaybackStarted).toHaveBeenCalled()
 
-		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 	})
 
 	testInFiber('piecePlaybackStopped', () => {
-		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID, false)
-		ActualServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, false)
+		ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 
 		if (DEBUG) setLoggerLevel('debug')
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -386,12 +376,12 @@ describe('test peripheralDevice general API methods', () => {
 
 		expect(ServerPlayoutAPI.onPiecePlaybackStopped).toHaveBeenCalled()
 
-		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 	})
 
 	testInFiber('timelineTriggerTime', () => {
-		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID, false)
-		ActualServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, false)
+		ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 
 		if (DEBUG) setLoggerLevel('debug')
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -428,7 +418,7 @@ describe('test peripheralDevice general API methods', () => {
 			expect(enable.start).toBeGreaterThan(0)
 		})
 
-		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, rundownPlaylistID)
+		ActualServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
 	})
 
 	testInFiber('killProcess with a rundown present', () => {

--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -9,13 +9,13 @@ import { Part, Parts } from '../../../../lib/collections/Parts'
 import { IngestRundown, IngestSegment, IngestPart } from '@sofie-automation/blueprints-integration'
 import { ServerRundownAPI } from '../../rundown'
 import { ServerPlayoutAPI } from '../../playout/playout'
-import { regenerateRundown, RundownInput } from '../rundownInput'
-import { RundownPlaylists, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
+import { RundownInput } from '../rundownInput'
+import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../../lib/collections/RundownPlaylists'
 import { PartInstances } from '../../../../lib/collections/PartInstances'
 import { MethodContext } from '../../../../lib/api/methods'
-import { Studio, Studios } from '../../../../lib/collections/Studios'
 import { removeRundownPlaylistFromDb } from '../../rundownPlaylist'
 import { Random } from 'meteor/random'
+import { VerifiedRundownPlaylistContentAccess } from '../../lib'
 
 require('../../peripheralDevice.ts') // include in order to create the Meteor methods needed
 
@@ -31,6 +31,12 @@ const DEFAULT_CONTEXT: MethodContext = {
 	},
 	setUserId: () => {},
 	unblock: () => {},
+}
+
+function PLAYLIST_ACCESS(rundownPlaylistID: RundownPlaylistId): VerifiedRundownPlaylistContentAccess {
+	const playlist = RundownPlaylists.findOne(rundownPlaylistID) as RundownPlaylist
+	expect(playlist).toBeTruthy()
+	return { userId: null, organizationId: null, studioId: null, playlist: playlist, cred: {} }
 }
 
 describe('Test ingest actions for rundowns and segments', () => {
@@ -1349,7 +1355,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 		expect(parts).toHaveLength(3)
 
 		// Activate the rundown, make data updates and verify that it gets unsynced properly
-		ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlist._id, true)
+		ServerPlayoutAPI.activateRundownPlaylist(PLAYLIST_ACCESS(playlist._id), playlist._id, true)
 		expect(getRundown().orphaned).toBeUndefined()
 
 		RundownInput.dataRundownDelete(DEFAULT_CONTEXT, device2._id, device2.token, rundownData.externalId)
@@ -1358,7 +1364,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 		resyncRundown()
 		expect(getRundown().orphaned).toBeUndefined()
 
-		ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlist._id)
+		ServerPlayoutAPI.takeNextPart(PLAYLIST_ACCESS(playlist._id), playlist._id)
 		const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
 		expect(partInstance).toHaveLength(1)
 		expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)

--- a/meteor/server/api/ingest/actions.ts
+++ b/meteor/server/api/ingest/actions.ts
@@ -18,8 +18,8 @@ import {
 	runPlayoutOperationWithCacheFromStudioOperation,
 	PlayoutLockFunctionPriority,
 } from '../playout/lockFunction'
-import { MethodContext } from '../../../lib/api/methods'
 import { removeRundownsFromDb } from '../rundownPlaylist'
+import { VerifiedRundownPlaylistContentAccess } from '../lib'
 
 /*
 This file contains actions that can be performed on an ingest-device (MOS-device)
@@ -105,14 +105,14 @@ export namespace IngestActions {
 	 * Run the cached data through blueprints in order to re-generate the Rundown
 	 */
 	export function regenerateRundownPlaylist(
-		context: MethodContext | null,
+		access: VerifiedRundownPlaylistContentAccess | null,
 		rundownPlaylistId: RundownPlaylistId,
 		purgeExisting?: boolean
 	) {
 		check(rundownPlaylistId, String)
 
 		const ingestData = runPlayoutOperationWithLock(
-			context,
+			access,
 			'regenerateRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.MISC,

--- a/meteor/server/api/lib.ts
+++ b/meteor/server/api/lib.ts
@@ -4,6 +4,11 @@ import { RundownPlaylistId, RundownPlaylist } from '../../lib/collections/Rundow
 import { Rundown, RundownId } from '../../lib/collections/Rundowns'
 import { RundownPlaylistContentAccess, RundownPlaylistContentWriteAccess } from '../security/rundownPlaylist'
 
+/**
+ * This is returned from a check of access to a playlist, when access is granted.
+ * Fields will be populated about the user.
+ * It is identical to RundownPlaylistContentAccess, except for confirming access is allowed
+ */
 export interface VerifiedRundownPlaylistContentAccess extends RundownPlaylistContentAccess {
 	playlist: RundownPlaylist
 }

--- a/meteor/server/api/lib.ts
+++ b/meteor/server/api/lib.ts
@@ -2,7 +2,24 @@ import { Meteor } from 'meteor/meteor'
 import { MethodContext } from '../../lib/api/methods'
 import { RundownPlaylistId, RundownPlaylist } from '../../lib/collections/RundownPlaylists'
 import { Rundown, RundownId } from '../../lib/collections/Rundowns'
-import { RundownPlaylistContentWriteAccess } from '../security/rundownPlaylist'
+import { RundownPlaylistContentAccess, RundownPlaylistContentWriteAccess } from '../security/rundownPlaylist'
+
+export interface VerifiedRundownPlaylistContentAccess extends RundownPlaylistContentAccess {
+	playlist: RundownPlaylist
+}
+
+export function checkAccessToPlaylist(
+	context: MethodContext,
+	playlistId: RundownPlaylistId
+): VerifiedRundownPlaylistContentAccess {
+	const access = RundownPlaylistContentWriteAccess.playout(context, playlistId)
+	const playlist = access.playlist
+	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${playlistId}" not found!`)
+	return {
+		...access,
+		playlist,
+	}
+}
 
 export function checkAccessAndGetPlaylist(context: MethodContext, playlistId: RundownPlaylistId): RundownPlaylist {
 	const access = RundownPlaylistContentWriteAccess.playout(context, playlistId)

--- a/meteor/server/api/playout/__tests__/timeline.test.ts
+++ b/meteor/server/api/playout/__tests__/timeline.test.ts
@@ -12,23 +12,15 @@ import '../api'
 import { Timeline } from '../../../../lib/collections/Timeline'
 import { ServerPlayoutAPI } from '../playout'
 import { updateTimeline } from '../timeline'
-import { RundownPlaylists, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
-import { MethodContext } from '../../../../lib/api/methods'
+import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../../lib/collections/RundownPlaylists'
 import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
 import { PlayoutLockFunctionPriority, runPlayoutOperationWithCache } from '../lockFunction'
+import { VerifiedRundownPlaylistContentAccess } from '../../lib'
 
-const DEFAULT_CONTEXT: MethodContext = {
-	userId: null,
-	isSimulation: false,
-	connection: {
-		id: 'mockConnectionId',
-		close: () => {},
-		onClose: () => {},
-		clientAddress: '127.0.0.1',
-		httpHeaders: {},
-	},
-	setUserId: () => {},
-	unblock: () => {},
+function DEFAULT_ACCESS(rundownPlaylistID: RundownPlaylistId): VerifiedRundownPlaylistContentAccess {
+	const playlist = RundownPlaylists.findOne(rundownPlaylistID) as RundownPlaylist
+	expect(playlist).toBeTruthy()
+	return { userId: null, organizationId: null, studioId: null, playlist: playlist, cred: {} }
 }
 
 describe('Timeline', () => {
@@ -67,7 +59,7 @@ describe('Timeline', () => {
 
 		{
 			// Prepare and activate in rehersal:
-			ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_CONTEXT, playlistId0, false)
+			ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(playlistId0), playlistId0, false)
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeFalsy()
 			expect(nextPartInstance).toBeTruthy()
@@ -82,7 +74,7 @@ describe('Timeline', () => {
 
 		{
 			// Take the first Part:
-			ServerPlayoutAPI.takeNextPart(DEFAULT_CONTEXT, playlistId0)
+			ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId0), playlistId0)
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
@@ -123,7 +115,7 @@ describe('Timeline', () => {
 
 		{
 			// Deactivate rundown:
-			ServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_CONTEXT, playlistId0)
+			ServerPlayoutAPI.deactivateRundownPlaylist(DEFAULT_ACCESS(playlistId0), playlistId0)
 			expect(getPlaylist0()).toMatchObject({
 				activationId: undefined,
 				currentPartInstanceId: null,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -43,7 +43,6 @@ import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { profiler } from '../profiler'
 import { getPieceInstancesForPart } from './infinites'
 import { PlayoutLockFunctionPriority, runPlayoutOperationWithCache } from './lockFunction'
-import { MethodContext } from '../../../lib/api/methods'
 import {
 	CacheForPlayout,
 	getOrderedSegmentsAndPartsFromPlayoutCache,
@@ -52,16 +51,17 @@ import {
 } from './cache'
 import { ReadonlyDeep } from 'type-fest'
 import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBaselineAdLibPieces'
+import { VerifiedRundownPlaylistContentAccess } from '../lib'
 
 export namespace ServerPlayoutAdLibAPI {
 	export function pieceTakeNow(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
 	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'pieceTakeNow',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -170,14 +170,14 @@ export namespace ServerPlayoutAdLibAPI {
 		)
 	}
 	export function segmentAdLibPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		adLibPieceId: PieceId,
 		queue: boolean
 	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'segmentAdLibPieceStart',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -213,14 +213,14 @@ export namespace ServerPlayoutAdLibAPI {
 		)
 	}
 	export function rundownBaselineAdLibPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		baselineAdLibPieceId: PieceId,
 		queue: boolean
 	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'rundownBaselineAdLibPieceStart',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -318,12 +318,12 @@ export namespace ServerPlayoutAdLibAPI {
 	}
 
 	export function sourceLayerStickyPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		sourceLayerId: string
 	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'sourceLayerStickyPieceStart',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -595,7 +595,7 @@ export namespace ServerPlayoutAdLibAPI {
 		return stoppedInstances
 	}
 	export function startBucketAdlibPiece(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		bucketAdlibId: PieceId,
@@ -605,7 +605,7 @@ export namespace ServerPlayoutAdLibAPI {
 		if (!bucketAdlib) throw new Meteor.Error(404, `Bucket Adlib "${bucketAdlibId}" not found!`)
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'startBucketAdlibPiece',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,

--- a/meteor/server/api/playout/api.ts
+++ b/meteor/server/api/playout/api.ts
@@ -4,101 +4,17 @@ import { NewPlayoutAPI, PlayoutAPIMethods } from '../../../lib/api/playout'
 import { ServerPlayoutAPI } from './playout'
 import { getCurrentTime, makePromise } from '../../../lib/lib'
 import { logger } from '../../logging'
-import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
-import { PartInstanceId } from '../../../lib/collections/PartInstances'
-import { PartId } from '../../../lib/collections/Parts'
-import { PieceId } from '../../../lib/collections/Pieces'
 import { StudioId } from '../../../lib/collections/Studios'
-import { PieceInstanceId } from '../../../lib/collections/PieceInstances'
-import { ClientAPI } from '../../../lib/api/client'
 import { MethodContextAPI } from '../../../lib/api/methods'
 import { Settings } from '../../../lib/Settings'
-import { SegmentId } from '../../../lib/collections/Segments'
 
 class ServerPlayoutAPIClass extends MethodContextAPI implements NewPlayoutAPI {
-	// rundownPrepareForBroadcast(playlistId: RundownPlaylistId) {
-	// 	return makePromise(() => ServerPlayoutAPI.prepareRundownPlaylistForBroadcast(this, playlistId))
-	// }
-	// rundownResetRundown(playlistId: RundownPlaylistId) {
-	// 	return makePromise(() => ServerPlayoutAPI.resetRundownPlaylist(this, playlistId))
-	// }
-	// rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean) {
-	// 	return makePromise(() => ServerPlayoutAPI.resetAndActivateRundownPlaylist(this, playlistId, rehearsal))
-	// }
-	// rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean) {
-	// 	return makePromise(() => ServerPlayoutAPI.activateRundownPlaylist(this, playlistId, rehearsal))
-	// }
-	// rundownDeactivate(playlistId: RundownPlaylistId) {
-	// 	return makePromise(() => ServerPlayoutAPI.deactivateRundownPlaylist(this, playlistId))
-	// }
-	// pieceTakeNow(
-	// 	playlistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
-	// ) {
-	// 	return makePromise(() =>
-	// 		ServerPlayoutAPI.pieceTakeNow(this, playlistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)
-	// 	)
-	// }
-	// rundownTake(playlistId: RundownPlaylistId) {
-	// 	return makePromise(() => ServerPlayoutAPI.takeNextPart(this, playlistId))
-	// }
-	// rundownSetNext(playlistId: RundownPlaylistId, partId: PartId, timeOffset?: number | undefined) {
-	// 	return makePromise(() => ServerPlayoutAPI.setNextPart(this, playlistId, partId, true, timeOffset))
-	// }
-	// rundownSetNextSegment(playlistId: RundownPlaylistId, segmentId: SegmentId | null) {
-	// 	return makePromise(() => ServerPlayoutAPI.setNextSegment(this, playlistId, segmentId))
-	// }
-	// rundownMoveNext(playlistId: RundownPlaylistId, horisontalDelta: number, verticalDelta: number) {
-	// 	return makePromise(() => ServerPlayoutAPI.moveNextPart(this, playlistId, horisontalDelta, verticalDelta))
-	// }
-	// rundownActivateHold(playlistId: RundownPlaylistId) {
-	// 	return makePromise(() => ServerPlayoutAPI.activateHold(this, playlistId))
-	// }
-	// rundownDisableNextPiece(rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-	// 	return makePromise(() => ServerPlayoutAPI.disableNextPiece(this, rundownPlaylistId, undo))
-	// }
-	// segmentAdLibPieceStart(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceId: PieceId,
-	// 	queue: boolean
-	// ) {
-	// 	return makePromise(() =>
-	// 		ServerPlayoutAPI.segmentAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
-	// 	)
-	// }
-	// rundownBaselineAdLibPieceStart(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	pieceId: PieceId,
-	// 	queue: boolean
-	// ) {
-	// 	return makePromise(() =>
-	// 		ServerPlayoutAPI.rundownBaselineAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
-	// 	)
-	// }
-	// sourceLayerOnPartStop(
-	// 	rundownPlaylistId: RundownPlaylistId,
-	// 	partInstanceId: PartInstanceId,
-	// 	sourceLayerIds: string[]
-	// ) {
-	// 	return makePromise(() =>
-	// 		ServerPlayoutAPI.sourceLayerOnPartStop(this, rundownPlaylistId, partInstanceId, sourceLayerIds)
-	// 	)
-	// }
-	// sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string) {
-	// 	return makePromise(() => ServerPlayoutAPI.sourceLayerStickyPieceStart(this, playlistId, sourceLayerId))
-	// }
 	updateStudioBaseline(studioId: StudioId) {
 		return makePromise(() => ServerPlayoutAPI.updateStudioBaseline(this, studioId))
 	}
 	shouldUpdateStudioBaseline(studioId: StudioId) {
 		return makePromise(() => ServerPlayoutAPI.shouldUpdateStudioBaseline(this, studioId))
 	}
-	// switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean) {
-	// 	return makePromise(() => ServerPlayoutAPI.switchRouteSet(this, studioId, routeSetId, state))
-	// }
 }
 registerClassToMeteorMethods(PlayoutAPIMethods, ServerPlayoutAPIClass, false)
 

--- a/meteor/server/api/playout/api.ts
+++ b/meteor/server/api/playout/api.ts
@@ -16,89 +16,89 @@ import { Settings } from '../../../lib/Settings'
 import { SegmentId } from '../../../lib/collections/Segments'
 
 class ServerPlayoutAPIClass extends MethodContextAPI implements NewPlayoutAPI {
-	rundownPrepareForBroadcast(playlistId: RundownPlaylistId) {
-		return makePromise(() => ServerPlayoutAPI.prepareRundownPlaylistForBroadcast(this, playlistId))
-	}
-	rundownResetRundown(playlistId: RundownPlaylistId) {
-		return makePromise(() => ServerPlayoutAPI.resetRundownPlaylist(this, playlistId))
-	}
-	rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean) {
-		return makePromise(() => ServerPlayoutAPI.resetAndActivateRundownPlaylist(this, playlistId, rehearsal))
-	}
-	rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean) {
-		return makePromise(() => ServerPlayoutAPI.activateRundownPlaylist(this, playlistId, rehearsal))
-	}
-	rundownDeactivate(playlistId: RundownPlaylistId) {
-		return makePromise(() => ServerPlayoutAPI.deactivateRundownPlaylist(this, playlistId))
-	}
-	pieceTakeNow(
-		playlistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
-	) {
-		return makePromise(() =>
-			ServerPlayoutAPI.pieceTakeNow(this, playlistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)
-		)
-	}
-	rundownTake(playlistId: RundownPlaylistId) {
-		return makePromise(() => ServerPlayoutAPI.takeNextPart(this, playlistId))
-	}
-	rundownSetNext(playlistId: RundownPlaylistId, partId: PartId, timeOffset?: number | undefined) {
-		return makePromise(() => ServerPlayoutAPI.setNextPart(this, playlistId, partId, true, timeOffset))
-	}
-	rundownSetNextSegment(playlistId: RundownPlaylistId, segmentId: SegmentId | null) {
-		return makePromise(() => ServerPlayoutAPI.setNextSegment(this, playlistId, segmentId))
-	}
-	rundownMoveNext(playlistId: RundownPlaylistId, horisontalDelta: number, verticalDelta: number) {
-		return makePromise(() => ServerPlayoutAPI.moveNextPart(this, playlistId, horisontalDelta, verticalDelta))
-	}
-	rundownActivateHold(playlistId: RundownPlaylistId) {
-		return makePromise(() => ServerPlayoutAPI.activateHold(this, playlistId))
-	}
-	rundownDisableNextPiece(rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-		return makePromise(() => ServerPlayoutAPI.disableNextPiece(this, rundownPlaylistId, undo))
-	}
-	segmentAdLibPieceStart(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceId: PieceId,
-		queue: boolean
-	) {
-		return makePromise(() =>
-			ServerPlayoutAPI.segmentAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
-		)
-	}
-	rundownBaselineAdLibPieceStart(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		pieceId: PieceId,
-		queue: boolean
-	) {
-		return makePromise(() =>
-			ServerPlayoutAPI.rundownBaselineAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
-		)
-	}
-	sourceLayerOnPartStop(
-		rundownPlaylistId: RundownPlaylistId,
-		partInstanceId: PartInstanceId,
-		sourceLayerIds: string[]
-	) {
-		return makePromise(() =>
-			ServerPlayoutAPI.sourceLayerOnPartStop(this, rundownPlaylistId, partInstanceId, sourceLayerIds)
-		)
-	}
-	sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string) {
-		return makePromise(() => ServerPlayoutAPI.sourceLayerStickyPieceStart(this, playlistId, sourceLayerId))
-	}
+	// rundownPrepareForBroadcast(playlistId: RundownPlaylistId) {
+	// 	return makePromise(() => ServerPlayoutAPI.prepareRundownPlaylistForBroadcast(this, playlistId))
+	// }
+	// rundownResetRundown(playlistId: RundownPlaylistId) {
+	// 	return makePromise(() => ServerPlayoutAPI.resetRundownPlaylist(this, playlistId))
+	// }
+	// rundownResetAndActivate(playlistId: RundownPlaylistId, rehearsal?: boolean) {
+	// 	return makePromise(() => ServerPlayoutAPI.resetAndActivateRundownPlaylist(this, playlistId, rehearsal))
+	// }
+	// rundownActivate(playlistId: RundownPlaylistId, rehearsal: boolean) {
+	// 	return makePromise(() => ServerPlayoutAPI.activateRundownPlaylist(this, playlistId, rehearsal))
+	// }
+	// rundownDeactivate(playlistId: RundownPlaylistId) {
+	// 	return makePromise(() => ServerPlayoutAPI.deactivateRundownPlaylist(this, playlistId))
+	// }
+	// pieceTakeNow(
+	// 	playlistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
+	// ) {
+	// 	return makePromise(() =>
+	// 		ServerPlayoutAPI.pieceTakeNow(this, playlistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)
+	// 	)
+	// }
+	// rundownTake(playlistId: RundownPlaylistId) {
+	// 	return makePromise(() => ServerPlayoutAPI.takeNextPart(this, playlistId))
+	// }
+	// rundownSetNext(playlistId: RundownPlaylistId, partId: PartId, timeOffset?: number | undefined) {
+	// 	return makePromise(() => ServerPlayoutAPI.setNextPart(this, playlistId, partId, true, timeOffset))
+	// }
+	// rundownSetNextSegment(playlistId: RundownPlaylistId, segmentId: SegmentId | null) {
+	// 	return makePromise(() => ServerPlayoutAPI.setNextSegment(this, playlistId, segmentId))
+	// }
+	// rundownMoveNext(playlistId: RundownPlaylistId, horisontalDelta: number, verticalDelta: number) {
+	// 	return makePromise(() => ServerPlayoutAPI.moveNextPart(this, playlistId, horisontalDelta, verticalDelta))
+	// }
+	// rundownActivateHold(playlistId: RundownPlaylistId) {
+	// 	return makePromise(() => ServerPlayoutAPI.activateHold(this, playlistId))
+	// }
+	// rundownDisableNextPiece(rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
+	// 	return makePromise(() => ServerPlayoutAPI.disableNextPiece(this, rundownPlaylistId, undo))
+	// }
+	// segmentAdLibPieceStart(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceId: PieceId,
+	// 	queue: boolean
+	// ) {
+	// 	return makePromise(() =>
+	// 		ServerPlayoutAPI.segmentAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
+	// 	)
+	// }
+	// rundownBaselineAdLibPieceStart(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	pieceId: PieceId,
+	// 	queue: boolean
+	// ) {
+	// 	return makePromise(() =>
+	// 		ServerPlayoutAPI.rundownBaselineAdLibPieceStart(this, rundownPlaylistId, partInstanceId, pieceId, queue)
+	// 	)
+	// }
+	// sourceLayerOnPartStop(
+	// 	rundownPlaylistId: RundownPlaylistId,
+	// 	partInstanceId: PartInstanceId,
+	// 	sourceLayerIds: string[]
+	// ) {
+	// 	return makePromise(() =>
+	// 		ServerPlayoutAPI.sourceLayerOnPartStop(this, rundownPlaylistId, partInstanceId, sourceLayerIds)
+	// 	)
+	// }
+	// sourceLayerStickyPieceStart(playlistId: RundownPlaylistId, sourceLayerId: string) {
+	// 	return makePromise(() => ServerPlayoutAPI.sourceLayerStickyPieceStart(this, playlistId, sourceLayerId))
+	// }
 	updateStudioBaseline(studioId: StudioId) {
 		return makePromise(() => ServerPlayoutAPI.updateStudioBaseline(this, studioId))
 	}
 	shouldUpdateStudioBaseline(studioId: StudioId) {
 		return makePromise(() => ServerPlayoutAPI.shouldUpdateStudioBaseline(this, studioId))
 	}
-	switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean) {
-		return makePromise(() => ServerPlayoutAPI.switchRouteSet(this, studioId, routeSetId, state))
-	}
+	// switchRouteSet(studioId: StudioId, routeSetId: string, state: boolean) {
+	// 	return makePromise(() => ServerPlayoutAPI.switchRouteSet(this, studioId, routeSetId, state))
+	// }
 }
 registerClassToMeteorMethods(PlayoutAPIMethods, ServerPlayoutAPIClass, false)
 

--- a/meteor/server/api/playout/lockFunction.ts
+++ b/meteor/server/api/playout/lockFunction.ts
@@ -5,7 +5,8 @@ import { RundownPlaylistId, RundownPlaylist, RundownPlaylists } from '../../../l
 import { assertNever, waitForPromise } from '../../../lib/lib'
 import { ReadOnlyCache } from '../../cache/CacheBase'
 import { syncFunction } from '../../codeControl'
-import { checkAccessAndGetPlaylist } from '../lib'
+import { RundownPlaylistContentAccess } from '../../security/rundownPlaylist'
+import { checkAccessAndGetPlaylist, VerifiedRundownPlaylistContentAccess } from '../lib'
 import { CacheForStudio } from '../studio/cache'
 import {
 	getStudioIdFromCacheOrLock,
@@ -59,13 +60,13 @@ export function getPlaylistIdFromCacheOrLock(cacheOrLock: any): RundownPlaylistI
 /**
  * Lock the playlist for performing a playout operation and load a cache of data.
  * Note: This also locks the studio, if that is already locked then use 'rundownPlaylistPlayoutFromStudioLockFunction' instead
- * @param context Meteor call context, to authenticate the request. Pass null if already authenticated
+ * @param access Meteor call context, to authenticate the request. Pass null if already authenticated
  * @param contextStr Contextual information for the call to this function. to aid debugging
  * @param rundownPlaylistId Id of the playlist to lock
  * @param fcn Function to run while holding the lock
  */
 export function runPlayoutOperationWithCache<T>(
-	context: MethodContext | null,
+	access: VerifiedRundownPlaylistContentAccess | null,
 	contextStr: string,
 	rundownPlaylistId: RundownPlaylistId,
 	priority: PlayoutLockFunctionPriority,
@@ -73,8 +74,14 @@ export function runPlayoutOperationWithCache<T>(
 	fcn: (cache: CacheForPlayout) => Promise<T> | T
 ): T {
 	let tmpPlaylist: RundownPlaylist
-	if (context) {
-		tmpPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	if (access) {
+		tmpPlaylist = access.playlist
+		if (!tmpPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+		if (tmpPlaylist._id !== rundownPlaylistId)
+			throw new Meteor.Error(
+				500,
+				`VerifiedAccess is for wrong Rundown Playlist "${rundownPlaylistId}" vs ${tmpPlaylist._id}!`
+			)
 	} else {
 		const pl = RundownPlaylists.findOne(rundownPlaylistId)
 		if (!pl) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
@@ -89,22 +96,23 @@ export function runPlayoutOperationWithCache<T>(
 /**
  * Lock the playlist for performing a playout operation and load a cache of data.
  * Warning: This will get the studio lock
- * @param context Contextual information for the call to this function. to aid debugging
+ * @param access Contextual information for the call to this function. to aid debugging
  * @param studioCache Cache of Studio or another Playlist data (used to verify the lock order)
  * @param rundownPlaylistId Id of the playlist to lock
  * @param priority Priority of function execution
  * @param fcn Function to run while holding the lock
  */
 export function runPlayoutOperationWithLock<T>(
-	context: MethodContext | null,
+	access: VerifiedRundownPlaylistContentAccess | null,
 	contextStr: string,
 	rundownPlaylistId: RundownPlaylistId,
 	priority: PlayoutLockFunctionPriority,
 	fcn: (lock: PlaylistLock, tmpPlaylist: ReadonlyDeep<RundownPlaylist>) => Promise<T> | T
 ): T {
 	let tmpPlaylist: RundownPlaylist
-	if (context) {
-		tmpPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	if (access) {
+		tmpPlaylist = access.playlist
+		if (!tmpPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
 	} else {
 		const pl = RundownPlaylists.findOne(rundownPlaylistId)
 		if (!pl) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -74,6 +74,7 @@ import { CacheForPlayout, getOrderedSegmentsAndPartsFromPlayoutCache, getSelecte
 import { PeripheralDevice } from '../../../lib/collections/PeripheralDevices'
 import { runStudioOperationWithCache, StudioLockFunctionPriority } from '../studio/lockFunction'
 import { CacheForStudio } from '../studio/cache'
+import { VerifiedRundownPlaylistContentAccess } from '../lib'
 
 /**
  * debounce time in ms before we accept another report of "Part started playing that was not selected by core"
@@ -85,9 +86,12 @@ export namespace ServerPlayoutAPI {
 	 * Prepare the rundown for transmission
 	 * To be triggered well before the broadcast, since it may take time and cause outputs to flicker
 	 */
-	export function prepareRundownPlaylistForBroadcast(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
+	export function prepareRundownPlaylistForBroadcast(
+		access: VerifiedRundownPlaylistContentAccess,
+		rundownPlaylistId: RundownPlaylistId
+	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'prepareRundownPlaylistForBroadcast',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -121,9 +125,12 @@ export namespace ServerPlayoutAPI {
 	 * Reset the broadcast, to be used during testing.
 	 * The User might have run through the rundown and wants to start over and try again
 	 */
-	export function resetRundownPlaylist(context: MethodContext, rundownPlaylistId: RundownPlaylistId): void {
+	export function resetRundownPlaylist(
+		access: VerifiedRundownPlaylistContentAccess,
+		rundownPlaylistId: RundownPlaylistId
+	): void {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'resetRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -147,12 +154,12 @@ export namespace ServerPlayoutAPI {
 	 * To be triggered by the User a short while before going on air
 	 */
 	export function resetAndActivateRundownPlaylist(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		rehearsal?: boolean
 	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'resetAndActivateRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -174,13 +181,13 @@ export namespace ServerPlayoutAPI {
 	 * Activate the rundownPlaylist, decativate any other running rundowns
 	 */
 	export function forceResetAndActivateRundownPlaylist(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		rehearsal: boolean
 	) {
 		check(rehearsal, Boolean)
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'forceResetAndActivateRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -243,13 +250,13 @@ export namespace ServerPlayoutAPI {
 	 * Only activate the rundown, don't reset anything
 	 */
 	export function activateRundownPlaylist(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		rehearsal: boolean
 	) {
 		check(rehearsal, Boolean)
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'activateRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -264,9 +271,12 @@ export namespace ServerPlayoutAPI {
 	/**
 	 * Deactivate the rundown
 	 */
-	export function deactivateRundownPlaylist(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
+	export function deactivateRundownPlaylist(
+		access: VerifiedRundownPlaylistContentAccess,
+		rundownPlaylistId: RundownPlaylistId
+	) {
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'deactivateRundownPlaylist',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -282,7 +292,7 @@ export namespace ServerPlayoutAPI {
 	 * Take the currently Next:ed Part (start playing it)
 	 */
 	export function takeNextPart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId
 	): ClientAPI.ClientResponse<void> {
 		check(rundownPlaylistId, String)
@@ -290,7 +300,7 @@ export namespace ServerPlayoutAPI {
 		const now = getCurrentTime()
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'takeNextPartInner',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -302,7 +312,7 @@ export namespace ServerPlayoutAPI {
 	}
 
 	export function setNextPart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		nextPartId: PartId | null,
 		setManually?: boolean,
@@ -312,7 +322,7 @@ export namespace ServerPlayoutAPI {
 		if (nextPartId) check(nextPartId, String)
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'setNextPart',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -359,7 +369,7 @@ export namespace ServerPlayoutAPI {
 		updateTimeline(cache)
 	}
 	export function moveNextPart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partDelta: number,
 		segmentDelta: number
@@ -369,7 +379,7 @@ export namespace ServerPlayoutAPI {
 		check(segmentDelta, Number)
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'moveNextPart',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -482,7 +492,7 @@ export namespace ServerPlayoutAPI {
 		}
 	}
 	export function setNextSegment(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		nextSegmentId: SegmentId | null
 	): ClientAPI.ClientResponse<void> {
@@ -490,7 +500,7 @@ export namespace ServerPlayoutAPI {
 		if (nextSegmentId) check(nextSegmentId, String)
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'setNextSegment',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -515,12 +525,12 @@ export namespace ServerPlayoutAPI {
 			}
 		)
 	}
-	export function activateHold(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
+	export function activateHold(access: VerifiedRundownPlaylistContentAccess, rundownPlaylistId: RundownPlaylistId) {
 		check(rundownPlaylistId, String)
 		logger.debug('rundownActivateHold')
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'activateHold',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -568,12 +578,12 @@ export namespace ServerPlayoutAPI {
 			}
 		)
 	}
-	export function deactivateHold(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
+	export function deactivateHold(access: VerifiedRundownPlaylistContentAccess, rundownPlaylistId: RundownPlaylistId) {
 		check(rundownPlaylistId, String)
 		logger.debug('deactivateHold')
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'deactivateHold',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -591,14 +601,14 @@ export namespace ServerPlayoutAPI {
 		)
 	}
 	export function disableNextPiece(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		undo?: boolean
 	): ClientAPI.ClientResponse<void> {
 		check(rundownPlaylistId, String)
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'disableNextPiece',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -711,7 +721,7 @@ export namespace ServerPlayoutAPI {
 	 * Triggered from Playout-gateway when a Piece has started playing
 	 */
 	export function onPiecePlaybackStarted(
-		context: MethodContext,
+		_context: MethodContext,
 		rundownPlaylistId: RundownPlaylistId,
 		pieceInstanceId: PieceInstanceId,
 		dynamicallyInserted: boolean,
@@ -724,7 +734,7 @@ export namespace ServerPlayoutAPI {
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
 		return runPlayoutOperationWithLock(
-			context,
+			null, // TODO: should security be done?
 			'onPiecePlaybackStarted',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.CALLBACK_PLAYOUT,
@@ -761,7 +771,7 @@ export namespace ServerPlayoutAPI {
 	 * Triggered from Playout-gateway when a Piece has stopped playing
 	 */
 	export function onPiecePlaybackStopped(
-		context: MethodContext,
+		_context: MethodContext,
 		rundownPlaylistId: RundownPlaylistId,
 		pieceInstanceId: PieceInstanceId,
 		dynamicallyInserted: boolean,
@@ -774,7 +784,7 @@ export namespace ServerPlayoutAPI {
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
 		return runPlayoutOperationWithLock(
-			context,
+			null, // TODO: should security be done?
 			'onPiecePlaybackStopped',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.CALLBACK_PLAYOUT,
@@ -973,7 +983,7 @@ export namespace ServerPlayoutAPI {
 	 * Triggered from Playout-gateway when a Part has stopped playing
 	 */
 	export function onPartPlaybackStopped(
-		context: MethodContext,
+		_context: MethodContext,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		stoppedPlayback: Time
@@ -985,7 +995,7 @@ export namespace ServerPlayoutAPI {
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
 		return runPlayoutOperationWithLock(
-			context,
+			null, // TODO: should security be done?
 			'onPartPlaybackStopped',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.CALLBACK_PLAYOUT,
@@ -1024,7 +1034,7 @@ export namespace ServerPlayoutAPI {
 	 * Make a copy of a piece and start playing it now
 	 */
 	export function pieceTakeNow(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
@@ -1034,14 +1044,14 @@ export namespace ServerPlayoutAPI {
 		check(pieceInstanceIdOrPieceIdToCopy, String)
 
 		return ServerPlayoutAdLibAPI.pieceTakeNow(
-			context,
+			access,
 			rundownPlaylistId,
 			partInstanceId,
 			pieceInstanceIdOrPieceIdToCopy
 		)
 	}
 	export function segmentAdLibPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		adLibPieceId: PieceId,
@@ -1052,7 +1062,7 @@ export namespace ServerPlayoutAPI {
 		check(adLibPieceId, String)
 
 		return ServerPlayoutAdLibAPI.segmentAdLibPieceStart(
-			context,
+			access,
 			rundownPlaylistId,
 			partInstanceId,
 			adLibPieceId,
@@ -1060,7 +1070,7 @@ export namespace ServerPlayoutAPI {
 		)
 	}
 	export function rundownBaselineAdLibPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		baselineAdLibPieceId: PieceId,
@@ -1071,7 +1081,7 @@ export namespace ServerPlayoutAPI {
 		check(baselineAdLibPieceId, String)
 
 		return ServerPlayoutAdLibAPI.rundownBaselineAdLibPieceStart(
-			context,
+			access,
 			rundownPlaylistId,
 			partInstanceId,
 			baselineAdLibPieceId,
@@ -1079,17 +1089,17 @@ export namespace ServerPlayoutAPI {
 		)
 	}
 	export function sourceLayerStickyPieceStart(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		sourceLayerId: string
 	) {
 		check(rundownPlaylistId, String)
 		check(sourceLayerId, String)
 
-		return ServerPlayoutAdLibAPI.sourceLayerStickyPieceStart(context, rundownPlaylistId, sourceLayerId)
+		return ServerPlayoutAdLibAPI.sourceLayerStickyPieceStart(access, rundownPlaylistId, sourceLayerId)
 	}
 	export function executeAction(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		actionId: string,
 		userData: any,
@@ -1100,7 +1110,7 @@ export namespace ServerPlayoutAPI {
 		check(userData, Match.Any)
 		check(triggerMode, Match.Maybe(String))
 
-		return executeActionInner(context, rundownPlaylistId, async (actionContext, cache, rundown) => {
+		return executeActionInner(access, rundownPlaylistId, async (actionContext, cache, rundown) => {
 			const blueprint = loadShowStyleBlueprint(actionContext.showStyleCompound)
 			if (!blueprint.blueprint.executeAction) {
 				throw new Meteor.Error(
@@ -1116,7 +1126,7 @@ export namespace ServerPlayoutAPI {
 	}
 
 	export function executeActionInner(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		func: (
 			context: ActionExecutionContext,
@@ -1128,7 +1138,7 @@ export namespace ServerPlayoutAPI {
 		const now = getCurrentTime()
 
 		runPlayoutOperationWithCache(
-			context,
+			access,
 			'executeActionInner',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,
@@ -1200,7 +1210,7 @@ export namespace ServerPlayoutAPI {
 		return takeNextPartInnerSync(cache, now)
 	}
 	export function sourceLayerOnPartStop(
-		context: MethodContext,
+		access: VerifiedRundownPlaylistContentAccess,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		sourceLayerIds: string[]
@@ -1210,7 +1220,7 @@ export namespace ServerPlayoutAPI {
 		check(sourceLayerIds, Match.OneOf(String, Array))
 
 		return runPlayoutOperationWithCache(
-			context,
+			access,
 			'sourceLayerOnPartStop',
 			rundownPlaylistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -52,6 +52,7 @@ import { runIngestOperationWithLock } from './ingest/lockFunction'
 import { getRundown } from './ingest/lib'
 import { asyncCollectionFindFetch } from '../lib/database'
 import { createShowStyleCompound } from './showStyles'
+import { checkAccessToPlaylist } from './lib'
 
 export function selectShowStyleVariant(
 	context: StudioUserContext,
@@ -304,8 +305,10 @@ export namespace ServerRundownAPI {
 	export function removeRundownPlaylist(context: MethodContext, playlistId: RundownPlaylistId): void {
 		check(playlistId, String)
 
+		const access = checkAccessToPlaylist(context, playlistId)
+
 		runPlayoutOperationWithLock(
-			context,
+			access,
 			'removeRundownPlaylist',
 			playlistId,
 			PlayoutLockFunctionPriority.USER_PLAYOUT,

--- a/meteor/server/api/rundownPlaylist.ts
+++ b/meteor/server/api/rundownPlaylist.ts
@@ -54,6 +54,7 @@ import { DbCacheWriteCollection } from '../cache/CacheCollection'
 import { Random } from 'meteor/random'
 import { asyncCollectionRemove, asyncCollectionFindOne } from '../lib/database'
 import { ExpectedPackages } from '../../lib/collections/ExpectedPackages'
+import { checkAccessToPlaylist } from './lib'
 
 export function removeEmptyPlaylists(studioId: StudioId) {
 	runStudioOperationWithCache('removeEmptyPlaylists', studioId, StudioLockFunctionPriority.MISC, async (cache) => {
@@ -71,8 +72,8 @@ export function removeEmptyPlaylists(studioId: StudioId) {
 						playlist,
 						PlayoutLockFunctionPriority.MISC,
 						async () => {
-							const playlists = Rundowns.find({ playlistId: playlist._id }).count()
-							if (playlists === 0) {
+							const rundowns = Rundowns.find({ playlistId: playlist._id }).count()
+							if (rundowns === 0) {
 								await removeRundownPlaylistFromDb(playlist)
 							}
 						}
@@ -445,8 +446,10 @@ export function moveRundownIntoPlaylist(
 }
 /** Restore the order of rundowns in a playlist, giving control over the ordering back to the NRCS */
 export function restoreRundownsInPlaylistToDefaultOrder(context: MethodContext, playlistId: RundownPlaylistId) {
+	const access = checkAccessToPlaylist(context, playlistId)
+
 	runPlayoutOperationWithLock(
-		context,
+		access,
 		'restoreRundownsInPlaylistToDefaultOrder',
 		playlistId,
 		PlayoutLockFunctionPriority.MISC,

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -21,7 +21,7 @@ import { IngestDataCache, IngestCacheType } from '../../lib/collections/IngestDa
 import { MOSDeviceActions } from './ingest/mosDevice/actions'
 import { getActiveRundownPlaylistsInStudioFromDb } from './studio/lib'
 import { IngestActions } from './ingest/actions'
-import { RundownPlaylists, RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
+import { RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
 import { PartInstances, PartInstanceId } from '../../lib/collections/PartInstances'
 import {
 	PieceInstances,
@@ -48,7 +48,7 @@ import { rundownContentAllowWrite } from '../security/rundown'
 import { profiler } from './profiler'
 import { AdLibActionId, AdLibActionCommon } from '../../lib/collections/AdLibActions'
 import { BucketAdLibAction } from '../../lib/collections/BucketAdlibActions'
-import { checkAccessAndGetPlaylist, checkAccessAndGetRundown } from './lib'
+import { checkAccessAndGetPlaylist, checkAccessAndGetRundown, checkAccessToPlaylist } from './lib'
 import { PackageManagerAPI } from './packageManager'
 import { PeripheralDeviceId } from '../../lib/collections/PeripheralDevices'
 import { moveRundownIntoPlaylist, restoreRundownsInPlaylistToDefaultOrder } from './rundownPlaylist'
@@ -77,7 +77,8 @@ export const take = syncFunction(function take(
 	// Called by the user. Wont throw as nasty errors
 	const now = getCurrentTime()
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (!playlist.activationId) {
 		return ClientAPI.responseError(`Rundown is not active, please activate the rundown before doing a TAKE.`)
@@ -109,7 +110,7 @@ export const take = syncFunction(function take(
 			)
 		}
 	}
-	return ServerPlayoutAPI.takeNextPart(context, playlist._id)
+	return ServerPlayoutAPI.takeNextPart(access, playlist._id)
 },
 'userActionsTake$0')
 
@@ -123,7 +124,8 @@ export function setNext(
 	check(rundownPlaylistId, String)
 	if (nextPartId) check(nextPartId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 	if (!playlist.activationId)
 		return ClientAPI.responseError(
 			'RundownPlaylist is not active, please activate it before setting a part as Next'
@@ -140,7 +142,7 @@ export function setNext(
 	if (playlist.holdState && playlist.holdState !== RundownHoldState.COMPLETE) {
 		return ClientAPI.responseError('The Next cannot be changed next during a Hold!')
 	}
-	return ServerPlayoutAPI.setNextPart(context, rundownPlaylistId, nextPartId, setManually, timeOffset)
+	return ServerPlayoutAPI.setNextPart(access, rundownPlaylistId, nextPartId, setManually, timeOffset)
 }
 export function setNextSegment(
 	context: MethodContext,
@@ -151,7 +153,8 @@ export function setNextSegment(
 	if (nextSegmentId) check(nextSegmentId, String)
 	else check(nextSegmentId, null)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 	if (!playlist.activationId)
 		return ClientAPI.responseError('Rundown is not active, please activate it before setting a part as Next')
 
@@ -177,11 +180,11 @@ export function setNextSegment(
 		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
 		if (!currentPartInstance || !nextPartInstance || nextPartInstance.segmentId !== currentPartInstance.segmentId) {
 			// Special: in this case, the user probably dosen't want to setNextSegment, but rather just setNextPart
-			return ServerPlayoutAPI.setNextPart(context, rundownPlaylistId, firstValidPartInSegment._id, true, 0)
+			return ServerPlayoutAPI.setNextPart(access, rundownPlaylistId, firstValidPartInSegment._id, true, 0)
 		}
 	}
 
-	return ServerPlayoutAPI.setNextSegment(context, rundownPlaylistId, nextSegmentId)
+	return ServerPlayoutAPI.setNextSegment(access, rundownPlaylistId, nextSegmentId)
 }
 export function moveNext(
 	context: MethodContext,
@@ -189,7 +192,8 @@ export function moveNext(
 	horisontalDelta: number,
 	verticalDelta: number
 ): ClientAPI.ClientResponse<PartId | null> {
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 	if (!playlist.activationId)
 		return ClientAPI.responseError('Rundown Playlist is not active, please activate it first')
 
@@ -201,7 +205,7 @@ export function moveNext(
 	}
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.moveNextPart(context, rundownPlaylistId, horisontalDelta, verticalDelta)
+		ServerPlayoutAPI.moveNextPart(access, rundownPlaylistId, horisontalDelta, verticalDelta)
 	)
 }
 export function prepareForBroadcast(
@@ -209,7 +213,9 @@ export function prepareForBroadcast(
 	rundownPlaylistId: RundownPlaylistId
 ): ClientAPI.ClientResponse<void> {
 	check(rundownPlaylistId, String)
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (playlist.activationId)
 		return ClientAPI.responseError(
@@ -226,22 +232,24 @@ export function prepareForBroadcast(
 			anyOtherActiveRundowns
 		)
 	}
-	return ClientAPI.responseSuccess(ServerPlayoutAPI.prepareRundownPlaylistForBroadcast(context, rundownPlaylistId))
+	return ClientAPI.responseSuccess(ServerPlayoutAPI.prepareRundownPlaylistForBroadcast(access, rundownPlaylistId))
 }
 export function resetRundownPlaylist(
 	context: MethodContext,
 	rundownPlaylistId: RundownPlaylistId
 ): ClientAPI.ClientResponse<void> {
 	check(rundownPlaylistId, String)
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (playlist.activationId && !playlist.rehearsal && !Settings.allowRundownResetOnAir) {
 		return ClientAPI.responseError(
 			'RundownPlaylist is active but not in rehearsal, please deactivate it or set in in rehearsal to be able to reset it.'
 		)
 	}
 
-	return ClientAPI.responseSuccess(ServerPlayoutAPI.resetRundownPlaylist(context, rundownPlaylistId))
+	return ClientAPI.responseSuccess(ServerPlayoutAPI.resetRundownPlaylist(access, rundownPlaylistId))
 }
 export function resetAndActivate(
 	context: MethodContext,
@@ -249,8 +257,10 @@ export function resetAndActivate(
 	rehearsal?: boolean
 ): ClientAPI.ClientResponse<void> {
 	check(rundownPlaylistId, String)
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-	if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (playlist.activationId && !playlist.rehearsal && !Settings.allowRundownResetOnAir) {
 		return ClientAPI.responseError(
 			'RundownPlaylist is active but not in rehearsal, please deactivate it or set in in rehearsal to be able to reset it.'
@@ -269,7 +279,7 @@ export function resetAndActivate(
 	}
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.resetAndActivateRundownPlaylist(context, rundownPlaylistId, rehearsal)
+		ServerPlayoutAPI.resetAndActivateRundownPlaylist(access, rundownPlaylistId, rehearsal)
 	)
 }
 export function forceResetAndActivate(
@@ -280,10 +290,10 @@ export function forceResetAndActivate(
 	// Reset and activates a rundown, automatically deactivates any other running rundowns
 
 	check(rehearsal, Boolean)
-	checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.forceResetAndActivateRundownPlaylist(context, rundownPlaylistId, rehearsal)
+		ServerPlayoutAPI.forceResetAndActivateRundownPlaylist(access, rundownPlaylistId, rehearsal)
 	)
 }
 export function activate(
@@ -294,7 +304,9 @@ export function activate(
 	check(rundownPlaylistId, String)
 	check(rehearsal, Boolean)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	const anyOtherActiveRundowns = waitForPromise(
 		getActiveRundownPlaylistsInStudioFromDb(playlist.studioId, playlist._id)
 	)
@@ -307,19 +319,23 @@ export function activate(
 			anyOtherActiveRundowns
 		)
 	}
-	return ClientAPI.responseSuccess(ServerPlayoutAPI.activateRundownPlaylist(context, playlist._id, rehearsal))
+	return ClientAPI.responseSuccess(ServerPlayoutAPI.activateRundownPlaylist(access, playlist._id, rehearsal))
 }
 export function deactivate(
 	context: MethodContext,
 	rundownPlaylistId: RundownPlaylistId
 ): ClientAPI.ClientResponse<void> {
-	return ClientAPI.responseSuccess(ServerPlayoutAPI.deactivateRundownPlaylist(context, rundownPlaylistId))
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+
+	return ClientAPI.responseSuccess(ServerPlayoutAPI.deactivateRundownPlaylist(access, rundownPlaylistId))
 }
 export function unsyncRundown(context: MethodContext, rundownId: RundownId) {
 	return ClientAPI.responseSuccess(ServerRundownAPI.unsyncRundown(context, rundownId))
 }
 export function disableNextPiece(context: MethodContext, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
-	return ServerPlayoutAPI.disableNextPiece(context, rundownPlaylistId, undo)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+
+	return ServerPlayoutAPI.disableNextPiece(access, rundownPlaylistId, undo)
 }
 export function pieceTakeNow(
 	context: MethodContext,
@@ -331,7 +347,9 @@ export function pieceTakeNow(
 	check(partInstanceId, String)
 	check(pieceInstanceIdOrPieceIdToCopy, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before starting an AdLib!`)
 	if (playlist.currentPartInstanceId !== partInstanceId)
@@ -372,7 +390,7 @@ export function pieceTakeNow(
 		)
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.pieceTakeNow(context, rundownPlaylistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)
+		ServerPlayoutAPI.pieceTakeNow(access, rundownPlaylistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)
 	)
 }
 export function pieceSetInOutPoints(
@@ -389,10 +407,12 @@ export function pieceSetInOutPoints(
 	check(inPoint, Number)
 	check(duration, Number)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	const part = Parts.findOne(partId)
 	if (!part) throw new Meteor.Error(404, `Part "${partId}" not found!`)
-	if (playlist && playlist.activationId && part.status === 'PLAY') {
+	if (playlist.activationId && part.status === 'PLAY') {
 		throw new Meteor.Error(`Part cannot be active while setting in/out!`) // @todo: un-hardcode
 	}
 	const rundown = Rundowns.findOne(part.rundownId)
@@ -430,15 +450,16 @@ export function executeAction(
 	check(userData, Match.Any)
 	check(triggerMode, Match.Maybe(String))
 
-	const playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-	if (!playlist) throw new Meteor.Error(404, `RundownPlaylist "${rundownPlaylistId}" not found!`)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before executing an action!`)
 	if (!playlist.currentPartInstanceId)
 		return ClientAPI.responseError(`No part is playing, please Take a part before executing an action.`)
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.executeAction(context, rundownPlaylistId, actionId, userData, triggerMode)
+		ServerPlayoutAPI.executeAction(access, rundownPlaylistId, actionId, userData, triggerMode)
 	)
 }
 export function segmentAdLibPieceStart(
@@ -452,7 +473,8 @@ export function segmentAdLibPieceStart(
 	check(partInstanceId, String)
 	check(adlibPieceId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before starting an AdLib!`)
@@ -461,7 +483,7 @@ export function segmentAdLibPieceStart(
 	}
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.segmentAdLibPieceStart(context, rundownPlaylistId, partInstanceId, adlibPieceId, queue)
+		ServerPlayoutAPI.segmentAdLibPieceStart(access, rundownPlaylistId, partInstanceId, adlibPieceId, queue)
 	)
 }
 export function sourceLayerOnPartStop(
@@ -474,12 +496,14 @@ export function sourceLayerOnPartStop(
 	check(partInstanceId, String)
 	check(sourceLayerIds, Match.OneOf(String, Array))
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, can't stop an AdLib on a deactivated Rundown!`)
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.sourceLayerOnPartStop(context, rundownPlaylistId, partInstanceId, sourceLayerIds)
+		ServerPlayoutAPI.sourceLayerOnPartStop(access, rundownPlaylistId, partInstanceId, sourceLayerIds)
 	)
 }
 export function rundownBaselineAdLibPieceStart(
@@ -493,7 +517,8 @@ export function rundownBaselineAdLibPieceStart(
 	check(partInstanceId, String)
 	check(adlibPieceId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before starting an AdLib!`)
@@ -501,7 +526,7 @@ export function rundownBaselineAdLibPieceStart(
 		return ClientAPI.responseError(`Can't start AdLib piece when the Rundown is in Hold mode!`)
 	}
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.rundownBaselineAdLibPieceStart(context, rundownPlaylistId, partInstanceId, adlibPieceId, queue)
+		ServerPlayoutAPI.rundownBaselineAdLibPieceStart(access, rundownPlaylistId, partInstanceId, adlibPieceId, queue)
 	)
 }
 export function sourceLayerStickyPieceStart(
@@ -512,14 +537,16 @@ export function sourceLayerStickyPieceStart(
 	check(rundownPlaylistId, String)
 	check(sourceLayerId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
+
 	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before starting a sticky-item!`)
 	if (!playlist.currentPartInstanceId)
 		return ClientAPI.responseError(`No part is playing, please Take a part before starting a sticky-item.`)
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.sourceLayerStickyPieceStart(context, rundownPlaylistId, sourceLayerId)
+		ServerPlayoutAPI.sourceLayerStickyPieceStart(access, rundownPlaylistId, sourceLayerId)
 	)
 }
 export function activateHold(
@@ -529,7 +556,8 @@ export function activateHold(
 ): ClientAPI.ClientResponse<void> {
 	check(rundownPlaylistId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (!playlist.currentPartInstanceId)
 		return ClientAPI.responseError(`No part is currently playing, please Take a part before activating Hold mode!`)
@@ -547,9 +575,9 @@ export function activateHold(
 	}
 
 	if (undo) {
-		return ClientAPI.responseSuccess(ServerPlayoutAPI.deactivateHold(context, rundownPlaylistId))
+		return ClientAPI.responseSuccess(ServerPlayoutAPI.deactivateHold(access, rundownPlaylistId))
 	} else {
-		return ClientAPI.responseSuccess(ServerPlayoutAPI.activateHold(context, rundownPlaylistId))
+		return ClientAPI.responseSuccess(ServerPlayoutAPI.activateHold(access, rundownPlaylistId))
 	}
 }
 export function userSaveEvaluation(context: MethodContext, evaluation: EvaluationBase): ClientAPI.ClientResponse<void> {
@@ -603,15 +631,12 @@ export function mediaAbortAllWorkflows(context: MethodContext) {
 	return ClientAPI.responseSuccess(MediaManagerAPI.abortAllWorkflows(context, access.organizationId))
 }
 export function packageManagerRestartExpectation(context: MethodContext, deviceId: PeripheralDeviceId, workId: string) {
-	const access = OrganizationContentWriteAccess.anyContent(context)
 	return ClientAPI.responseSuccess(PackageManagerAPI.restartExpectation(context, deviceId, workId))
 }
 export function packageManagerRestartAllExpectations(context: MethodContext, studioId: StudioId) {
-	const access = OrganizationContentWriteAccess.anyContent(context)
 	return ClientAPI.responseSuccess(PackageManagerAPI.restartAllExpectationsInStudio(context, studioId))
 }
 export function packageManagerAbortExpectation(context: MethodContext, deviceId: PeripheralDeviceId, workId: string) {
-	const access = OrganizationContentWriteAccess.anyContent(context)
 	return ClientAPI.responseSuccess(PackageManagerAPI.abortExpectation(context, deviceId, workId))
 }
 export function bucketsRemoveBucket(context: MethodContext, id: BucketId) {
@@ -674,13 +699,14 @@ export function bucketsModifyBucketAdLibAction(
 export function regenerateRundownPlaylist(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
 	check(rundownPlaylistId, String)
 
-	let playlist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+	const playlist = access.playlist
 
 	if (playlist.activationId) {
 		return ClientAPI.responseError(`Rundown Playlist is active, please deactivate it before regenerating it.`)
 	}
 
-	return ClientAPI.responseSuccess(IngestActions.regenerateRundownPlaylist(context, rundownPlaylistId))
+	return ClientAPI.responseSuccess(IngestActions.regenerateRundownPlaylist(access, rundownPlaylistId))
 }
 
 export function bucketAdlibImport(
@@ -741,16 +767,17 @@ export function bucketAdlibStart(
 	check(partInstanceId, String)
 	check(bucketAdlibId, String)
 
-	let rundown = RundownPlaylists.findOne(rundownPlaylistId)
-	if (!rundown) throw new Meteor.Error(404, `Rundown "${rundownPlaylistId}" not found!`)
-	if (!rundown.activationId)
+	const access = checkAccessToPlaylist(context, rundownPlaylistId)
+
+	const playlist = access.playlist
+	if (!playlist.activationId)
 		return ClientAPI.responseError(`The Rundown isn't active, please activate it before starting an AdLib!`)
-	if (rundown.holdState === RundownHoldState.ACTIVE || rundown.holdState === RundownHoldState.PENDING) {
+	if (playlist.holdState === RundownHoldState.ACTIVE || playlist.holdState === RundownHoldState.PENDING) {
 		return ClientAPI.responseError(`Can't start AdLibPiece when the Rundown is in Hold mode!`)
 	}
 
 	return ClientAPI.responseSuccess(
-		ServerPlayoutAdLibAPI.startBucketAdlibPiece(context, rundownPlaylistId, partInstanceId, bucketAdlibId, !!queue)
+		ServerPlayoutAdLibAPI.startBucketAdlibPiece(access, rundownPlaylistId, partInstanceId, bucketAdlibId, !!queue)
 	)
 }
 

--- a/meteor/server/security/rundownPlaylist.ts
+++ b/meteor/server/security/rundownPlaylist.ts
@@ -36,6 +36,15 @@ export namespace RundownPlaylistReadAccess {
 		return true
 	}
 }
+
+export interface RundownPlaylistContentAccess {
+	userId: UserId | null
+	organizationId: OrganizationId | null
+	studioId: StudioId | null
+	playlist: RundownPlaylist | null
+	cred: ResolvedCredentials | Credentials
+}
+
 export namespace RundownPlaylistContentWriteAccess {
 	export function rundown(cred0: Credentials, existingRundown: Rundown | RundownId) {
 		triggerWriteAccess()
@@ -47,20 +56,11 @@ export namespace RundownPlaylistContentWriteAccess {
 		}
 		return { ...anyContent(cred0, existingRundown.playlistId), rundown: existingRundown }
 	}
-	export function playout(cred0: Credentials, playlistId: RundownPlaylistId) {
+	export function playout(cred0: Credentials, playlistId: RundownPlaylistId): RundownPlaylistContentAccess {
 		return anyContent(cred0, playlistId)
 	}
 	/** Return credentials if writing is allowed, throw otherwise */
-	export function anyContent(
-		cred0: Credentials,
-		playlistId: RundownPlaylistId
-	): {
-		userId: UserId | null
-		organizationId: OrganizationId | null
-		studioId: StudioId | null
-		playlist: RundownPlaylist | null
-		cred: ResolvedCredentials | Credentials
-	} {
+	export function anyContent(cred0: Credentials, playlistId: RundownPlaylistId): RundownPlaylistContentAccess {
 		triggerWriteAccess()
 		if (!Settings.enableUserAccounts) {
 			const playlist = RundownPlaylists.findOne(playlistId) || null

--- a/meteor/server/security/rundownPlaylist.ts
+++ b/meteor/server/security/rundownPlaylist.ts
@@ -37,6 +37,10 @@ export namespace RundownPlaylistReadAccess {
 	}
 }
 
+/**
+ * This is returned from a check of access to a playlist.
+ * Fields will be populated about the user, and the playlist if they have permission
+ */
 export interface RundownPlaylistContentAccess {
 	userId: UserId | null
 	organizationId: OrganizationId | null

--- a/meteor/server/security/studio.ts
+++ b/meteor/server/security/studio.ts
@@ -37,6 +37,10 @@ export namespace StudioReadAccess {
 	}
 }
 
+/**
+ * This is returned from a check of access to a studio.
+ * Fields will be populated about the user, and the studio if they have permission
+ */
 export interface StudioContentAccess {
 	userId: UserId | null
 	organizationId: OrganizationId | null

--- a/meteor/server/security/studio.ts
+++ b/meteor/server/security/studio.ts
@@ -3,7 +3,6 @@ import { check } from '../../lib/check'
 import { allowAccessToStudio } from './lib/security'
 import { StudioId, Studios, Studio } from '../../lib/collections/Studios'
 import { MongoQuery, UserId } from '../../lib/typings/meteor'
-import * as _ from 'underscore'
 import { logNotAllowed } from './lib/lib'
 import {
 	ExternalMessageQueue,
@@ -37,6 +36,15 @@ export namespace StudioReadAccess {
 		return true
 	}
 }
+
+export interface StudioContentAccess {
+	userId: UserId | null
+	organizationId: OrganizationId | null
+	studioId: StudioId | null
+	studio: Studio | null
+	cred: ResolvedCredentials | Credentials
+}
+
 export namespace StudioContentWriteAccess {
 	// These functions throws if access is not allowed.
 
@@ -79,16 +87,7 @@ export namespace StudioContentWriteAccess {
 		return { ...anyContent(cred0, existingMessage.studioId), message: existingMessage }
 	}
 	/** Return credentials if writing is allowed, throw otherwise */
-	export function anyContent(
-		cred0: Credentials,
-		studioId: StudioId
-	): {
-		userId: UserId | null
-		organizationId: OrganizationId | null
-		studioId: StudioId | null
-		studio: Studio | null
-		cred: ResolvedCredentials | Credentials
-	} {
+	export function anyContent(cred0: Credentials, studioId: StudioId): StudioContentAccess {
 		triggerWriteAccess()
 		if (!Settings.enableUserAccounts) {
 			return {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

Some security warnings are thrown at startup in development. 

* **What is the new behavior (if this is a feature change)?**

Fixes these warnings. This is done mostly by splitting the security check out of the lock functions, with the result of the check being passed into the lock function instead

* **Other information**:

We have discussed removing a lot of the `ServerPlayoutAPI` as the `UserActionsAPI` should always be used.
I have done that as part of this, as otherwise each method needs updating to be hooked into the security correctly.


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
