### PR TITLE
chore(ci): publish comment of prerelease version number

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -441,13 +441,24 @@ jobs:
         env:
           CI: true
       - name: Publish to NPM
+        id: publish-npm
         if: ${{ steps.do-publish.outputs.publish }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           cd packages/${{ matrix.package-name }}
           NEW_VERSION=$(node -p "require('./package.json').version")
           yarn publish --access=public --new-version=$NEW_VERSION --network-timeout 100000 --tag nightly
+          echo ::set-output name=version::$NEW_VERSION
         env:
+          CI: true
+      - name: Post published prerelease lib version comment in PR
+        if: ${{ steps.do-publish.outputs.publish }}
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ⚡ Published prerelease version **${{ matrix.package-name }}@${{ steps.publish-npm.outputs.version }}** to NPM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: true
 
   release-libs:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a feature for the CI system.

* **What is the current behavior?** (You can also link to an open issue here)

To find out the version of the pre-release library published using the CI flow, one needs to rummage through GitHub actions logs

* **What is the new behavior (if this is a feature change)?**

GitHub Actions will post a comment on the PR if a pre-release library version was published to NPM.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
