### PR TITLE
fix: adlib action trigger mode labels are not translated

### DIFF
--- a/meteor/client/ui/Shelf/ShelfContextMenu.tsx
+++ b/meteor/client/ui/Shelf/ShelfContextMenu.tsx
@@ -81,8 +81,9 @@ export default function ShelfContextMenu() {
 		onToggle: (adLib: T, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => void
 	}) {
 		if (isActionItem(item.adLib)) {
-			const triggerModes = getActionItem(item.adLib)
-				?.triggerModes?.sort(
+			const adLibAction = getActionItem(item.adLib)
+			const triggerModes = adLibAction?.triggerModes
+				?.sort(
 					(a, b) =>
 						a.display._rank - b.display._rank ||
 						translateMessage(a.display.label, t).localeCompare(translateMessage(b.display.label, t))
@@ -95,7 +96,7 @@ export default function ShelfContextMenu() {
 							item.onToggle(item.adLib, false, e, mode)
 						}}
 					>
-						{t(mode.display.label.key, mode.display.label.args)}
+						{translateMessage(mode.display.label, t)}
 					</MenuItem>
 				))
 			return (
@@ -106,7 +107,8 @@ export default function ShelfContextMenu() {
 							item.onToggle(item.adLib, false, e)
 						}}
 					>
-						{t('Execute')}
+						{(adLibAction?.display.triggerLabel && translateMessage(adLibAction?.display.triggerLabel, t)) ??
+							t('Execute')}
 					</MenuItem>
 				)
 			)

--- a/meteor/lib/api/TranslatableMessage.ts
+++ b/meteor/lib/api/TranslatableMessage.ts
@@ -1,5 +1,11 @@
 import { TFunction } from 'i18next'
-import { ITranslatableMessage as IBlueprintTranslatableMessage } from '@sofie-automation/blueprints-integration'
+import {
+	IBlueprintActionManifest,
+	ITranslatableMessage as IBlueprintTranslatableMessage,
+} from '@sofie-automation/blueprints-integration'
+import { ArrayElement, unprotectString } from '../lib'
+import { BlueprintId } from '../collections/Blueprints'
+import { BucketAdLibAction } from '../collections/BucketAdlibActions'
 
 /**
  * @enum - A translatable message (i18next)
@@ -91,6 +97,71 @@ export function isTranslatableMessage(obj: any): obj is ITranslatableMessage {
 	}
 
 	return true
+}
+
+/**
+ * A utility function to add namespaces to ITranslatableMessages found in AdLib Actions
+ *
+ * @export
+ * @template K
+ * @template T
+ * @param {T} itemOrig
+ * @param {BlueprintId} blueprintId
+ * @param {number} [rank]
+ * @return {*}  {(Pick<K, 'display' | 'triggerModes'>)}
+ */
+export function processAdLibActionITranslatableMessages<
+	K extends {
+		display: IBlueprintActionManifest['display'] & {
+			label: ITranslatableMessage
+			triggerLabel?: ITranslatableMessage
+			description?: ITranslatableMessage
+		}
+		triggerModes?: (ArrayElement<IBlueprintActionManifest['triggerModes']> & {
+			display: ArrayElement<IBlueprintActionManifest['triggerModes']>['display'] & {
+				label: ITranslatableMessage
+				description?: ITranslatableMessage
+			}
+		})[]
+	},
+	T extends IBlueprintActionManifest
+>(itemOrig: T, blueprintId: BlueprintId, rank?: number): Pick<K, 'display' | 'triggerModes'> {
+	return {
+		display: {
+			...itemOrig.display,
+			_rank: rank ?? itemOrig.display._rank,
+			label: {
+				...itemOrig.display.label,
+				namespaces: [unprotectString(blueprintId)],
+			},
+			triggerLabel: itemOrig.display.triggerLabel && {
+				...itemOrig.display.triggerLabel,
+				namespaces: [unprotectString(blueprintId)],
+			},
+			description: itemOrig.display.description && {
+				...itemOrig.display.description,
+				namespaces: [unprotectString(blueprintId)],
+			},
+		},
+		triggerModes:
+			itemOrig.triggerModes &&
+			itemOrig.triggerModes.map(
+				(triggerMode): ArrayElement<BucketAdLibAction['triggerModes']> => ({
+					...triggerMode,
+					display: {
+						...triggerMode.display,
+						label: {
+							...triggerMode.display.label,
+							namespaces: [unprotectString(blueprintId)],
+						},
+						description: triggerMode.display.description && {
+							...triggerMode.display.description,
+							namespaces: [unprotectString(blueprintId)],
+						},
+					},
+				})
+			),
+	}
 }
 
 function checkArgs(args: any): args is { [key: string]: any } {

--- a/meteor/lib/collections/AdLibActions.ts
+++ b/meteor/lib/collections/AdLibActions.ts
@@ -1,16 +1,31 @@
 import { TransformedCollection } from '../typings/meteor'
-import { registerCollection, ProtectedStringProperties, ProtectedString } from '../lib'
+import { registerCollection, ProtectedStringProperties, ProtectedString, ArrayElement } from '../lib'
 import { IBlueprintActionManifest } from '@sofie-automation/blueprints-integration'
 import { createMongoCollection } from './lib'
 import { PartId } from './Parts'
 import { RundownId } from './Rundowns'
 import { registerIndex } from '../database'
+import { ITranslatableMessage } from '../api/TranslatableMessage'
 
 /** A string, identifying an AdLibActionId */
 export type AdLibActionId = ProtectedString<'AdLibActionId'>
 
+/** The following extended interface allows assigning namespace information to the actions as they are stored in the
+ *  database after being emitted from the blueprints
+ */
 export interface AdLibActionCommon extends ProtectedStringProperties<IBlueprintActionManifest, 'partId'> {
 	rundownId: RundownId
+	display: IBlueprintActionManifest['display'] & {
+		label: ITranslatableMessage
+		triggerLabel?: ITranslatableMessage
+		description?: ITranslatableMessage
+	}
+	triggerModes?: (ArrayElement<IBlueprintActionManifest['triggerModes']> & {
+		display: ArrayElement<IBlueprintActionManifest['triggerModes']>['display'] & {
+			label: ITranslatableMessage
+			description?: ITranslatableMessage
+		}
+	})[]
 }
 
 export interface AdLibAction extends AdLibActionCommon {

--- a/meteor/lib/collections/BucketAdlibActions.ts
+++ b/meteor/lib/collections/BucketAdlibActions.ts
@@ -1,6 +1,6 @@
 import { PieceId } from './Pieces'
 import { TransformedCollection } from '../typings/meteor'
-import { registerCollection } from '../lib'
+import { ArrayElement, registerCollection } from '../lib'
 import { IBlueprintActionManifest } from '@sofie-automation/blueprints-integration'
 import { createMongoCollection } from './lib'
 import { RundownImportVersions } from './Rundowns'
@@ -9,6 +9,7 @@ import { ShowStyleVariantId } from './ShowStyleVariants'
 import { BucketId } from './Buckets'
 import { registerIndex } from '../database'
 import { AdLibActionId } from './AdLibActions'
+import { ITranslatableMessage } from '../api/TranslatableMessage'
 
 export type BucketAdLibActionId = AdLibActionId
 export interface BucketAdLibAction extends Omit<IBlueprintActionManifest, 'partId'> {
@@ -24,6 +25,23 @@ export interface BucketAdLibAction extends Omit<IBlueprintActionManifest, 'partI
 	studioId: StudioId
 	showStyleVariantId: ShowStyleVariantId
 	importVersions: RundownImportVersions // TODO - is this good?
+
+	/** The following extended interface allows assigning namespace information to the actions as they are stored in the
+	 *  database after being emitted from the blueprints
+	 */
+
+	// How this AdLib Action should be displayed to the User
+	display: IBlueprintActionManifest['display'] & {
+		label: ITranslatableMessage
+		triggerLabel?: ITranslatableMessage
+		description?: ITranslatableMessage
+	}
+	triggerModes?: (ArrayElement<IBlueprintActionManifest['triggerModes']> & {
+		display: ArrayElement<IBlueprintActionManifest['triggerModes']>['display'] & {
+			label: ITranslatableMessage
+			description?: ITranslatableMessage
+		}
+	})[]
 }
 
 export const BucketAdLibActions: TransformedCollection<

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -116,6 +116,7 @@ export function literal<T>(o: T) {
 export type Partial<T> = {
 	[P in keyof T]?: T[P]
 }
+export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never
 export function partial<T>(o: Partial<T>) {
 	return o
 }

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -1,6 +1,6 @@
 import { Piece, PieceId } from '../../../lib/collections/Pieces'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
-import { protectString, unprotectString, literal, ArrayElement } from '../../../lib/lib'
+import { protectString, unprotectString, literal } from '../../../lib/lib'
 import { TimelineObjGeneric, TimelineObjRundown, TimelineObjType } from '../../../lib/collections/Timeline'
 import { Studio } from '../../../lib/collections/Studios'
 import { Meteor } from 'meteor/meteor'

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -1,6 +1,6 @@
 import { Piece, PieceId } from '../../../lib/collections/Pieces'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
-import { protectString, unprotectString, literal } from '../../../lib/lib'
+import { protectString, unprotectString, literal, ArrayElement } from '../../../lib/lib'
 import { TimelineObjGeneric, TimelineObjRundown, TimelineObjType } from '../../../lib/collections/Timeline'
 import { Studio } from '../../../lib/collections/Studios'
 import { Meteor } from 'meteor/meteor'
@@ -213,6 +213,39 @@ export function postProcessGlobalAdLibActions(
 			_id: protectString(innerContext.getHashId(`${blueprintId}_global_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: undefined,
+			display: {
+				...action.display,
+				label: {
+					...action.display.label,
+					namespaces: [unprotectString(blueprintId)],
+				},
+				triggerLabel: action.display.triggerLabel && {
+					...action.display.triggerLabel,
+					namespaces: [unprotectString(blueprintId)],
+				},
+				description: action.display.description && {
+					...action.display.description,
+					namespaces: [unprotectString(blueprintId)],
+				},
+			},
+			triggerModes:
+				action.triggerModes &&
+				action.triggerModes.map(
+					(triggerMode): ArrayElement<AdLibAction['triggerModes']> => ({
+						...triggerMode,
+						display: {
+							...triggerMode.display,
+							label: {
+								...triggerMode.display.label,
+								namespaces: [unprotectString(blueprintId)],
+							},
+							description: triggerMode.display.description && {
+								...triggerMode.display.description,
+								namespaces: [unprotectString(blueprintId)],
+							},
+						},
+					})
+				),
 		})
 	)
 }
@@ -231,6 +264,39 @@ export function postProcessAdLibActions(
 			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: partId,
+			display: {
+				...action.display,
+				label: {
+					...action.display.label,
+					namespaces: [unprotectString(blueprintId)],
+				},
+				triggerLabel: action.display.triggerLabel && {
+					...action.display.triggerLabel,
+					namespaces: [unprotectString(blueprintId)],
+				},
+				description: action.display.description && {
+					...action.display.description,
+					namespaces: [unprotectString(blueprintId)],
+				},
+			},
+			triggerModes:
+				action.triggerModes &&
+				action.triggerModes.map(
+					(triggerMode): ArrayElement<AdLibAction['triggerModes']> => ({
+						...triggerMode,
+						display: {
+							...triggerMode.display,
+							label: {
+								...triggerMode.display.label,
+								namespaces: [unprotectString(blueprintId)],
+							},
+							description: triggerMode.display.description && {
+								...triggerMode.display.description,
+								namespaces: [unprotectString(blueprintId)],
+							},
+						},
+					})
+				),
 		})
 	)
 }
@@ -292,7 +358,7 @@ export function postProcessBucketAction(
 	innerContext: ShowStyleContext,
 	itemOrig: IBlueprintActionManifest,
 	externalId: string,
-	_blueprintId: BlueprintId,
+	blueprintId: BlueprintId,
 	bucketId: BucketId,
 	rank: number | undefined,
 	importVersions: RundownImportVersions
@@ -312,7 +378,37 @@ export function postProcessBucketAction(
 		display: {
 			...itemOrig.display,
 			_rank: rank ?? itemOrig.display._rank,
+			label: {
+				...itemOrig.display.label,
+				namespaces: [unprotectString(blueprintId)],
+			},
+			triggerLabel: itemOrig.display.triggerLabel && {
+				...itemOrig.display.triggerLabel,
+				namespaces: [unprotectString(blueprintId)],
+			},
+			description: itemOrig.display.description && {
+				...itemOrig.display.description,
+				namespaces: [unprotectString(blueprintId)],
+			},
 		},
+		triggerModes:
+			itemOrig.triggerModes &&
+			itemOrig.triggerModes.map(
+				(triggerMode): ArrayElement<BucketAdLibAction['triggerModes']> => ({
+					...triggerMode,
+					display: {
+						...triggerMode.display,
+						label: {
+							...triggerMode.display.label,
+							namespaces: [unprotectString(blueprintId)],
+						},
+						description: triggerMode.display.description && {
+							...triggerMode.display.description,
+							namespaces: [unprotectString(blueprintId)],
+						},
+					},
+				})
+			),
 	}
 
 	return action

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -28,6 +28,7 @@ import { profiler } from '../profiler'
 import { BucketAdLibAction } from '../../../lib/collections/BucketAdlibActions'
 import { CommonContext, ShowStyleContext } from './context'
 import { ReadonlyDeep } from 'type-fest'
+import { processAdLibActionITranslatableMessages } from '../../../lib/api/TranslatableMessage'
 
 /**
  *
@@ -213,39 +214,7 @@ export function postProcessGlobalAdLibActions(
 			_id: protectString(innerContext.getHashId(`${blueprintId}_global_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: undefined,
-			display: {
-				...action.display,
-				label: {
-					...action.display.label,
-					namespaces: [unprotectString(blueprintId)],
-				},
-				triggerLabel: action.display.triggerLabel && {
-					...action.display.triggerLabel,
-					namespaces: [unprotectString(blueprintId)],
-				},
-				description: action.display.description && {
-					...action.display.description,
-					namespaces: [unprotectString(blueprintId)],
-				},
-			},
-			triggerModes:
-				action.triggerModes &&
-				action.triggerModes.map(
-					(triggerMode): ArrayElement<AdLibAction['triggerModes']> => ({
-						...triggerMode,
-						display: {
-							...triggerMode.display,
-							label: {
-								...triggerMode.display.label,
-								namespaces: [unprotectString(blueprintId)],
-							},
-							description: triggerMode.display.description && {
-								...triggerMode.display.description,
-								namespaces: [unprotectString(blueprintId)],
-							},
-						},
-					})
-				),
+			...processAdLibActionITranslatableMessages(action, blueprintId),
 		})
 	)
 }
@@ -264,39 +233,7 @@ export function postProcessAdLibActions(
 			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: partId,
-			display: {
-				...action.display,
-				label: {
-					...action.display.label,
-					namespaces: [unprotectString(blueprintId)],
-				},
-				triggerLabel: action.display.triggerLabel && {
-					...action.display.triggerLabel,
-					namespaces: [unprotectString(blueprintId)],
-				},
-				description: action.display.description && {
-					...action.display.description,
-					namespaces: [unprotectString(blueprintId)],
-				},
-			},
-			triggerModes:
-				action.triggerModes &&
-				action.triggerModes.map(
-					(triggerMode): ArrayElement<AdLibAction['triggerModes']> => ({
-						...triggerMode,
-						display: {
-							...triggerMode.display,
-							label: {
-								...triggerMode.display.label,
-								namespaces: [unprotectString(blueprintId)],
-							},
-							description: triggerMode.display.description && {
-								...triggerMode.display.description,
-								namespaces: [unprotectString(blueprintId)],
-							},
-						},
-					})
-				),
+			...processAdLibActionITranslatableMessages(action, blueprintId),
 		})
 	)
 }
@@ -375,40 +312,7 @@ export function postProcessBucketAction(
 		showStyleVariantId: innerContext.showStyleCompound.showStyleVariantId,
 		bucketId,
 		importVersions,
-		display: {
-			...itemOrig.display,
-			_rank: rank ?? itemOrig.display._rank,
-			label: {
-				...itemOrig.display.label,
-				namespaces: [unprotectString(blueprintId)],
-			},
-			triggerLabel: itemOrig.display.triggerLabel && {
-				...itemOrig.display.triggerLabel,
-				namespaces: [unprotectString(blueprintId)],
-			},
-			description: itemOrig.display.description && {
-				...itemOrig.display.description,
-				namespaces: [unprotectString(blueprintId)],
-			},
-		},
-		triggerModes:
-			itemOrig.triggerModes &&
-			itemOrig.triggerModes.map(
-				(triggerMode): ArrayElement<BucketAdLibAction['triggerModes']> => ({
-					...triggerMode,
-					display: {
-						...triggerMode.display,
-						label: {
-							...triggerMode.display.label,
-							namespaces: [unprotectString(blueprintId)],
-						},
-						description: triggerMode.display.description && {
-							...triggerMode.display.description,
-							namespaces: [unprotectString(blueprintId)],
-						},
-					},
-				})
-			),
+		...processAdLibActionITranslatableMessages(itemOrig, blueprintId, rank),
 	}
 
 	return action


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Action trigger mode labels are not translated in the UI, because proper namespaces are not stored alongside those strings and aren't used in the `t` function.

* **What is the new behavior (if this is a feature change)?**

Incoming ITranslatableMessage objects for AdLib Actions are now post-processed by core, namespace data is injected and messages are properly handled when being displayed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
