### PR TITLE
feat: Add duplicate AdLibs filtering

### DIFF
--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -127,6 +127,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 						rank: 0,
 						rundownBaseline: false,
 						showThumbnailsInList: false,
+						hideDuplicates: false,
 						default: false,
 					}),
 				},
@@ -771,6 +772,19 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 									<EditAttribute
 										modifiedClassName="bghl"
 										attribute={`filters.${index}.toggleOnSingleClick`}
+										obj={item}
+										type="checkbox"
+										collection={RundownLayouts}
+										className="mod mas"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Hide duplicated AdLibs')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.hideDuplicates`}
 										obj={item}
 										type="checkbox"
 										collection={RundownLayouts}

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -790,6 +790,9 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 										collection={RundownLayouts}
 										className="mod mas"
 									/>
+									<span className="text-s dimmed">
+										{t('Picks the first instance of an adLib per rundown, identified by uniqueness Id')}
+									</span>
 								</label>
 							</div>
 						</React.Fragment>

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -172,7 +172,6 @@ export function matchFilter(
 		// Scope of the filter is determined by the scope of the uniquenessIds set (typically rundown-wide).
 		if (filter.hideDuplicates && uniquenessIds) {
 			const uniquenessId = item.uniquenessId || unprotectString(item._id)
-			console.log(uniquenessId)
 			if (uniquenessIds.has(uniquenessId)) {
 				return false
 			} else {

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -266,15 +266,17 @@ const AdLibListView = withTranslation()(
 				<tbody className="adlib-panel__list-view__list__segment adlib-panel__list-view__item__rundown-baseline">
 					{this.props.rundownAdLibs &&
 						this.props.rundownAdLibs
-							.filter((item) =>
-								matchFilter(
-									item,
-									this.props.showStyleBase,
-									this.props.uiSegments,
-									this.props.filter,
-									this.props.searchFilter,
-									uniquenessIds
-								)
+							.filter(
+								(item) =>
+									!item.isHidden &&
+									matchFilter(
+										item,
+										this.props.showStyleBase,
+										this.props.uiSegments,
+										this.props.filter,
+										this.props.searchFilter,
+										uniquenessIds
+									)
 							)
 							.map((adLibPiece: AdLibPieceUi) => (
 								<AdLibListItem

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -92,6 +92,15 @@ interface IListViewStateHeader {
 	}
 }
 
+/**
+ * Applies a filter to an adLib to determine whether it matches filter criteria.
+ * @param item AdLib to test against filter.
+ * @param showStyleBase
+ * @param uiSegments All segments to search for live segment.
+ * @param filter Filter to match against.
+ * @param searchFilter Text to try to match against adLib label.
+ * @param uniquenessIds Set of uniquenessIds, for a given set only one adLib per uniquness Id will be matched by this filter.
+ */
 export function matchFilter(
 	item: AdLibPieceUi,
 	showStyleBase: ShowStyleBase,
@@ -159,6 +168,8 @@ export function matchFilter(
 			return false
 		}
 		// Hide duplicates
+		// Only the first adLib found with a given uniquenessId will be displayed if this option is enabled.
+		// Scope of the filter is determined by the scope of the uniquenessIds set (typically rundown-wide).
 		if (filter.hideDuplicates && uniquenessIds) {
 			const uniquenessId = item.uniquenessId || unprotectString(item._id)
 			console.log(uniquenessId)

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -251,10 +251,16 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		this.usedHotkeys.length = 0
 	}
 
-	protected static filterOutAdLibs(props: IAdLibPanelProps & AdLibFetchAndFilterProps, state: IState): AdLibPieceUi[] {
+	protected static filterOutAdLibs(
+		props: IAdLibPanelProps & AdLibFetchAndFilterProps,
+		state: IState,
+		uniquenessIds?: Set<string>
+	): AdLibPieceUi[] {
 		return props.rundownBaselineAdLibs
 			.concat(props.uiSegments.map((seg) => seg.pieces).flat())
-			.filter((item) => matchFilter(item, props.showStyleBase, props.uiSegments, props.filter, state.searchFilter))
+			.filter((item) =>
+				matchFilter(item, props.showStyleBase, props.uiSegments, props.filter, state.searchFilter, uniquenessIds)
+			)
 	}
 
 	protected isAdLibOnAir(adLib: AdLibPieceUi) {
@@ -569,7 +575,8 @@ export class DashboardPanelInner extends MeteorReactComponent<
 
 	render() {
 		const { t } = this.props
-		const filteredAdLibs = DashboardPanelInner.filterOutAdLibs(this.props, this.state)
+		const uniquenessIds = new Set<string>()
+		const filteredAdLibs = DashboardPanelInner.filterOutAdLibs(this.props, this.state, uniquenessIds)
 		if (this.props.visible && this.props.showStyleBase && this.props.filter) {
 			const filter = this.props.filter as DashboardLayoutFilter
 			if (!this.props.uiSegments || !this.props.playlist) {

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -356,6 +356,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 					_rank: action.display._rank || 0,
 					content: content,
 					adlibAction: action,
+					uniquenessId: action.display.uniquenessId,
 				})
 			})
 

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -88,6 +88,7 @@ export const TimelineDashboardPanel = translateWithTracker<
 		render() {
 			if (this.props.visible && this.props.showStyleBase && this.props.filter) {
 				const filter = this.props.filter as DashboardLayoutFilter
+				const uniquenessIds = new Set<string>()
 				if (!this.props.uiSegments || !this.props.playlist) {
 					return <Spinner />
 				} else {
@@ -97,7 +98,8 @@ export const TimelineDashboardPanel = translateWithTracker<
 							this.props.showStyleBase,
 							this.props.uiSegments,
 							this.props.filter,
-							this.state.searchFilter
+							this.state.searchFilter,
+							uniquenessIds
 						)
 					)
 
@@ -155,7 +157,8 @@ export const TimelineDashboardPanel = translateWithTracker<
 													this.props.showStyleBase,
 													this.props.uiSegments,
 													this.props.filter,
-													this.state.searchFilter
+													this.state.searchFilter,
+													uniquenessIds
 												)
 										  )
 										: []

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -66,6 +66,7 @@ export namespace RundownLayoutsAPI {
 			displayStyle: PieceDisplayStyle.BUTTONS,
 			currentSegment: false,
 			showThumbnailsInList: false,
+			hideDuplicates: false,
 		}
 	}
 }

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -87,6 +87,7 @@ export interface RundownLayoutFilterBase extends RundownLayoutElementBase {
 	tags: string[] | undefined
 	displayStyle: PieceDisplayStyle
 	showThumbnailsInList: boolean
+	hideDuplicates: boolean
 	currentSegment: boolean
 	/**
 	 * true: include Rundown Baseline AdLib Pieces

--- a/packages/blueprints-integration/src/action.ts
+++ b/packages/blueprints-integration/src/action.ts
@@ -30,6 +30,8 @@ export interface IBlueprintActionManifestDisplay {
 	currentPieceTags?: string[]
 	/** Piece tags to use to determine if action is set as next */
 	nextPieceTags?: string[]
+	/** String that can be used to identify adlibs that are equivalent to each other */
+	uniquenessId?: string
 }
 
 export interface IBlueprintActionManifestDisplayContent extends IBlueprintActionManifestDisplay {

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -348,6 +348,8 @@ export interface IBlueprintAdLibPiece<TMetadata = unknown> extends IBlueprintPie
 	currentPieceTags?: string[]
 	/** Piece tags to use to determine if action is set as next */
 	nextPieceTags?: string[]
+	/** String that can be used to identify adlibs that are equivalent to each other */
+	uniquenessId?: string
 }
 /** The AdLib piece sent from Core */
 export interface IBlueprintAdLibPieceDB<TMetadata = unknown> extends IBlueprintAdLibPiece<TMetadata> {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR allows blueprints to generate an identifier for adLibs/adLib actions that can then be used to only display one "copy" of a given adLib to the user.

The use case for this is a script writing workflow where, for example, a lower third might be entered into the script for every segment in which an interviewee is expected to appear. This PR allows Sofie to just show one copy of the generated lower third adlib instead of one per segment.


* **What is the current behavior?** (You can also link to an open issue here)

No feature.

* **What is the new behavior (if this is a feature change)?**

The blueprints can add a `uniquenessId` to adLibs/adLib actions, it is left to the blueprint writer to determine how this Id should be generated. There is then an option added to the rundown layout editor to allow a shelf layout to request that only one copy of each adLib with the same `uniquenessId` be returned from the function `matchFilter`.

![image](https://user-images.githubusercontent.com/10697525/113173390-3be00a00-9241-11eb-94a2-9aee689775c2.png)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
