### PR TITLE
feat: zero-based integers in settings

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -123,6 +123,32 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, Doc
 					type="int"
 					collection={collection}
 					className="input text-input input-m"
+					mutateDisplayValue={(v) => (item.zeroBased ? v + 1 : v)}
+					mutateUpdateValue={(v) => (item.zeroBased ? v - 1 : v)}
+				/>
+			)
+		case ConfigManifestEntryType.INT:
+			return (
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={attribute}
+					obj={object}
+					type="int"
+					collection={collection}
+					className="input text-input input-m"
+					mutateDisplayValue={(v) => (item.zeroBased ? v + 1 : v)}
+					mutateUpdateValue={(v) => (item.zeroBased ? v - 1 : v)}
+				/>
+			)
+		case ConfigManifestEntryType.FLOAT:
+			return (
+				<EditAttribute
+					modifiedClassName="bghl"
+					attribute={attribute}
+					obj={object}
+					type="float"
+					collection={collection}
+					className="input text-input input-m"
 				/>
 			)
 		case ConfigManifestEntryType.BOOLEAN:
@@ -685,6 +711,9 @@ export class ConfigManifestSettings<
 				) : (
 					value.toString()
 				)
+			case ConfigManifestEntryType.NUMBER:
+			case ConfigManifestEntryType.INT:
+				return _.isNumber(value) && item.zeroBased ? (value + 1).toString() : value.toString()
 			default:
 				return value.toString()
 		}

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -47,7 +47,7 @@ import { MeteorCall } from '../../../lib/api/methods'
 import { TransformedCollection } from '../../../lib/typings/meteor'
 import { doUserAction, UserAction } from '../../lib/userAction'
 import { PlayoutDeviceSettings } from '../../../lib/collections/PeripheralDeviceSettings/playoutDevice'
-import { MappingManifestEntry, MappingsManifest } from '../../../lib/api/deviceConfig'
+import { ConfigManifestEntryType, MappingManifestEntry, MappingsManifest } from '../../../lib/api/deviceConfig'
 import { renderEditAttribute } from './components/ConfigManifestEntryComponent'
 
 interface IStudioDevicesProps {
@@ -357,14 +357,20 @@ const StudioMappings = withTranslation()(
 					<span>
 						{m
 							.filter((entry) => entry.includeInSummary)
-							.map(
-								(entry) =>
-									entry.name +
-									': ' +
-									(entry.values && entry.values[mapping[entry.id]]
-										? entry.values[mapping[entry.id]]
-										: mapping[entry.id])
-							)
+							.map((entry) => {
+								let summary = entry.name + ': '
+
+								let mappingValue = entry.values && entry.values[mapping[entry.id]]
+								if (!mappingValue) {
+									mappingValue = mapping[entry.id]
+								}
+
+								if (entry.type === ConfigManifestEntryType.INT && entry.zeroBased && _.isNumber(mappingValue)) {
+									mappingValue += 1
+								}
+
+								return summary + mappingValue
+							})
 							.join(' - ')}
 					</span>
 				)

--- a/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
+++ b/meteor/client/ui/Settings/components/ConfigManifestEntryComponent.tsx
@@ -23,8 +23,18 @@ export const renderEditAttribute = (
 		label: (configField as ConfigManifestEntry).placeholder || '',
 	}
 
-	if (configField.type === ConfigManifestEntryType.FLOAT || configField.type === ConfigManifestEntryType.INT) {
-		return <EditAttribute {...opts} type={configField.type} className="input text-input input-l"></EditAttribute>
+	if (configField.type === ConfigManifestEntryType.FLOAT) {
+		return <EditAttribute {...opts} type="float" className="input text-input input-l"></EditAttribute>
+	} else if (configField.type === ConfigManifestEntryType.INT) {
+		return (
+			<EditAttribute
+				{...opts}
+				type={'int'}
+				className="input text-input input-l"
+				mutateDisplayValue={(v) => (configField.zeroBased ? v + 1 : v)}
+				mutateUpdateValue={(v) => (configField.zeroBased ? v - 1 : v)}
+			></EditAttribute>
+		)
 	} else if (configField.type === ConfigManifestEntryType.STRING) {
 		return <EditAttribute {...opts} type="text" className="input text-input input-l"></EditAttribute>
 	} else if (configField.type === ConfigManifestEntryType.BOOLEAN) {

--- a/meteor/lib/api/deviceConfig.ts
+++ b/meteor/lib/api/deviceConfig.ts
@@ -42,6 +42,7 @@ export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
 	BOOLEAN = 'boolean',
+	/** @deprecated use INT/FLOAT instead */
 	NUMBER = 'float',
 	FLOAT = 'float',
 	INT = 'int',
@@ -50,7 +51,12 @@ export enum ConfigManifestEntryType {
 	ENUM = 'enum',
 }
 
-export type ConfigManifestEntry = ConfigManifestEntryDefault | TableConfigManifestEntry | ConfigManifestEnumEntry
+export type ConfigManifestEntry =
+	| ConfigManifestEntryDefault
+	| TableConfigManifestEntry
+	| ConfigManifestEnumEntry
+	| ConfigManifestIntEntry
+	| ConfigManifestFloatEntry
 export interface ConfigManifestEntryBase {
 	id: string
 	name: string
@@ -64,7 +70,20 @@ export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 	values: any // for enum
 }
 export interface ConfigManifestEntryDefault extends ConfigManifestEntryBase {
-	type: Exclude<ConfigManifestEntryType, ConfigManifestEntryType.ENUM>
+	type: Exclude<
+		ConfigManifestEntryType,
+		ConfigManifestEntryType.ENUM | ConfigManifestEntryType.INT | ConfigManifestEntryType.FLOAT
+	>
+}
+export interface ConfigManifestIntEntry extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.INT
+	/** Zero-based values will be stored in the database (and reported to blueprints) as values starting from 0, however,
+	 * 	when rendered in settings pages they will appear as value + 1
+	 */
+	zeroBased?: boolean
+}
+export interface ConfigManifestFloatEntry extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.FLOAT
 }
 export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.ENUM
@@ -95,7 +114,10 @@ export interface TableConfigManifestEntry extends ConfigManifestEntryBase {
 
 export type MappingsManifest = Record<string, MappingManifestEntry[]>
 
-export interface MappingManifestEntry extends ConfigManifestEntryBase {
+export interface MappingManifestEntryProps {
 	optional?: boolean
 	includeInSummary?: boolean
 }
+
+export type MappingManifestEntry = MappingManifestEntryProps &
+	(ConfigManifestEntryDefault | ConfigManifestEnumEntry | ConfigManifestIntEntry | ConfigManifestFloatEntry)

--- a/packages/blueprints-integration/src/config.ts
+++ b/packages/blueprints-integration/src/config.ts
@@ -5,7 +5,10 @@ import { SourceLayerType } from './content'
 export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
+	/** @deprecated use INT/FLOAT instead */
 	NUMBER = 'number',
+	INT = 'int',
+	FLOAT = 'float',
 	BOOLEAN = 'boolean',
 	ENUM = 'enum',
 	TABLE = 'table',
@@ -19,6 +22,8 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryString
 	| ConfigManifestEntryMultilineString
 	| ConfigManifestEntryNumber
+	| ConfigManifestEntryInt
+	| ConfigManifestEntryFloat
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
 	| ConfigManifestEntrySelectFromOptions<true>
@@ -50,8 +55,25 @@ export interface ConfigManifestEntryMultilineString extends ConfigManifestEntryB
 	type: ConfigManifestEntryType.MULTILINE_STRING
 	defaultVal: string[]
 }
+/** @deprecated use INT/FLOAT instead */
 export interface ConfigManifestEntryNumber extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.NUMBER
+	defaultVal: number
+	/** Zero-based values will be stored in the database (and reported to blueprints) as values starting from 0, however,
+	 * 	when rendered in settings pages they will appear as value + 1
+	 */
+	zeroBased?: boolean
+}
+export interface ConfigManifestEntryInt extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.INT
+	defaultVal: number
+	/** Zero-based values will be stored in the database (and reported to blueprints) as values starting from 0, however,
+	 * 	when rendered in settings pages they will appear as value + 1
+	 */
+	zeroBased?: boolean
+}
+export interface ConfigManifestEntryFloat extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.FLOAT
 	defaultVal: number
 }
 export interface ConfigManifestEntryBoolean extends ConfigManifestEntryBase {

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -410,7 +410,7 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			name: 'Mapping Type',
 			includeInSummary: true,
 		},
-		{ id: 'index', type: ConfigManifestEntryType.INT, name: 'index', includeInSummary: true },
+		{ id: 'index', type: ConfigManifestEntryType.INT, name: 'index', includeInSummary: true, zeroBased: true },
 	],
 	[TSRDeviceType.CASPARCG]: [
 		{
@@ -520,6 +520,7 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			name: 'Channel',
 			optional: true,
 			includeInSummary: true,
+			zeroBased: true,
 		},
 	],
 	// TODO - add VMix?

--- a/packages/server-core-integration/src/lib/configManifest.ts
+++ b/packages/server-core-integration/src/lib/configManifest.ts
@@ -1,4 +1,3 @@
-
 export interface DeviceConfigManifest {
 	deviceConfig: ConfigManifestEntry[]
 	deviceOAuthFlow?: DeviceOAuthFlow
@@ -7,7 +6,9 @@ export interface DeviceConfigManifest {
 
 export interface SubDeviceConfigManifest {
 	defaultType: string
-	config: { [type: string]: SubDeviceConfigManifestEntry[] | ConfigManifestEntry[] }
+	config: {
+		[type: string]: SubDeviceConfigManifestEntry[] | ConfigManifestEntry[]
+	}
 }
 
 export interface DeviceOAuthFlow {
@@ -21,15 +22,23 @@ export enum ConfigManifestEntryType {
 	STRING = 'string',
 	MULTILINE_STRING = 'multiline_string',
 	BOOLEAN = 'boolean',
+	/** @deprecated use INT/FLOAT instead */
 	NUMBER = 'float',
 	FLOAT = 'float',
 	INT = 'int',
 	TABLE = 'table',
 	OBJECT = 'object',
-	ENUM = 'enum' // @todo: implement
+	ENUM = 'enum', // @todo: implement
 }
 
-export type ConfigManifestEntry = ConfigManifestEntryBase | TableConfigManifestEntry | ConfigManifestEnumEntry | SubDeviceConfigManifestEntry
+export type ConfigManifestEntry =
+	| ConfigManifestEntryBase
+	| ConfigManifestEnumEntry
+	| TableConfigManifestEntry
+	| ConfigManifestEnumEntry
+	| ConfigManifestIntEntry
+	| ConfigManifestFloatEntry
+	| SubDeviceConfigManifestEntry
 export interface ConfigManifestEntryBase {
 	id: string
 	name: string
@@ -38,7 +47,23 @@ export interface ConfigManifestEntryBase {
 	placeholder?: string
 	hint?: string
 }
-export interface ConfigManifestEnumEntry {
+export interface ConfigManifestEntryDefault extends ConfigManifestEntryBase {
+	type: Exclude<
+		ConfigManifestEntryType,
+		ConfigManifestEntryType.ENUM | ConfigManifestEntryType.INT | ConfigManifestEntryType.FLOAT
+	>
+}
+export interface ConfigManifestIntEntry extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.INT
+	/** Zero-based values will be stored in the database (and reported to blueprints) as values starting from 0, however,
+	 * 	when rendered in settings pages they will appear as value + 1
+	 */
+	zeroBased?: boolean
+}
+export interface ConfigManifestFloatEntry extends ConfigManifestEntryBase {
+	type: ConfigManifestEntryType.FLOAT
+}
+export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.ENUM
 	values: any // for enum
 }
@@ -62,7 +87,10 @@ export interface TableConfigManifestEntry extends ConfigManifestEntryBase {
 
 export type MappingsManifest = Record<string, MappingManifestEntry[]>
 
-export interface MappingManifestEntry extends ConfigManifestEntryBase {
+export interface MappingManifestEntryProps {
 	optional?: boolean
 	includeInSummary?: boolean
 }
+
+export type MappingManifestEntry = MappingManifestEntryProps &
+	(ConfigManifestEntryDefault | ConfigManifestEnumEntry | ConfigManifestIntEntry | ConfigManifestFloatEntry)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds a property to integer config manifest entries named `zeroBased`, which indicates that this is a value that should be stored in the databse as a value starting from 0, but makes more sense to show to the user as a value starting from 1. For example, an ATEM Aux makes more sense to show to the user as AUX 1->X than AUX 0-> Y.


* **What is the current behavior?** (You can also link to an open issue here)

Currently all numerical config values are displayed to the user as whatever is stored in the database, which is usually the value required by the consuming device/blueprint.


* **What is the new behavior (if this is a feature change)?**

Integer config fields for both blueprints and device manifests can be marked as `zeroBased`, meaning that if the user wants to, for example, map a layer to sisyfos fader 1, they can enter 1 into the UI and the value 0 will be stored in the database. The motivation here is to make the UI match the language used by devices. ie, the ATEM control software uses AUX 1, AUX 2, ME 1, ME 2 etc whereas Sofie currently will display these to the user as AUX 0, AUX 1, ME 0, ME 1.

This is configurable on a per-config basis, so devices like Quantel which use 0-based naming in their 1st-party products/UIs can be presented using the same language in Sofie.

* **Other information**:

This PR also marks the config manifest entry type `NUMBER` as deprecated in favour of `INT` and `FLOAT`. The reason for this is that `INT` and `FLOAT` have already been introduced previously, but `NUMBER` is inconsistently interpreted. If you use a `NUMBER` in a blueprint manifest, it will be treated as an integer. However, if a `NUMBER` is used in a device manifest, it will be treated as a float.

Moving to an explicit distinction between `INT` and `FLOAT` also means that the `zeroBased` property can be scoped to just integer values in the future. This would also make merging the various definitions for config manifests easier in the future, once `NUMBER` is removed. No functionality is changed by marking `NUMBER` as deprecated.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
