### PR TITLE
feat: add NextInfo panel

### DIFF
--- a/meteor/client/styles/shelf/nextInfoPanel.scss
+++ b/meteor/client/styles/shelf/nextInfoPanel.scss
@@ -3,7 +3,6 @@
 .next-info-panel {
 	position: absolute;
 	user-select: none;
-	text-align: center;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -11,5 +10,16 @@
 
 	.next-info-panel__segment {
 		font-weight: 500;
+	}
+
+	.next-info-panel__part {
+		&:before {
+			content: ' (';
+			display: inline;
+		}
+		&:after {
+			content: ')';
+			display: inline;
+		}
 	}
 }

--- a/meteor/client/styles/shelf/nextInfoPanel.scss
+++ b/meteor/client/styles/shelf/nextInfoPanel.scss
@@ -1,0 +1,15 @@
+@import '../colorScheme';
+
+.next-info-panel {
+	position: absolute;
+	user-select: none;
+	text-align: center;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin: 0.625rem;
+
+	.next-info-panel__segment {
+		font-weight: 500;
+	}
+}

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -25,6 +25,7 @@ import {
 	RundownLayoutAdLibRegionRole,
 	RundownLayoutId,
 	RundownLayoutPieceCountdown,
+	RundownLayoutNextInfo,
 } from '../../../lib/collections/RundownLayouts'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { PubSub } from '../../../lib/api/pubsub'
@@ -1196,6 +1197,128 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 			)
 		}
 
+		renderNextInfo(
+			item: RundownLayoutBase,
+			tab: RundownLayoutNextInfo,
+			index: number,
+			isRundownLayout: boolean,
+			isDashboardLayout: boolean
+		) {
+			const { t } = this.props
+			return (
+				<React.Fragment>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Name')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.name`}
+								obj={item}
+								type="text"
+								collection={RundownLayouts}
+								className="input text-input input-l"
+							/>
+						</label>
+					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Show segment name')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.showSegmentName`}
+								obj={item}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							/>
+						</label>
+					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Show part title')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.showPartTitle`}
+								obj={item}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							/>
+						</label>
+					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Hide for dynamically inserted parts')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={`filters.${index}.hideForDynamicallyInsertedParts`}
+								obj={item}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							/>
+						</label>
+					</div>
+					{isDashboardLayout && (
+						<React.Fragment>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('X')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.x`}
+										obj={item}
+										type="float"
+										collection={RundownLayouts}
+										className="input text-input input-l"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Y')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.y`}
+										obj={item}
+										type="float"
+										collection={RundownLayouts}
+										className="input text-input input-l"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Width')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.width`}
+										obj={item}
+										type="float"
+										collection={RundownLayouts}
+										className="input text-input input-l"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Scale')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.scale`}
+										obj={item}
+										type="float"
+										collection={RundownLayouts}
+										className="input text-input input-l"
+									/>
+								</label>
+							</div>
+						</React.Fragment>
+					)}
+				</React.Fragment>
+			)
+		}
+
 		renderElements(item: RundownLayoutBase) {
 			const { t } = this.props
 
@@ -1330,6 +1453,8 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 								? this.renderAdLibRegion(item, tab, index, isRundownLayout, isDashboardLayout)
 								: RundownLayoutsAPI.isPieceCountdown(tab)
 								? this.renderPieceCountdown(item, tab, index, isRundownLayout, isDashboardLayout)
+								: RundownLayoutsAPI.isNextInfo(tab)
+								? this.renderNextInfo(item, tab, index, isRundownLayout, isDashboardLayout)
 								: undefined}
 						</div>
 					))}

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -58,13 +58,16 @@ export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps
 				<span className="next-info-panel__name" style={style}>
 					{showAny && this.props.panel.name}{' '}
 				</span>
-				<span className="next-info-panel__segment" style={style}>
-					{segmentName}
-				</span>
-				<span className="next-info-panel__part" style={style}>
-					{segmentName && partTitle && ': '}
-					{partTitle}
-				</span>
+				{segmentName && (
+					<span className="next-info-panel__segment" style={style}>
+						{segmentName}
+					</span>
+				)}
+				{partTitle && (
+					<span className="next-info-panel__part" style={style}>
+						{partTitle}
+					</span>
+				)}
 			</div>
 		)
 	}

--- a/meteor/client/ui/Shelf/NextInfoPanel.tsx
+++ b/meteor/client/ui/Shelf/NextInfoPanel.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import ClassNames from 'classnames'
+import {
+	RundownLayoutBase,
+	DashboardLayoutNextInfo,
+	RundownLayoutNextInfo,
+} from '../../../lib/collections/RundownLayouts'
+import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
+import { dashboardElementPosition } from './DashboardPanel'
+import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
+import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
+import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { PartInstance, PartInstances } from '../../../lib/collections/PartInstances'
+import { Segment, Segments } from '../../../lib/collections/Segments'
+interface INextInfoPanelProps {
+	visible?: boolean
+	layout: RundownLayoutBase
+	panel: RundownLayoutNextInfo
+	playlist: RundownPlaylist
+}
+
+interface INextInfoPanelTrackedProps {
+	nextPartInstance?: PartInstance
+	nextSegment?: Segment
+}
+
+interface IState {}
+
+export class NextInfoPanelInner extends MeteorReactComponent<INextInfoPanelProps & INextInfoPanelTrackedProps, IState> {
+	constructor(props) {
+		super(props)
+		this.state = {}
+	}
+
+	render() {
+		const isDashboardLayout = RundownLayoutsAPI.isDashboardLayout(this.props.layout)
+		const showAny =
+			!this.props.panel.hideForDynamicallyInsertedParts ||
+			!this.props.nextPartInstance?.part.dynamicallyInsertedAfterPartId
+		const segmentName = showAny && this.props.panel.showSegmentName && this.props.nextSegment?.name
+		const partTitle = showAny && this.props.panel.showPartTitle && this.props.nextPartInstance?.part.title
+		const style = {
+			fontSize: isDashboardLayout ? ((this.props.panel as DashboardLayoutNextInfo).scale || 1) * 1.5 + 'em' : undefined,
+		}
+		return (
+			<div
+				className="next-info-panel"
+				style={_.extend(
+					isDashboardLayout
+						? dashboardElementPosition({ ...(this.props.panel as DashboardLayoutNextInfo), height: 1 })
+						: {},
+					{
+						visibility: this.props.visible ? 'visible' : 'hidden',
+					}
+				)}
+			>
+				<span className="next-info-panel__name" style={style}>
+					{showAny && this.props.panel.name}{' '}
+				</span>
+				<span className="next-info-panel__segment" style={style}>
+					{segmentName}
+				</span>
+				<span className="next-info-panel__part" style={style}>
+					{segmentName && partTitle && ': '}
+					{partTitle}
+				</span>
+			</div>
+		)
+	}
+}
+
+export const NextInfoPanel = withTracker<INextInfoPanelProps, IState, INextInfoPanelTrackedProps>(
+	(props: INextInfoPanelProps & INextInfoPanelTrackedProps) => {
+		let nextPartInstance: PartInstance | undefined = undefined
+		let nextSegment: Segment | undefined = undefined
+
+		if (props.playlist.nextPartInstanceId) {
+			nextPartInstance = PartInstances.findOne(props.playlist.nextPartInstanceId)
+		}
+		if (nextPartInstance) {
+			nextSegment = Segments.findOne(nextPartInstance.segmentId)
+		}
+		return { nextPartInstance, nextSegment }
+	},
+	(_data, props: INextInfoPanelProps, nextProps: INextInfoPanelProps) => {
+		return !_.isEqual(props, nextProps)
+	}
+)(NextInfoPanelInner)

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -17,6 +17,7 @@ import { BucketAdLibItem } from './RundownViewBuckets'
 import { IAdLibListItem } from './AdLibListItem'
 import { PieceUi } from '../SegmentTimeline/SegmentTimelineContainer'
 import { AdLibPieceUi } from './AdLibPanel'
+import { NextInfoPanel } from './NextInfoPanel'
 
 export interface IShelfDashboardLayoutProps {
 	rundownLayout: DashboardLayout
@@ -100,6 +101,14 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 						/>
 					) : RundownLayoutsAPI.isPieceCountdown(panel) ? (
 						<PieceCountdownPanel
+							key={panel._id}
+							panel={panel}
+							layout={rundownLayout}
+							playlist={props.playlist}
+							visible={true}
+						/>
+					) : RundownLayoutsAPI.isNextInfo(panel) ? (
+						<NextInfoPanel
 							key={panel._id}
 							panel={panel}
 							layout={rundownLayout}

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -11,6 +11,7 @@ import {
 	RundownLayoutAdLibRegion,
 	PieceDisplayStyle,
 	RundownLayoutPieceCountdown,
+	RundownLayoutNextInfo,
 } from '../collections/RundownLayouts'
 import { ShowStyleBaseId } from '../collections/ShowStyleBases'
 import * as _ from 'underscore'
@@ -52,6 +53,10 @@ export namespace RundownLayoutsAPI {
 
 	export function isPieceCountdown(element: RundownLayoutElementBase): element is RundownLayoutPieceCountdown {
 		return element.type === RundownLayoutElementType.PIECE_COUNTDOWN
+	}
+
+	export function isNextInfo(element: RundownLayoutElementBase): element is RundownLayoutNextInfo {
+		return element.type === RundownLayoutElementType.NEXT_INFO
 	}
 
 	export function adLibRegionToFilter(element: RundownLayoutAdLibRegion): RundownLayoutFilterBase {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -37,6 +37,7 @@ export enum RundownLayoutElementType {
 	EXTERNAL_FRAME = 'external_frame',
 	ADLIB_REGION = 'adlib_region',
 	PIECE_COUNTDOWN = 'piece_countdown',
+	NEXT_INFO = 'next_info',
 }
 
 export interface RundownLayoutElementBase {
@@ -69,6 +70,13 @@ export interface RundownLayoutAdLibRegion extends RundownLayoutElementBase {
 export interface RundownLayoutPieceCountdown extends RundownLayoutElementBase {
 	type: RundownLayoutElementType.PIECE_COUNTDOWN
 	sourceLayerIds: string[] | undefined
+}
+
+export interface RundownLayoutNextInfo extends RundownLayoutElementBase {
+	type: RundownLayoutElementType.NEXT_INFO
+	showSegmentName: boolean
+	showPartTitle: boolean
+	hideForDynamicallyInsertedParts: boolean
 }
 
 /**
@@ -115,6 +123,13 @@ export interface DashboardLayoutAdLibRegion extends RundownLayoutAdLibRegion {
 }
 
 export interface DashboardLayoutPieceCountdown extends RundownLayoutPieceCountdown {
+	x: number
+	y: number
+	width: number
+	scale: number
+}
+
+export interface DashboardLayoutNextInfo extends RundownLayoutNextInfo {
 	x: number
 	y: number
 	width: number


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A feature - new dashboard panel type.


* **What is the current behavior?** (You can also link to an open issue here)
No feature.


* **What is the new behavior (if this is a feature change)?**
This adds a new type of dashboard panel, called NextInfo panel. It displays a label consisting of: 
  - name of the panel
  - name of the next Segment (the segment that the next part(Instance) of the playlist belongs to)
  - title of the next Part

  It can be configured through the `RundownLayoutEditor` with the following custom options:
  - _Show segment name_
  - _Show part title_
  - _Hide for dynamically inserted parts_ - if the next part was inserted dynamically, the label will be hidden
  - _Scale_ - font size multiplier (instead of _Height_)

* **Other information**:
Screenshots:
![image](https://user-images.githubusercontent.com/9103996/113024028-936d6f80-9186-11eb-92e2-45099f98e650.png)
![image](https://user-images.githubusercontent.com/9103996/113024476-1262a800-9187-11eb-9f5c-545a6f767bd9.png)

  Formatting (brackets around part title etc.) could be customized with CSS.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
