### PR TITLE
Various fixes from TV 2 for Release 33

### DIFF
--- a/meteor/client/lib/StyledTimecode.tsx
+++ b/meteor/client/lib/StyledTimecode.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ClassNames from 'classnames'
 import { Time, formatDurationAsTimecode } from '../../lib/lib'
 
 interface IProps {
@@ -11,12 +12,21 @@ const FRAMES_INLINE_STYLE: React.CSSProperties = {
 
 export function StyledTimecode({ time: time }: IProps) {
 	const timecode = formatDurationAsTimecode(time)
-	const hoursMinutesSeconds = timecode.substring(0, 8)
+	const hours = timecode.substring(0, 3)
+	const minutesSeconds = timecode.substring(3, 8)
 	const frames = timecode.substring(8)
 	return (
 		<>
-			{hoursMinutesSeconds}
-			<span style={FRAMES_INLINE_STYLE}>{frames}</span>
+			<span
+				className={ClassNames('styled-timecode__hours', {
+					'zero-hours': hours === '00:',
+				})}>
+				{hours}
+			</span>
+			{minutesSeconds}
+			<span className="styled-timecode__frames" style={FRAMES_INLINE_STYLE}>
+				{frames}
+			</span>
 		</>
 	)
 }

--- a/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/L3rdFloatingInspector.tsx
@@ -100,7 +100,7 @@ export const L3rdFloatingInspector: React.FunctionComponent<IProps> = ({
 								<span className="mini-inspector__in-point">
 									{RundownUtils.formatTimeToShortTime(pieceRenderedIn || 0)}
 								</span>
-								{innerPiece.lifespan ? (
+								{!pieceRenderedDuration && !innerPiece.enable.duration ? (
 									(innerPiece.lifespan === PieceLifespan.WithinPart && (
 										<span className="mini-inspector__duration">{t('Until next take')}</span>
 									)) ||

--- a/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/VTFloatingInspector.tsx
@@ -11,6 +11,7 @@ import { StyledTimecode } from '../../lib/StyledTimecode'
 import { ScanInfoForPackages } from '../../../lib/mediaObjects'
 import { Studio } from '../../../lib/collections/Studios'
 import { getPreviewPackageSettings } from '../../../lib/collections/ExpectedPackages'
+import { ensureHasTrailingSlash } from '../../lib/lib'
 
 interface IProps {
 	mediaPreviewUrl?: string
@@ -73,7 +74,7 @@ function getMediaPreviewUrl(
 ): string | undefined {
 	const metadata = contentMetaData
 	if (metadata && metadata.previewPath && mediaPreviewUrl) {
-		return mediaPreviewUrl + 'media/preview/' + encodeURIComponent(metadata.mediaId)
+		return ensureHasTrailingSlash(mediaPreviewUrl) + 'media/preview/' + encodeURIComponent(metadata.mediaId)
 	}
 }
 

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1836,63 +1836,65 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		}
 
 		componentDidUpdate(prevProps: IProps & ITrackedProps, prevState: IState) {
-			if (
-				this.props.playlist &&
-				prevProps.playlist &&
-				prevProps.playlist.currentPartInstanceId !== this.props.playlist.currentPartInstanceId &&
-				this.state.manualSetAsNext
-			) {
-				// reset followLiveSegments after a manual set as next
-				this.setState({
-					manualSetAsNext: false,
-					followLiveSegments: true,
-				})
-				if (this.props.playlist.currentPartInstanceId) {
+			if (!this.props.onlyShelf) {
+				if (
+					this.props.playlist &&
+					prevProps.playlist &&
+					prevProps.playlist.currentPartInstanceId !== this.props.playlist.currentPartInstanceId &&
+					this.state.manualSetAsNext
+				) {
+					// reset followLiveSegments after a manual set as next
+					this.setState({
+						manualSetAsNext: false,
+						followLiveSegments: true,
+					})
+					if (this.props.playlist.currentPartInstanceId) {
+						scrollToPartInstance(this.props.playlist.currentPartInstanceId, true).catch((error) => {
+							if (!error.toString().match(/another scroll/)) console.warn(error)
+						})
+					}
+				} else if (
+					this.props.playlist &&
+					prevProps.playlist &&
+					prevProps.playlist.activationId &&
+					!this.props.playlist.activationId
+				) {
+					// reset followLiveSegments after deactivating a rundown
+					this.setState({
+						followLiveSegments: true,
+					})
+				} else if (
+					this.props.playlist &&
+					prevProps.playlist &&
+					!prevProps.playlist.activationId &&
+					this.props.playlist.activationId &&
+					this.props.playlist.nextPartInstanceId
+				) {
+					// scroll to next after activation
+					scrollToPartInstance(this.props.playlist.nextPartInstanceId).catch((error) => {
+						if (!error.toString().match(/another scroll/)) console.warn(error)
+					})
+				} else if (
+					// after take
+					this.props.playlist &&
+					prevProps.playlist &&
+					this.props.playlist.currentPartInstanceId !== prevProps.playlist.currentPartInstanceId &&
+					this.props.playlist.currentPartInstanceId &&
+					this.state.followLiveSegments
+				) {
 					scrollToPartInstance(this.props.playlist.currentPartInstanceId, true).catch((error) => {
 						if (!error.toString().match(/another scroll/)) console.warn(error)
 					})
+				} else if (
+					// initial Rundown open
+					this.props.playlist &&
+					this.props.playlist.currentPartInstanceId &&
+					this.state.subsReady &&
+					!prevState.subsReady
+				) {
+					// allow for some time for the Rundown to render
+					maintainFocusOnPartInstance(this.props.playlist.currentPartInstanceId, 7000, true, true)
 				}
-			} else if (
-				this.props.playlist &&
-				prevProps.playlist &&
-				prevProps.playlist.activationId &&
-				!this.props.playlist.activationId
-			) {
-				// reset followLiveSegments after deactivating a rundown
-				this.setState({
-					followLiveSegments: true,
-				})
-			} else if (
-				this.props.playlist &&
-				prevProps.playlist &&
-				!prevProps.playlist.activationId &&
-				this.props.playlist.activationId &&
-				this.props.playlist.nextPartInstanceId
-			) {
-				// scroll to next after activation
-				scrollToPartInstance(this.props.playlist.nextPartInstanceId).catch((error) => {
-					if (!error.toString().match(/another scroll/)) console.warn(error)
-				})
-			} else if (
-				// after take
-				this.props.playlist &&
-				prevProps.playlist &&
-				this.props.playlist.currentPartInstanceId !== prevProps.playlist.currentPartInstanceId &&
-				this.props.playlist.currentPartInstanceId &&
-				this.state.followLiveSegments
-			) {
-				scrollToPartInstance(this.props.playlist.currentPartInstanceId, true).catch((error) => {
-					if (!error.toString().match(/another scroll/)) console.warn(error)
-				})
-			} else if (
-				// initial Rundown open
-				this.props.playlist &&
-				this.props.playlist.currentPartInstanceId &&
-				this.state.subsReady &&
-				!prevState.subsReady
-			) {
-				// allow for some time for the Rundown to render
-				maintainFocusOnPartInstance(this.props.playlist.currentPartInstanceId, 7000, true, true)
 			}
 
 			if (

--- a/meteor/client/ui/Settings/StudioSettings.tsx
+++ b/meteor/client/ui/Settings/StudioSettings.tsx
@@ -391,7 +391,7 @@ const StudioMappings = withTranslation()(
 								{activeRoutes.existing[layerId] !== undefined ? (
 									<Tooltip
 										overlay={t('This layer is now rerouted by an active Route Set: {{routeSets}}', {
-											routeSets: activeRoutes.existing[layerId].join(', '),
+											routeSets: activeRoutes.existing[layerId].map((s) => s.outputMappedLayer).join(', '),
 											count: activeRoutes.existing[layerId].length,
 										})}
 										placement="right"

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -825,6 +825,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 
 					rundownBaselineAdLibs = rundownBaselineAdLibs
 						.concat(globalAdLibActions)
+						.sort((a, b) => a._rank - b._rank)
 						.map((item) => {
 							// automatically assign hotkeys based on adLibItem index
 							const uiAdLib: AdLibPieceUi = _.clone(item)
@@ -851,7 +852,6 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 							// always add them to the list
 							return uiAdLib
 						})
-						.sort((a, b) => a._rank - b._rank)
 
 					return rundownBaselineAdLibs.sort((a, b) => a._rank - b._rank)
 				},

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -29,6 +29,7 @@ import { protectString } from '../../../lib/lib'
 import { Studio } from '../../../lib/collections/Studios'
 import { withMediaObjectStatus } from '../SegmentTimeline/withMediaObjectStatus'
 import { getThumbnailPackageSettings } from '../../../lib/collections/ExpectedPackages'
+import { ensureHasTrailingSlash } from '../../lib/lib'
 
 export interface IDashboardButtonProps {
 	piece: IAdLibListItem
@@ -135,7 +136,11 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 			// Fallback to media objects
 			if (this.props.mediaPreviewUrl && piece.contentMetaData) {
 				if (piece.contentMetaData && piece.contentMetaData.previewPath && this.props.mediaPreviewUrl) {
-					return this.props.mediaPreviewUrl + 'media/thumbnail/' + encodeURIComponent(piece.contentMetaData.mediaId)
+					return (
+						ensureHasTrailingSlash(this.props.mediaPreviewUrl) +
+						'media/thumbnail/' +
+						encodeURIComponent(piece.contentMetaData.mediaId)
+					)
 				}
 			}
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR encompasses a number of fixes including:
- Removing an `[object Object]` message displayed in the mapping settings when a route set is active.
- Fix a bug where graphic duration does not get displayed in `L3rdFloatingInspector`.
- Prevent attempts to scroll to segments/focus parts when in a shelf-only view of a rundown.
- Sort global adLibs by rank before assigning shortcuts in adLib panels.
- Ensure `mediaPreviewUrl` has a trailing slash before using it to get a preview/thumbnail URL.
- Wrap some aspects of `StyledTimecode` in `<span>` tags with class names to allow styling of timecode by custom CSS at TV 2 (does not affect how timecode is displayed for NRK).

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
