### PR TITLE
Feat: Layer name

### DIFF
--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -48,7 +48,7 @@ import { NotificationCenter, NoticeLevel, Notification } from '../../lib/notific
 function filterSourceLayers(
 	select: ConfigManifestEntrySourceLayers<true | false>,
 	layers: Array<{ name: string; value: string; type: SourceLayerType }>
-) {
+): Array<{ name: string; value: string; type: SourceLayerType }> {
 	if (select.filters && select.filters.sourceLayerTypes) {
 		const sourceLayerTypes = select.filters.sourceLayerTypes
 		return _.filter(layers, (layer) => {
@@ -62,21 +62,19 @@ function filterSourceLayers(
 function filterLayerMappings(
 	select: ConfigManifestEntryLayerMappings<true | false>,
 	mappings: { [key: string]: MappingsExt }
-) {
-	if (select.filters && select.filters.deviceTypes) {
-		const deviceTypes = select.filters.deviceTypes
-		return _.mapObject(mappings, (studioMappings) => {
-			return Object.keys(
-				_.pick(studioMappings, (mapping) => {
-					return deviceTypes.includes(mapping.device)
-				})
-			)
-		})
-	} else {
-		return _.mapObject(mappings, (studioMappings) => {
-			return Object.keys(studioMappings)
-		})
+): Array<{ name: string; value: string }> {
+	const deviceTypes = select.filters?.deviceTypes
+	const result: Array<{ name: string; value: string }> = []
+
+	for (const studioMappings of Object.values(mappings)) {
+		for (const [layerId, mapping] of Object.entries(studioMappings)) {
+			if (!deviceTypes || deviceTypes.includes(mapping.device)) {
+				result.push({ name: mapping.layerName ?? layerId, value: layerId })
+			}
+		}
 	}
+
+	return result
 }
 
 function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, DocClass extends DBInterface>(

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -69,7 +69,7 @@ function filterLayerMappings(
 	for (const studioMappings of Object.values(mappings)) {
 		for (const [layerId, mapping] of Object.entries(studioMappings)) {
 			if (!deviceTypes || deviceTypes.includes(mapping.device)) {
-				result.push({ name: mapping.layerName ?? layerId, value: layerId })
+				result.push({ name: mapping.layerName || layerId, value: layerId })
 			}
 		}
 	}

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -387,13 +387,7 @@ const StudioMappings = withTranslation()(
 							})}
 						>
 							<th className="settings-studio-device__name c3 notifications-s notifications-text">
-								{mapping.layerName ? (
-									<React.Fragment>
-										{mapping.layerName}&nbsp;({layerId})
-									</React.Fragment>
-								) : (
-									layerId
-								)}
+								{mapping.layerName ?? layerId}
 								{activeRoutes.existing[layerId] !== undefined ? (
 									<Tooltip
 										overlay={t('This layer is now rerouted by an active Route Set: {{routeSets}}', {

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -387,7 +387,13 @@ const StudioMappings = withTranslation()(
 							})}
 						>
 							<th className="settings-studio-device__name c3 notifications-s notifications-text">
-								{layerId}
+								{mapping.layerName ? (
+									<React.Fragment>
+										{mapping.layerName}&nbsp;({layerId})
+									</React.Fragment>
+								) : (
+									layerId
+								)}
 								{activeRoutes.existing[layerId] !== undefined ? (
 									<Tooltip
 										overlay={t('This layer is now rerouted by an active Route Set: {{routeSets}}', {

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -387,7 +387,7 @@ const StudioMappings = withTranslation()(
 							})}
 						>
 							<th className="settings-studio-device__name c3 notifications-s notifications-text">
-								{mapping.layerName ?? layerId}
+								{mapping.layerName || layerId}
 								{activeRoutes.existing[layerId] !== undefined ? (
 									<Tooltip
 										overlay={t('This layer is now rerouted by an active Route Set: {{routeSets}}', {
@@ -442,7 +442,8 @@ const StudioMappings = withTranslation()(
 													obj={this.props.studio}
 													type="text"
 													collection={Studios}
-													className="input text-input input-l"></EditAttribute>
+													className="input text-input input-l"
+												></EditAttribute>
 												<span className="text-s dimmed">{t('Human-readable name of the layer')}</span>
 											</label>
 										</div>

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -435,6 +435,19 @@ const StudioMappings = withTranslation()(
 										</div>
 										<div className="mod mvs mhs">
 											<label className="field">
+												{t('Layer Name')}
+												<EditAttribute
+													modifiedClassName="bghl"
+													attribute={'mappings.' + layerId + '.layerName'}
+													obj={this.props.studio}
+													type="text"
+													collection={Studios}
+													className="input text-input input-l"></EditAttribute>
+												<span className="text-s dimmed">{t('Human-readable name of the layer')}</span>
+											</label>
+										</div>
+										<div className="mod mvs mhs">
+											<label className="field">
 												{t('Device Type')}
 												<EditAttribute
 													modifiedClassName="bghl"

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -39,7 +39,7 @@
 	],
 	"dependencies": {
 		"moment": "2.29.1",
-		"timeline-state-resolver-types": "5.6.0-nightly-release31-20210322-163519-1a4031442.0",
+		"timeline-state-resolver-types": "5.7.0-nightly-release33-20210420-084209-a6d7970bf.0",
 		"tslib": "^2.1.0",
 		"underscore": "1.12.1"
 	}

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -521,6 +521,11 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			optional: true,
 			includeInSummary: true,
 		},
+		{
+			id: 'setLabelToLayerName',
+			type: ConfigManifestEntryType.BOOLEAN,
+			name: 'Set channel label to layer name',
+		},
 	],
 	// TODO - add VMix?
 }

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -6230,7 +6230,12 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^0.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
+
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -8790,10 +8795,10 @@ timeline-state-resolver-types@5.5.5:
   dependencies:
     tslib "^1.13.0"
 
-timeline-state-resolver-types@5.6.0-nightly-release31-20210322-163519-1a4031442.0:
-  version "5.6.0-nightly-release31-20210322-163519-1a4031442.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-5.6.0-nightly-release31-20210322-163519-1a4031442.0.tgz#7f870b8734f9b540cf2d49ed0c6e7eadd523e5c7"
-  integrity sha512-yXWK1R6HspbtL5TA0z6RcYCgLGPqOHSpFqtpl777FRnIoLhT3e04Nzjm+RwUHEbXXa8MeA1wnIXGTctrHUFXjQ==
+timeline-state-resolver-types@5.7.0-nightly-release33-20210420-084209-a6d7970bf.0:
+  version "5.7.0-nightly-release33-20210420-084209-a6d7970bf.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-5.7.0-nightly-release33-20210420-084209-a6d7970bf.0.tgz#ff5e6ae0c74643fddaf6745f0b6d40b4c5e11ef9"
+  integrity sha512-92pz79ZUPgaxbR3oU7T03QMcIX/WHKgpZ5YCKoS+W/dWFVSj3fAf3qfPUmcizC1dKb/XTTFLZszFCVo2bsciEw==
   dependencies:
     tslib "^1.13.0"
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds support for configuring the `layerName` of a mapping and uses it in the layer mapping dropdown in settings.

* **What is the current behavior?** (You can also link to an open issue here)

No feature.

* **What is the new behavior (if this is a feature change)?**

A setting is added to mapping settings to allow the input of a layer name, this name is then used instead of the layer Id in the mapping table.

![image](https://user-images.githubusercontent.com/10697525/113159638-acccf500-9234-11eb-97c5-56e8b070e3d8.png)


Additionally, where the layer mapping dropdown type is used in settings, the layer name will be used if it's available (here GFX Ident is displayed instead of `graphic_layer_ident`)

![image](https://user-images.githubusercontent.com/10697525/113159794-cc641d80-9234-11eb-8921-4171e7e218f6.png)


* **Other information**:

See https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/178 for information on how this is used on a device level.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
