### PR TITLE
fix: only reset previous segment on looping rundowns

### DIFF
--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -14830,7 +14830,8 @@
 		"y18n": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+			"dev": true
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -181,6 +181,7 @@ export function resetPreviousSegmentAndClearNextSegmentId(cache: CacheForPlayout
 		})
 	}
 
+	// If the playlist is looping and
 	// If the previous and current part are not in the same segment, then we have just left a segment
 	if (
 		cache.Playlist.doc.loop &&

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -182,7 +182,11 @@ export function resetPreviousSegmentAndClearNextSegmentId(cache: CacheForPlayout
 	}
 
 	// If the previous and current part are not in the same segment, then we have just left a segment
-	if (previousPartInstance && previousPartInstance.segmentId !== currentPartInstance?.segmentId) {
+	if (
+		cache.Playlist.doc.loop &&
+		previousPartInstance &&
+		previousPartInstance.segmentId !== currentPartInstance?.segmentId
+	) {
 		// Reset the old segment
 		const segmentId = previousPartInstance.segmentId
 		const resetIds = new Set(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

After playback of a segment ends, PartInstances inside are reset. This causes problems for timing in the GUI as reset PartInstances are not sent to the GUI and are not taken under consideration for timing purposes.

* **What is the new behavior (if this is a feature change)?**

PartInstances inside segments that stop playing are only reset if the playlist is looping.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [x] The functionality has been tested by NRK
