### PR TITLE
feat: migrations to ensure the playout and mos gateways are matching the version of core

### DIFF
--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -27,7 +27,5 @@ export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 	// },
 	//
 	//
-	// setExpectedVersion('expectedVersion.playoutDevice',	PeripheralDeviceAPI.DeviceType.PLAYOUT,			'_process', '^1.0.0'),
-	// setExpectedVersion('expectedVersion.mosDevice',		PeripheralDeviceAPI.DeviceType.MOS,				'_process', '^1.0.0'),
 	// setExpectedVersion('expectedVersion.mediaManager',	PeripheralDeviceAPI.DeviceType.MEDIA_MANAGER,	'_process', '^1.0.0'),
 ])

--- a/meteor/server/migration/currentSystemVersion.ts
+++ b/meteor/server/migration/currentSystemVersion.ts
@@ -35,4 +35,4 @@
  */
 
 // Note: Only set this to release versions, (ie X.Y.Z), not pre-releases (ie X.Y.Z-0-pre-release)
-export const CURRENT_SYSTEM_VERSION = '1.32.0'
+export const CURRENT_SYSTEM_VERSION = '1.33.0'

--- a/meteor/server/migration/expectedDeviceVersions.ts
+++ b/meteor/server/migration/expectedDeviceVersions.ts
@@ -1,0 +1,22 @@
+import { addMigrationSteps } from './databaseMigration'
+import { setExpectedVersion } from './lib'
+import { PeripheralDeviceAPI } from '../../lib/api/peripheralDevice'
+import { PackageJson } from 'type-fest'
+import { CURRENT_SYSTEM_VERSION } from './currentSystemVersion'
+const PackageInfo: PackageJson = require('../../package.json')
+
+/** Ensure the devices(gateways) which reside in the mono-repo have migrations to enforce them to be a matching version */
+export const addExpectedDeviceVersions = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
+	setExpectedVersion(
+		'expectedVersion.playoutDevice',
+		PeripheralDeviceAPI.DeviceType.PLAYOUT,
+		'_process',
+		`~${PackageInfo.version}`
+	),
+	setExpectedVersion(
+		'expectedVersion.mosDevice',
+		PeripheralDeviceAPI.DeviceType.MOS,
+		'_process',
+		`~${PackageInfo.version}`
+	),
+])

--- a/meteor/server/migration/migrations.ts
+++ b/meteor/server/migration/migrations.ts
@@ -96,3 +96,7 @@ addSteps1_32_0()
 // Migrations for the in-development release:
 import { addSteps as addStepsX_X_X } from './X_X_X'
 addStepsX_X_X()
+
+// Final migrations
+import { addExpectedDeviceVersions } from './expectedDeviceVersions'
+addExpectedDeviceVersions()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature/workflow improvement

(For release34)

* **What is the current behavior?** (You can also link to an open issue here)

For each release a migration is added to update the expected version of the playout and mos gateways

* **What is the new behavior (if this is a feature change)?**

Now that the gateways follow the same versioning scheme as core, a migration has been added to update the expected version to match the current version of core. This means that one doesnt have to be added for each release.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
