### PR TITLE
chore: lerna precommit hook

### DIFF
--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -18,6 +18,7 @@
 		"build": "rimraf dist && yarn build:main",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "eslint . --ext .ts --ext .js --ignore-pattern dist",
+		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"watch": "jest --watch",

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -27,7 +27,8 @@
 		"send-coverage": "codecov -p ../..",
 		"validate:dependencies": "yarn audit --groups dependencies && yarn license-validate",
 		"validate:dev-dependencies": "yarn audit --groups devDependencies",
-		"license-validate": "yarn sofie-licensecheck"
+		"license-validate": "yarn sofie-licensecheck",
+		"precommit": "lint-staged"
 	},
 	"engines": {
 		"node": ">=10.10"
@@ -43,5 +44,13 @@
 		"timeline-state-resolver-types": "5.6.0-nightly-release31-20210322-163519-1a4031442.0",
 		"tslib": "^2.1.0",
 		"underscore": "1.12.1"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier --write"
+		],
+		"*.{ts,tsx}": [
+			"yarn lint-fix"
+		]
 	}
 }

--- a/packages/blueprints-integration/package.json
+++ b/packages/blueprints-integration/package.json
@@ -18,7 +18,6 @@
 		"build": "rimraf dist && yarn build:main",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "eslint . --ext .ts --ext .js --ignore-pattern dist",
-		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"watch": "jest --watch",
@@ -50,7 +49,7 @@
 			"prettier --write"
 		],
 		"*.{ts,tsx}": [
-			"yarn lint-fix"
+			"yarn lint --fix"
 		]
 	}
 }

--- a/packages/mos-gateway/package.json
+++ b/packages/mos-gateway/package.json
@@ -32,7 +32,6 @@
 		"buildinspect": "yarn build && yarn inspect",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "tslint --project tsconfig.json --config tslint.json",
-		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"test:integration": "yarn lint && jest --config=jest-integration.config.js",

--- a/packages/mos-gateway/package.json
+++ b/packages/mos-gateway/package.json
@@ -32,6 +32,7 @@
 		"buildinspect": "yarn build && yarn inspect",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "tslint --project tsconfig.json --config tslint.json",
+		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"test:integration": "yarn lint && jest --config=jest-integration.config.js",

--- a/packages/mos-gateway/package.json
+++ b/packages/mos-gateway/package.json
@@ -45,7 +45,8 @@
 		"validate:dependencies": "yarn audit --groups dependencies && yarn license-validate",
 		"validate:dev-dependencies": "yarn audit --groups devDependencies",
 		"license-validate": "node-license-validator -p -d --allow-licenses MIT 0BSD BSD BSD-2-Clause BSD-3-Clause ISC Apache Apache-2.0 Unlicense WTFPL --allow-packages cycle",
-		"start": "node dist/index.js"
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
 	},
 	"scripts-info": {
 		"info": "Display information about the scripts",
@@ -81,5 +82,13 @@
 		"tslib": "^2.1.0",
 		"underscore": "^1.12.1",
 		"winston": "^2.4.2"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier --write"
+		],
+		"*.{ts,tsx}": [
+			"yarn lint --fix"
+		]
 	}
 }

--- a/packages/package.json
+++ b/packages/package.json
@@ -48,16 +48,8 @@
 	"name": "packages",
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged"
+			"pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
 		}
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier --write"
-		],
-		"*.{ts,tsx}": [
-			"yarn lint-fix"
-		]
 	},
 	"resolutions": {
 		"node-license-validator/**/minimist": "^1.2.3"

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -38,7 +38,8 @@
 		"start": "node dist/index.js",
 		"validate:dependencies": "yarn audit --groups dependencies && yarn license-validate",
 		"validate:dev-dependencies": "yarn audit --groups devDependencies",
-		"license-validate": "yarn sofie-licensecheck --allowPackages cycle@1.0.3"
+		"license-validate": "yarn sofie-licensecheck --allowPackages cycle@1.0.3",
+		"precommit": "lint-staged"
 	},
 	"scripts-info": {
 		"info": "Display information about the scripts",
@@ -73,5 +74,13 @@
 		"tslib": "^2.1.0",
 		"underscore": "^1.12.1",
 		"winston": "^2.4.2"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier --write"
+		],
+		"*.{ts,tsx}": [
+			"yarn lint-fix"
+		]
 	}
 }

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -26,7 +26,6 @@
 		"buildinspect": "yarn build && yarn inspect",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "eslint . --ext .ts --ext .js --ignore-pattern dist",
-		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"watch": "jest --watch",
@@ -80,7 +79,7 @@
 			"prettier --write"
 		],
 		"*.{ts,tsx}": [
-			"yarn lint-fix"
+			"yarn lint --fix"
 		]
 	}
 }

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -62,7 +62,8 @@
 		"cov-open": "Open current test coverage",
 		"send-coverage": "send coverage to codecov",
 		"validate:dependencies": "Scan dependencies for vulnerabilities and check licenses",
-		"license-validate": "Validate licenses for dependencies."
+		"license-validate": "Validate licenses for dependencies.",
+		"precommit": "lint-staged"
 	},
 	"engines": {
 		"node": ">=10.10"
@@ -93,5 +94,13 @@
 		"got": "^11.8.2",
 		"tslib": "^2.0.3",
 		"underscore": "^1.12.1"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier --write"
+		],
+		"*.{ts,tsx}": [
+			"yarn lint --fix"
+		]
 	}
 }

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -36,6 +36,7 @@
 		"build": "rimraf dist && yarn build:main && yarn copytypes",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "tslint --project tsconfig.json --config tslint.json",
+		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"test:integration": "yarn lint && jest --config=jest-integration.config.js",

--- a/packages/server-core-integration/package.json
+++ b/packages/server-core-integration/package.json
@@ -36,7 +36,6 @@
 		"build": "rimraf dist && yarn build:main && yarn copytypes",
 		"build:main": "tsc -p tsconfig.build.json",
 		"lint": "tslint --project tsconfig.json --config tslint.json",
-		"lint-fix": "yarn lint --fix",
 		"unit": "jest",
 		"test": "yarn lint && yarn unit",
 		"test:integration": "yarn lint && jest --config=jest-integration.config.js",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a workflow bugfix where the husky linting precommit hook prevented commits because the linting would fail.

* **What is the current behavior?** (You can also link to an open issue here)

If making changes in `packages`, the husky precommit hook will trigger and will fail because the root `package.json` doesn't contain any `lint-fix` task.

* **What is the new behavior (if this is a feature change)?**

Based on [#1](https://github.com/lerna/lerna/tree/main/core/filter-options) [#2](https://github.com/typicode/husky/issues/624) [#3](https://medium.com/rewrite-tech/how-to-create-a-monorepo-with-lerna-3ed6dfec5021) and [#4](https://dev.to/try_catch/top-5-handy-lerna-flags-for-your-monorepo-10fa), this PR moves the precommit lint-staged tasks into each of the packages and then uses lerna to run them for the packages that have been changed since HEAD.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
