### PR TITLE
Feat: Find last scripted piece on layer

### DIFF
--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -50,6 +50,7 @@ const getResolvedPiecesMock = getResolvedPieces as TgetResolvedPieces
 
 jest.mock('../postProcess')
 import { postProcessPieces } from '../postProcess'
+import { Pieces } from '../../../../lib/collections/Pieces'
 
 type TpostProcessPieces = jest.MockedFunction<typeof postProcessPieces>
 const postProcessPiecesMock = postProcessPieces as TpostProcessPieces
@@ -72,6 +73,16 @@ describe('Test blueprint api context', () => {
 				takeCount: i,
 				rehearsal: false,
 				part,
+			})
+
+			part.getPieces().forEach((p) => {
+				PieceInstances.insert({
+					_id: protectString(`${part._id}_piece_${p._id}`),
+					rundownId: rundown._id,
+					partInstanceId: protectString(`${part._id}_instance`),
+					playlistActivationId: activationId,
+					piece: p,
+				})
 			})
 
 			const count = ((i + 2) % 4) + 1 // Some consistent randomness
@@ -240,7 +251,7 @@ describe('Test blueprint api context', () => {
 					// Check the current part
 					cache.Playlist.update({ $set: { currentPartInstanceId: partInstanceIds[1] } })
 					expect(context.getPieceInstances('next')).toHaveLength(0)
-					expect(context.getPieceInstances('current')).toHaveLength(4)
+					expect(context.getPieceInstances('current')).toHaveLength(5)
 
 					// Now the next part
 					cache.Playlist.update({ $set: { currentPartInstanceId: null } })
@@ -572,6 +583,168 @@ describe('Test blueprint api context', () => {
 							pieceMetaDataFilter: { prop1: { $ne: 'hello' } },
 						})
 					).toMatchObject({ _id: pieceId0 })
+				})
+			})
+		})
+
+		describe('findLastScriptedPieceOnLayer', () => {
+			testInFiber('No Current Part', () => {
+				wrapWithCache((cache) => {
+					const { context, rundown, activationId } = getActionExecutionContext(cache)
+
+					// We need to push changes back to 'mongo' for these tests
+					waitForPromise(cache.saveAllToDatabase())
+
+					const sourceLayerIds = env.showStyleBase.sourceLayers.map((l) => l._id)
+					expect(sourceLayerIds).toHaveLength(2)
+
+					// No playback has begun, so nothing should happen
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[0])).toBeUndefined()
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[1])).toBeUndefined()
+				})
+			})
+
+			testInFiber('First Part', () => {
+				wrapWithCache((cache) => {
+					const { context, rundown, activationId } = getActionExecutionContext(cache)
+
+					// We need to push changes back to 'mongo' for these tests
+					waitForPromise(cache.saveAllToDatabase())
+
+					const segmentIds = cache.Segments.findFetch()
+						.sort((a, b) => a._rank - b._rank)
+						.map((s) => s._id)
+
+					const partInstances = cache.PartInstances.findFetch({ segmentId: segmentIds[0] }).sort(
+						(a, b) => a.part._rank - b.part._rank
+					)
+					expect(partInstances).toHaveLength(2)
+
+					const pieceInstances = cache.PieceInstances.findFetch({
+						partInstanceId: { $in: partInstances.map((p) => p._id) },
+					})
+					expect(pieceInstances).toHaveLength(10)
+
+					const sourceLayerIds = env.showStyleBase.sourceLayers.map((l) => l._id)
+					expect(sourceLayerIds).toHaveLength(2)
+
+					// Set Part 1 as current part
+					// as any to bypass readonly
+					;(cache.Playlist.doc.currentPartInstanceId as any) = partInstances[0]._id
+
+					const expectedPieceInstanceSourceLayer0 = pieceInstances.find(
+						(p) =>
+							p.partInstanceId === cache.Playlist.doc.currentPartInstanceId &&
+							p.piece.sourceLayerId === sourceLayerIds[0]
+					)
+					expect(expectedPieceInstanceSourceLayer0).not.toBeUndefined()
+
+					const expectedPieceSourceLayer0 = Pieces.findOne({
+						_id: expectedPieceInstanceSourceLayer0?.piece._id,
+					})
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[0])).toMatchObject({
+						_id: expectedPieceSourceLayer0?._id,
+					})
+
+					const expectedPieceInstanceSourceLayer1 = pieceInstances.find(
+						(p) =>
+							p.partInstanceId === cache.Playlist.doc.currentPartInstanceId &&
+							p.piece.sourceLayerId === sourceLayerIds[1]
+					)
+					expect(expectedPieceInstanceSourceLayer1).not.toBeUndefined()
+
+					const expectedPieceSourceLayer1 = Pieces.findOne({
+						_id: expectedPieceInstanceSourceLayer1?.piece._id,
+					})
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[1])).toMatchObject({
+						_id: expectedPieceSourceLayer1?._id,
+					})
+				})
+			})
+
+			testInFiber('First Part, Ignore Current Part', () => {
+				wrapWithCache((cache) => {
+					const { context, rundown, activationId } = getActionExecutionContext(cache)
+
+					// We need to push changes back to 'mongo' for these tests
+					waitForPromise(cache.saveAllToDatabase())
+
+					const segmentIds = cache.Segments.findFetch()
+						.sort((a, b) => a._rank - b._rank)
+						.map((s) => s._id)
+
+					const partInstances = cache.PartInstances.findFetch({ segmentId: segmentIds[0] }).sort(
+						(a, b) => a.part._rank - b.part._rank
+					)
+					expect(partInstances).toHaveLength(2)
+
+					const sourceLayerIds = env.showStyleBase.sourceLayers.map((l) => l._id)
+					expect(sourceLayerIds).toHaveLength(2)
+
+					// Set Part 1 as current part
+					// as any to bypass readonly
+					;(cache.Playlist.doc.currentPartInstanceId as any) = partInstances[0]._id
+
+					expect(
+						context.findLastScriptedPieceOnLayer(sourceLayerIds[0], { excludeCurrentPart: true })
+					).toBeUndefined()
+				})
+			})
+
+			testInFiber('Second Part', () => {
+				wrapWithCache((cache) => {
+					const { context, rundown, activationId } = getActionExecutionContext(cache)
+
+					// We need to push changes back to 'mongo' for these tests
+					waitForPromise(cache.saveAllToDatabase())
+
+					const segmentIds = cache.Segments.findFetch()
+						.sort((a, b) => a._rank - b._rank)
+						.map((s) => s._id)
+
+					const partInstances = cache.PartInstances.findFetch({ segmentId: segmentIds[0] }).sort(
+						(a, b) => a.part._rank - b.part._rank
+					)
+					expect(partInstances).toHaveLength(2)
+
+					const pieceInstances = cache.PieceInstances.findFetch({
+						partInstanceId: { $in: partInstances.map((p) => p._id) },
+					})
+					expect(pieceInstances).toHaveLength(10)
+
+					const sourceLayerIds = env.showStyleBase.sourceLayers.map((l) => l._id)
+					expect(sourceLayerIds).toHaveLength(2)
+
+					// Set Part 2 as current part
+					// as any to bypass readonly
+					;(cache.Playlist.doc.currentPartInstanceId as any) = partInstances[1]._id
+
+					const expectedPieceInstanceSourceLayer0 = pieceInstances.find(
+						(p) =>
+							p.partInstanceId === cache.Playlist.doc.currentPartInstanceId &&
+							p.piece.sourceLayerId === sourceLayerIds[0]
+					)
+					expect(expectedPieceInstanceSourceLayer0).not.toBeUndefined()
+
+					const expectedPieceSourceLayer0 = Pieces.findOne({
+						_id: expectedPieceInstanceSourceLayer0?.piece._id,
+					})
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[0])).toMatchObject({
+						_id: expectedPieceSourceLayer0?._id,
+					})
+
+					// Part 2 does not have any pieces on this sourcelayer, so we should find the piece from part 1
+					const expectedPieceInstanceSourceLayer1 = pieceInstances.find(
+						(p) => p.partInstanceId === partInstances[0]._id && p.piece.sourceLayerId === sourceLayerIds[1]
+					)
+					expect(expectedPieceInstanceSourceLayer0).not.toBeUndefined()
+
+					const expectedPieceSourceLayer1 = Pieces.findOne({
+						_id: expectedPieceInstanceSourceLayer1?.piece._id,
+					})
+					expect(context.findLastScriptedPieceOnLayer(sourceLayerIds[1])).toMatchObject({
+						_id: expectedPieceSourceLayer1?._id,
+					})
 				})
 			})
 		})

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -803,6 +803,64 @@ describe('Test blueprint api context', () => {
 			})
 		})
 
+		describe('getPartForPreviousPiece', () => {
+			testInFiber('invalid parameters', () => {
+				wrapWithCache((cache) => {
+					const { context } = getActionExecutionContext(cache)
+
+					// @ts-ignore
+					expect(() => context.getPartForPreviousPiece()).toThrowError('Cannot find Part from invalid Piece')
+					// @ts-ignore
+					expect(() => context.getPartForPreviousPiece({})).toThrowError(
+						'Cannot find Part from invalid Piece'
+					)
+					// @ts-ignore
+					expect(() => context.getPartForPreviousPiece('abc')).toThrowError(
+						'Cannot find Part from invalid Piece'
+					)
+					expect(() =>
+						context.getPartForPreviousPiece({
+							// @ts-ignore
+							partInstanceId: 6,
+						})
+					).toThrowError('Cannot find Part from invalid Piece')
+					expect(() =>
+						// @ts-ignore
+						context.getPartForPreviousPiece({
+							_id: 'abc',
+						})
+					).toThrowError('Cannot find Piece abc')
+				})
+			})
+
+			testInFiber('valid parameters', () => {
+				wrapWithCache((cache) => {
+					const { context } = getActionExecutionContext(cache)
+
+					const partInstances = cache.PartInstances.findFetch({})
+					expect(partInstances).toHaveLength(5)
+
+					const pieceInstance0 = cache.PieceInstances.findOne({ partInstanceId: partInstances[0]._id })
+					expect(pieceInstance0).not.toBeUndefined()
+
+					expect(
+						context.getPartForPreviousPiece({ _id: unprotectString(pieceInstance0!.piece._id) })
+					).toMatchObject({
+						_id: partInstances[0].part._id,
+					})
+
+					const pieceInstance1 = cache.PieceInstances.findOne({ partInstanceId: partInstances[1]._id })
+					expect(pieceInstance1).not.toBeUndefined()
+
+					expect(
+						context.getPartForPreviousPiece({ _id: unprotectString(pieceInstance1!.piece._id) })
+					).toMatchObject({
+						_id: partInstances[1].part._id,
+					})
+				})
+			})
+		})
+
 		describe('insertPiece', () => {
 			beforeEach(() => {
 				postProcessPiecesMock.mockClear()

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -217,7 +217,10 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			throw new Error('Cannot find Part from invalid Piece')
 		}
 
-		const pieceDB = Pieces.findOne({ _id: protectString(piece._id) })
+		const pieceDB = Pieces.findOne({
+			_id: protectString(piece._id),
+			startRundownId: { $in: this._cache.Playlist.doc.getRundownIDs() },
+		})
 		if (!pieceDB) throw new Error(`Cannot find Piece ${piece._id}`)
 
 		return Parts.findOne({ _id: pieceDB.startPartId })

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -155,7 +155,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 	}
 
 	findLastScriptedPieceOnLayer(
-		sourceLayerId: string,
+		sourceLayerId0: string | string[],
 		options?: {
 			excludeCurrentPart?: boolean
 			pieceMetaDataFilter?: any
@@ -166,19 +166,21 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			for (const [key, value] of Object.entries(options.pieceMetaDataFilter)) {
 				// TODO do we need better validation here?
 				// It should be pretty safe as we are working with the cache version (for now)
-				query[`piece.metaData.${key}`] = value
+				query[`metaData.${key}`] = value
 			}
 		}
 
 		if (options && options.excludeCurrentPart && this._cache.Playlist.doc.currentPartInstanceId) {
 			const currentPartInstance = this._cache.PartInstances.findOne(
-				(p) => p._id === this._cache.Playlist.doc.currentPartInstanceId
+				this._cache.Playlist.doc.currentPartInstanceId
 			)
 
 			if (currentPartInstance) {
 				query['startPartId'] = { $ne: currentPartInstance.part._id }
 			}
 		}
+
+		const sourceLayerId = Array.isArray(sourceLayerId0) ? sourceLayerId0 : [sourceLayerId0]
 
 		const lastPiece = ServerPlayoutAdLibAPI.innerFindLastScriptedPieceOnLayer(this._cache, sourceLayerId, query)
 

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -9,6 +9,7 @@ import {
 	getRandomId,
 	protectStringArray,
 	waitForPromise,
+	UnprotectedStringProperties,
 } from '../../../../lib/lib'
 import { Part, Parts } from '../../../../lib/collections/Parts'
 import { logger } from '../../../../lib/logging'
@@ -209,9 +210,13 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		}
 	}
 
-	getPartForPreviousPiece(piece: IBlueprintPieceDB): IBlueprintPart | undefined {
+	getPartForPreviousPiece(piece: UnprotectedStringProperties<Pick<Piece, '_id'>>): IBlueprintPart | undefined {
+		if (!piece?._id) {
+			throw new Error('Cannot find Part from invalid Piece')
+		}
+
 		const pieceDB = Pieces.findOne({ _id: protectString(piece._id) })
-		if (!pieceDB) throw new Error(`Cannot find piece ${piece._id}`)
+		if (!pieceDB) throw new Error(`Cannot find Piece ${piece._id}`)
 
 		return Parts.findOne({ _id: pieceDB.startPartId })
 	}

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -219,7 +219,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 
 		const pieceDB = Pieces.findOne({
 			_id: protectString(piece._id),
-			startRundownId: { $in: this._cache.Playlist.doc.getRundownIDs() },
+			startRundownId: { $in: getRundownIDsFromCache(this._cache) },
 		})
 		if (!pieceDB) throw new Error(`Cannot find Piece ${piece._id}`)
 

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -10,7 +10,7 @@ import {
 	protectStringArray,
 	waitForPromise,
 } from '../../../../lib/lib'
-import { Part } from '../../../../lib/collections/Parts'
+import { Part, Parts } from '../../../../lib/collections/Parts'
 import { logger } from '../../../../lib/logging'
 import {
 	IEventContext,
@@ -22,6 +22,7 @@ import {
 	IBlueprintResolvedPieceInstance,
 	OmitId,
 	IBlueprintMutatablePart,
+	IBlueprintPieceDB,
 } from '@sofie-automation/blueprints-integration'
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { RundownPlaylistActivationId } from '../../../../lib/collections/RundownPlaylists'
@@ -39,7 +40,7 @@ import { Meteor } from 'meteor/meteor'
 import { CacheForPlayout, getRundownIDsFromCache } from '../../playout/cache'
 import { ShowStyleCompound } from '../../../../lib/collections/ShowStyleVariants'
 import { ServerPlayoutAPI } from '../../playout/playout'
-import { Piece } from '../../../../lib/collections/Pieces'
+import { Piece, Pieces } from '../../../../lib/collections/Pieces'
 
 export enum ActionPartChange {
 	NONE = 0,
@@ -158,7 +159,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			excludeCurrentPart?: boolean
 			pieceMetaDataFilter?: any
 		}
-	): IBlueprintPiece | undefined {
+	): IBlueprintPieceDB | undefined {
 		const query: MongoQuery<Piece> = {}
 		if (options && options.pieceMetaDataFilter) {
 			for (const [key, value] of Object.entries(options.pieceMetaDataFilter)) {
@@ -206,6 +207,13 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		} else {
 			throw new Error('Cannot find PartInstance for PieceInstance')
 		}
+	}
+
+	getPartForPreviousPiece(piece: IBlueprintPieceDB): IBlueprintPart | undefined {
+		const pieceDB = Pieces.findOne({ _id: protectString(piece._id) })
+		if (!pieceDB) throw new Error(`Cannot find piece ${piece._id}`)
+
+		return Parts.findOne({ _id: pieceDB.startPartId })
 	}
 
 	insertPiece(part: 'current' | 'next', rawPiece: IBlueprintPiece): IBlueprintPieceInstance {

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -433,9 +433,8 @@ export namespace ServerPlayoutAdLibAPI {
 
 		const query = {
 			...customQuery,
-			playlistActivationId: cache.Playlist.doc.activationId,
 			startRundownId: { $in: rundownIds },
-			'piece.sourceLayerId': sourceLayerId,
+			sourceLayerId,
 		}
 
 		if (span) span.end()

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -128,8 +128,9 @@ export interface IActionExecutionContext extends IShowStyleUserContext, IEventCo
 			pieceMetaDataFilter?: any // Mongo query against properties inside of piece.metaData
 		}
 	): IBlueprintPieceInstance | undefined
+	/** Get the previous scripted piece on a given layer, looking backwards from the current part. */
 	findLastScriptedPieceOnLayer(
-		sourceLayerId: string,
+		sourceLayerId: string | string[],
 		options?: {
 			excludeCurrentPart?: boolean
 			pieceMetaDataFilter?: any

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -128,6 +128,13 @@ export interface IActionExecutionContext extends IShowStyleUserContext, IEventCo
 			pieceMetaDataFilter?: any // Mongo query against properties inside of piece.metaData
 		}
 	): IBlueprintPieceInstance | undefined
+	findLastScriptedPieceOnLayer(
+		sourceLayerId: string,
+		options?: {
+			excludeCurrentPart?: boolean
+			pieceMetaDataFilter?: any
+		}
+	): IBlueprintPiece | undefined
 	/** Gets the PartInstance for a PieceInstane retrieved from findLastPieceOnLayer. This primarily allows for accessing metadata of the PartInstance */
 	getPartInstanceForPreviousPiece(piece: IBlueprintPieceInstance): IBlueprintPartInstance
 	/** Fetch the showstyle config for the specified part */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds a pair of functions to allow adLib actions to look backwards in the script from the current point to find the last *scripted* piece on a layer as apposed to the last played piece.

* **What is the current behavior?** (You can also link to an open issue here)

AdLib actions can only find the last played piece.

* **What is the new behavior (if this is a feature change)?**

AdLib actions can call `findLastScriptedPieceOnLayer` which will look backwards from the current part to find the piece on a given sourcelayer that appears closest to the current part. The use case for this is, for example, a producer is on a VT going into an interview over a Live feed, but the interviewee is not ready yet. The producer chooses to skip over the scripted Live to the Camera after it. When the interviewee is ready they press a button which runs an adLib action to find the last scripted Live and cut to it. In this case the live never started playing, so the current implementation of `findLastPieceOnLayer` would not find it.

This PR also adds the function `getPartForPreviousPiece` as a counterpart to `getPartInstanceForPreviousPiece`, allowing the part associated with the found piece to be fetched. This allows e.g. the adLib action to create a new part with the same title.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
