### PR TITLE
feat: playout-gw atem clip uploading

### DIFF
--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -22,13 +22,13 @@ function consoleError(...args: any[]) {
 }
 export class AtemUploadScript {
 	private readonly connection: Atem
-	
+
 	constructor() {
 		this.connection = new Atem()
-		
+
 		this.connection.on('error', consoleError)
 	}
-	
+
 	public connect(ip: string): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			this.connection.once('connected', () => {
@@ -39,7 +39,7 @@ export class AtemUploadScript {
 			})
 		})
 	}
-	
+
 	public loadFile(fileUrl: string): Promise<Buffer> {
 		return new Promise<Buffer>((resolve, reject) => {
 			fs.readFile(fileUrl, (e, data) => {
@@ -49,39 +49,34 @@ export class AtemUploadScript {
 			})
 		})
 	}
-	public loadFiles(folder: string): Promise<Buffer[]> {
-		return new Promise<Buffer[]>(async (resolve, reject) => {
-			try {
-				const files = await fs.promises.readdir(folder)
-				consoleLog(files)
-				const loadBuffers = files.map(file => fs.promises.readFile(path.join(folder, file)))
-				const buffers = await Promise.all(loadBuffers)
-				
-				consoleLog('got files')
-				resolve(buffers)
-			} catch (e) {
-				console.error(e)
-				reject(e)
-			}
-		})
+	public async loadFiles(folder: string): Promise<Buffer[]> {
+		const files = await fs.promises.readdir(folder)
+		consoleLog(files)
+		const loadBuffers = files.map((file) => fs.promises.readFile(path.join(folder, file)))
+		const buffers = await Promise.all(loadBuffers)
+
+		consoleLog('got files')
+		return buffers
 	}
-	
+
 	public checkIfFileOrClipExistsOnAtem(fileName: string, stillOrClipIndex: number, type: AtemMediaPoolType): boolean {
 		consoleLog('got a file')
-		
+
 		const still = this.connection.state ? this.connection.state.media.stillPool[stillOrClipIndex] : undefined
 		const clip = this.connection.state ? this.connection.state.media.clipPool[stillOrClipIndex] : undefined
 		let pool: typeof still | typeof clip
 		if (type === AtemMediaPoolType.Still) pool = still
 		if (type === AtemMediaPoolType.Clip) pool = clip
-		
+
 		if (pool) {
 			consoleLog('has ' + type)
 			if (pool.isUsed) {
 				consoleLog(type + ' is used')
-				const comparisonName = fileName.substr(type === AtemMediaPoolType.Still ? -ATEM_MAX_FILENAME_LENGTH : -ATEM_MAX_CLIPNAME_LENGTH)
+				const comparisonName = fileName.substr(
+					type === AtemMediaPoolType.Still ? -ATEM_MAX_FILENAME_LENGTH : -ATEM_MAX_CLIPNAME_LENGTH
+				)
 				const poolName = 'fileName' in pool ? pool.fileName : pool.name
-				
+
 				if (poolName === comparisonName) {
 					consoleLog('name equals')
 					return true
@@ -96,7 +91,7 @@ export class AtemUploadScript {
 			throw Error('Atem appears to be missing ' + type)
 		}
 	}
-	
+
 	public async uploadStillToAtem(fileName: string, fileData: Buffer, stillIndex: number): Promise<void> {
 		fileName = fileName.substr(-ATEM_MAX_FILENAME_LENGTH) // cannot be longer than 63 chars
 		if (!this.checkIfFileOrClipExistsOnAtem(fileName, stillIndex, AtemMediaPoolType.Still)) {
@@ -107,7 +102,7 @@ export class AtemUploadScript {
 			consoleLog(fileName + ' does exist on ATEM')
 		}
 	}
-	public async uploadClipToAtem(name: string, fileData: Buffer[], clipIndex: number) {
+	public async uploadClipToAtem(name: string, fileData: Buffer[], clipIndex: number): Promise<void> {
 		name = name.substr(-ATEM_MAX_CLIPNAME_LENGTH) // cannot be longer than 43 chars
 		if (!this.checkIfFileOrClipExistsOnAtem(name, clipIndex, AtemMediaPoolType.Clip)) {
 			consoleLog(name + ' does not exist on ATEM')

--- a/packages/playout-gateway/src/atemUploader.ts
+++ b/packages/playout-gateway/src/atemUploader.ts
@@ -53,7 +53,7 @@ export class AtemUploadScript {
 		const files = await fs.promises.readdir(folder)
 		consoleLog(files)
 		const loadBuffers = files.map((file) => fs.promises.readFile(path.join(folder, file)))
-		const buffers = await Promise.all(loadBuffers)
+		const buffers = Promise.all(loadBuffers)
 
 		consoleLog('got files')
 		return buffers
@@ -66,7 +66,7 @@ export class AtemUploadScript {
 		const clip = this.connection.state ? this.connection.state.media.clipPool[stillOrClipIndex] : undefined
 		let pool: typeof still | typeof clip
 		if (type === AtemMediaPoolType.Still) pool = still
-		if (type === AtemMediaPoolType.Clip) pool = clip
+		else if (type === AtemMediaPoolType.Clip) pool = clip
 
 		if (pool) {
 			consoleLog('has ' + type)

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -606,7 +606,7 @@ export class TSRHandler {
 					const assets = (options as DeviceOptionsAtem).options.mediaPoolAssets
 					if (assets && assets.length > 0) {
 						try {
-							this.uploadFilesToAtem(assets.filter((asset) => _.isNumber(asset.position) && asset.path))
+							this.uploadFilesToAtem(device, assets.filter((asset) => _.isNumber(asset.position) && asset.path))
 						} catch (e) {
 							// don't worry about it.
 						}
@@ -725,25 +725,23 @@ export class TSRHandler {
 	 * // @todo: proper atem media management
 	 * /Balte - 22-08
 	 */
-	private uploadFilesToAtem(files: AtemMediaPoolAsset[]) {
+	private uploadFilesToAtem(device: DeviceContainer, files: AtemMediaPoolAsset[]) {
 		this.logger.info('try to load ' + JSON.stringify(files.map((f) => f.path).join(', ')) + ' to atem')
-		this.tsr.getDevices().forEach(async (device) => {
-			if (device.deviceType === DeviceType.ATEM) {
-				const options = device.deviceOptions.options as { host: string }
-				this.logger.info('options ' + JSON.stringify(options))
-				if (options && options.host) {
-					this.logger.info('uploading files to ' + options.host)
-					const process = cp.spawn(`node`, [`./dist/atemUploader.js`, options.host, JSON.stringify(files)])
-					process.stdout.on('data', (data) => this.logger.info(data.toString()))
-					process.stderr.on('data', (data) => this.logger.info(data.toString()))
-					process.on('close', () => {
-						process.removeAllListeners()
-					})
-				} else {
-					throw Error('ATEM host option not set')
-				}
+		if (device && device.deviceType === DeviceType.ATEM) {
+			const options = device.deviceOptions.options as { host: string }
+			this.logger.info('options ' + JSON.stringify(options))
+			if (options && options.host) {
+				this.logger.info('uploading files to ' + options.host)
+				const process = cp.spawn(`node`, [`./dist/atemUploader.js`, options.host, JSON.stringify(files)])
+				process.stdout.on('data', (data) => this.logger.info(data.toString()))
+				process.stderr.on('data', (data) => this.logger.info(data.toString()))
+				process.on('close', () => {
+					process.removeAllListeners()
+				})
+			} else {
+				throw Error('ATEM host option not set')
 			}
-		})
+		}
 	}
 	private async _removeDevice(deviceId: string): Promise<any> {
 		if (this._coreTsrHandlers[deviceId]) {

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -606,9 +606,7 @@ export class TSRHandler {
 					const assets = (options as DeviceOptionsAtem).options.mediaPoolAssets
 					if (assets && assets.length > 0) {
 						try {
-							this.uploadFilesToAtem(
-								assets.filter(asset => _.isNumber(asset.position) && asset.path)
-							)
+							this.uploadFilesToAtem(assets.filter((asset) => _.isNumber(asset.position) && asset.path))
 						} catch (e) {
 							// don't worry about it.
 						}
@@ -728,18 +726,14 @@ export class TSRHandler {
 	 * /Balte - 22-08
 	 */
 	private uploadFilesToAtem(files: AtemMediaPoolAsset[]) {
-		this.logger.info('try to load ' + JSON.stringify(files.map(f => f.path).join(', ')) + ' to atem')
+		this.logger.info('try to load ' + JSON.stringify(files.map((f) => f.path).join(', ')) + ' to atem')
 		this.tsr.getDevices().forEach(async (device) => {
 			if (device.deviceType === DeviceType.ATEM) {
 				const options = device.deviceOptions.options as { host: string }
 				this.logger.info('options ' + JSON.stringify(options))
 				if (options && options.host) {
 					this.logger.info('uploading files to ' + options.host)
-					const process = cp.spawn(`node`, [
-						`./dist/atemUploader.js`,
-						options.host,
-						JSON.stringify(files)
-					])
+					const process = cp.spawn(`node`, [`./dist/atemUploader.js`, options.host, JSON.stringify(files)])
 					process.stdout.on('data', (data) => this.logger.info(data.toString()))
 					process.stderr.on('data', (data) => this.logger.info(data.toString()))
 					process.on('close', () => {


### PR DESCRIPTION
Currently the playout-gateway can upload stills to the atem switcher, this PR adds clip uploading to that functionality.

Because the uploading functionality has matured a fair bit since the original implementation I've changed the uploading to upload all assets from a single process rather than spawn new processes for every upload. In addition this means the media is uploaded one after the other instead of all at once.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
