### PR TITLE
Chore/various tests

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -381,8 +381,7 @@ export interface DefaultEnvironment {
 
 	ingestDevice: PeripheralDevice
 }
-export function setupDefaultStudioEnvironment(organizationId?: OrganizationId | null): DefaultEnvironment {
-	organizationId = organizationId || null
+export function setupDefaultStudioEnvironment(organizationId: OrganizationId | null = null): DefaultEnvironment {
 	const core = setupMockCore({})
 
 	const showStyleBaseId: ShowStyleBaseId = getRandomId()

--- a/meteor/__mocks__/random.ts
+++ b/meteor/__mocks__/random.ts
@@ -7,6 +7,10 @@ export class RandomMock {
 		if (!id) id = 'randomId' + RandomMock.mockI++
 		return id
 	}
+	/** Returns a "mocked random" number 0-1 */
+	static number(): number {
+		return (RandomMock.mockI++ / 1.6180339887) % 1
+	}
 }
 export function setup() {
 	return {

--- a/meteor/server/api/__mocks__/ntp-client.ts
+++ b/meteor/server/api/__mocks__/ntp-client.ts
@@ -1,0 +1,27 @@
+import { RandomMock } from '../../../__mocks__/random'
+
+export let ntpReplyTimeout: number = 1000
+
+export const getNetworkTime = (
+	host: string,
+	port: number,
+	cb: (error: Error | undefined, date: Date | undefined) => void
+): void => {
+	const validAdresses = ['0.se.pool.ntp.org:123', '1.se.pool.ntp.org:123', '2.se.pool.ntp.org:123']
+
+	const mockDiffFromRealTime = 400 // ms
+
+	const hostPort = `${host}:${port}`
+	if (validAdresses.includes(hostPort)) {
+		const noise = RandomMock.number() * 2 - 1 // -1 ... +1
+		const serverTime = new Date(Date.now() - mockDiffFromRealTime + noise)
+
+		setTimeout(() => {
+			cb(undefined, serverTime)
+		}, 5)
+	} else {
+		setTimeout(() => {
+			cb(new Error(`Mock: Timeout for host ${hostPort}`), undefined)
+		}, 5)
+	}
+}

--- a/meteor/server/api/blueprints/api.ts
+++ b/meteor/server/api/blueprints/api.ts
@@ -123,9 +123,10 @@ export function internalUploadBlueprint(
 	blueprintId: BlueprintId,
 	body: string,
 	blueprintName?: string,
-	ignoreIdChange?: boolean
+	ignoreIdChange?: boolean,
+	organizationId?: OrganizationId | null
 ): Blueprint {
-	const organizationId = null
+	organizationId = organizationId || null
 	const blueprint = Blueprints.findOne(blueprintId)
 
 	return innerUploadBlueprint(organizationId, blueprint, blueprintId, body, blueprintName, ignoreIdChange)

--- a/meteor/server/api/snapshot.ts
+++ b/meteor/server/api/snapshot.ts
@@ -434,7 +434,10 @@ function storeSnaphot(
 
 	// Store to the persistant file storage
 	logger.info(`Save snapshot file ${filePath}`)
-	fsWriteFile(filePath, str)
+	if (!Meteor.isTest) {
+		// If we're running in a unit-test, don't write to disk
+		fsWriteFile(filePath, str)
+	}
 
 	let id = Snapshots.insert({
 		_id: protectString(fileName),
@@ -478,7 +481,9 @@ function retreiveSnapshot(snapshotId: SnapshotId, cred0: Credentials): AnySnapsh
 
 	let filePath = Path.join(system.storePath, snapshot.fileName)
 
-	let dataStr = fsReadFile(filePath).toString()
+	let dataStr = !Meteor.isTest // If we're running in a unit-test, don't access files
+		? fsReadFile(filePath).toString()
+		: ''
 
 	let readSnapshot = JSON.parse(dataStr)
 
@@ -859,7 +864,10 @@ export function removeSnapshot(context: MethodContext, snapshotId: SnapshotId) {
 		try {
 			logger.info(`Removing snapshot file ${filePath}`)
 
-			fsUnlinkFile(filePath)
+			if (!Meteor.isTest) {
+				// If we're running in a unit-test, don't access files
+				fsUnlinkFile(filePath)
+			}
 		} catch (e) {
 			// Log the error, but continue
 			logger.error('Error in removeSnapshot')

--- a/meteor/server/security/__tests__/security.test.ts
+++ b/meteor/server/security/__tests__/security.test.ts
@@ -1,0 +1,279 @@
+import { MethodContext } from '../../../lib/api/methods'
+import { Blueprints } from '../../../lib/collections/Blueprints'
+import { CoreSystem, getCoreSystem, setCoreSystemStorePath } from '../../../lib/collections/CoreSystem'
+import { DBOrganization, Organization, OrganizationId, Organizations } from '../../../lib/collections/Organization'
+import { ShowStyleBase, ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
+import { Studio, Studios } from '../../../lib/collections/Studios'
+import { User, Users } from '../../../lib/collections/Users'
+import { protectString, unprotectString } from '../../../lib/lib'
+import { Settings } from '../../../lib/Settings'
+import { UserId } from '../../../lib/typings/meteor'
+import { DefaultEnvironment, setupDefaultStudioEnvironment } from '../../../__mocks__/helpers/database'
+import { beforeAllInFiber, testInFiber, testInFiberOnly } from '../../../__mocks__/helpers/jest'
+import { BucketsAPI } from '../../api/buckets'
+import { storeSystemSnapshot } from '../../api/snapshot'
+import { BucketSecurity } from '../buckets'
+import { Credentials } from '../lib/credentials'
+import { NoSecurityReadAccess } from '../noSecurity'
+import { OrganizationContentWriteAccess, OrganizationReadAccess } from '../organization'
+
+describe('Security', () => {
+	function getContext(cred: Credentials): MethodContext {
+		return {
+			...cred,
+
+			isSimulation: false,
+			connection: null,
+			setUserId: (userId: string) => {},
+			unblock: () => {},
+		}
+	}
+	function getUser(userId: UserId, orgId: OrganizationId): User {
+		return {
+			_id: userId,
+			organizationId: orgId,
+
+			createdAt: '',
+			services: {
+				password: {
+					bcrypt: 'abc',
+				},
+			},
+			username: 'username',
+			emails: [{ address: 'email.com', verified: false }],
+			profile: {
+				name: 'John Doe',
+			},
+		}
+	}
+	function getOrg(id: string): DBOrganization {
+		return {
+			_id: protectString(id),
+			name: 'The Company',
+
+			userRoles: {
+				userA: {
+					admin: true,
+				},
+			},
+
+			created: 0,
+			modified: 0,
+
+			applications: [],
+			broadcastMediums: [],
+		}
+	}
+	function changeEnableUserAccounts(fcn: () => void) {
+		try {
+			Settings.enableUserAccounts = false
+			fcn()
+			Settings.enableUserAccounts = true
+			fcn()
+		} catch (e) {
+			console.log(`Error happened when Settings.enableUserAccounts = ${Settings.enableUserAccounts}`)
+			throw e
+		}
+	}
+
+	const idCreator: UserId = protectString('userCreator')
+	const idUserB: UserId = protectString('userB')
+	const idNonExisting: UserId = protectString('userNonExistant')
+	const idInWrongOrg: UserId = protectString('userInWrongOrg')
+	const idSuperAdmin: UserId = protectString('userSuperAdmin')
+	const idSuperAdminInOtherOrg: UserId = protectString('userSuperAdminOther')
+
+	// Credentials for various users:
+	const nothing: MethodContext = getContext({ userId: null })
+	const creator: MethodContext = getContext({ userId: idCreator })
+	const userB: MethodContext = getContext({ userId: idUserB })
+	const nonExisting: MethodContext = getContext({ userId: idNonExisting })
+	const wrongOrg: MethodContext = getContext({ userId: idInWrongOrg })
+	const superAdmin: MethodContext = getContext({ userId: idSuperAdmin })
+	const otherSuperAdmin: MethodContext = getContext({ userId: idSuperAdminInOtherOrg })
+
+	const unknownId = protectString('unknown')
+
+	const org0: Organization = getOrg('org0')
+	const org1: Organization = getOrg('org1')
+	const org2: Organization = getOrg('org2')
+
+	function expectReadNotAllowed(fcn: () => boolean) {
+		if (Settings.enableUserAccounts === false) return expectReadAllowed(fcn)
+		expect(fcn()).toEqual(false)
+	}
+	function expectReadAllowed(fcn: () => boolean) {
+		expect(fcn()).toEqual(true)
+	}
+	function expectNotAllowed(fcn: () => any) {
+		if (Settings.enableUserAccounts === false) return expectAllowed(fcn)
+		expect(fcn).toThrowError()
+	}
+	function expectNotLoggedIn(fcn: () => any) {
+		if (Settings.enableUserAccounts === false) return expectAllowed(fcn)
+		expect(fcn).toThrowError(/not logged in/i)
+	}
+	function expectNotFound(fcn: () => any) {
+		if (Settings.enableUserAccounts === false) return expectAllowed(fcn)
+		expect(fcn).toThrowError(/not found/i)
+	}
+	function expectAllowed(fcn: () => any) {
+		expect(fcn).not.toThrowError()
+	}
+	let env: DefaultEnvironment
+	beforeAllInFiber(() => {
+		env = setupDefaultStudioEnvironment(org0._id)
+
+		Organizations.insert(org0)
+		Organizations.insert(org1)
+		Organizations.insert(org2)
+
+		Users.insert(getUser(idCreator, org0._id))
+		Users.insert(getUser(idUserB, org0._id))
+		Users.insert(getUser(idInWrongOrg, org1._id))
+		Users.insert({ ...getUser(idSuperAdmin, org0._id), superAdmin: true })
+		Users.insert({ ...getUser(idSuperAdminInOtherOrg, org2._id), superAdmin: true })
+	})
+
+	testInFiber('Buckets', () => {
+		const bucket = BucketsAPI.createNewBucket(creator, 'myBucket', env.studio._id, unprotectString(creator.userId))
+
+		changeEnableUserAccounts(() => {
+			expectReadAllowed(() => BucketSecurity.allowReadAccess({ _id: bucket._id }, '', creator))
+			expectAllowed(() => BucketSecurity.allowWriteAccess({ _id: bucket._id }, creator))
+			// expectAccessAllowed(() => BucketSecurity.allowWriteAccessPiece({ _id: bucket._id }, credUserA))
+
+			// Unknown bucket:
+			expectNotFound(() => BucketSecurity.allowReadAccess({ _id: unknownId }, '', creator))
+			expectNotFound(() => BucketSecurity.allowWriteAccess({ _id: unknownId }, creator))
+			expectNotFound(() => BucketSecurity.allowWriteAccessPiece({ _id: unknownId }, creator))
+
+			// Not logged in:
+			expectReadNotAllowed(() => BucketSecurity.allowReadAccess({ _id: bucket._id }, '', nothing))
+			expectNotLoggedIn(() => BucketSecurity.allowWriteAccess({ _id: bucket._id }, nothing))
+			// expectAccessNotLoggedIn(() => BucketSecurity.allowWriteAccessPiece({ _id: bucket._id }, credNothing))
+
+			// Non existing user:
+			expectReadNotAllowed(() => BucketSecurity.allowReadAccess({ _id: bucket._id }, '', nonExisting))
+			expectNotLoggedIn(() => BucketSecurity.allowWriteAccess({ _id: bucket._id }, nonExisting))
+			// expectAccess(() => BucketSecurity.allowWriteAccessPiece({ _id: bucket._id }, credNonExistingUser))
+
+			// Other user in same org:
+			expectReadAllowed(() => BucketSecurity.allowReadAccess({ _id: bucket._id }, '', userB))
+			expectAllowed(() => BucketSecurity.allowWriteAccess({ _id: bucket._id }, userB))
+			// expectAccess(() => BucketSecurity.allowWriteAccessPiece({ _id: bucket._id }, credUserB))
+
+			// Other user in other org:
+			expectReadNotAllowed(() => BucketSecurity.allowReadAccess({ _id: bucket._id }, '', wrongOrg))
+			expectNotAllowed(() => BucketSecurity.allowWriteAccess({ _id: bucket._id }, wrongOrg))
+			// expectAccess(() => BucketSecurity.allowWriteAccessPiece({ _id: bucket._id }, credUserInWrongOrganization))
+		})
+	})
+
+	testInFiber('NoSecurity', () => {
+		changeEnableUserAccounts(() => {
+			expectAllowed(() => NoSecurityReadAccess.any())
+		})
+	})
+	testInFiber('Organization', () => {
+		setCoreSystemStorePath('/non-existent-path/')
+		const snapshotId = storeSystemSnapshot(superAdmin, env.studio._id, 'for test')
+
+		changeEnableUserAccounts(() => {
+			const selectorId = { _id: org0._id }
+			const selectorOrg = { organizationId: org0._id }
+
+			// === Read access: ===
+
+			// No user credentials:
+			expectReadNotAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, nothing))
+			expectReadNotAllowed(() => OrganizationReadAccess.organization(selectorId, nothing))
+			expectReadNotAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, nothing))
+			// Normal user:
+			expectReadAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, creator))
+			expectReadAllowed(() => OrganizationReadAccess.organization(selectorId, creator))
+			expectReadAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, creator))
+			// Other normal user:
+			expectReadAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, userB))
+			expectReadAllowed(() => OrganizationReadAccess.organization(selectorId, userB))
+			expectReadAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, userB))
+			// Non-existing user:
+			expectReadNotAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, nonExisting))
+			expectReadNotAllowed(() => OrganizationReadAccess.organization(selectorId, nonExisting))
+			expectReadNotAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, nonExisting))
+			// User in wrong organization:
+			expectReadNotAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, wrongOrg))
+			expectReadNotAllowed(() => OrganizationReadAccess.organization(selectorId, wrongOrg))
+			expectReadNotAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, wrongOrg))
+			// SuperAdmin:
+			expectReadNotAllowed(() => OrganizationReadAccess.adminUsers(selectorOrg, otherSuperAdmin))
+			expectReadNotAllowed(() => OrganizationReadAccess.organization(selectorId, otherSuperAdmin))
+			expectReadNotAllowed(() => OrganizationReadAccess.organizationContent(selectorOrg, otherSuperAdmin))
+
+			// === Write access: ===
+
+			// No user credentials:
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.organization(nothing, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.studio(nothing, env.studio))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.evaluation(nothing))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.mediaWorkFlows(nothing, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.blueprint(nothing, env.studioBlueprint._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.snapshot(nothing, snapshotId))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.dataFromSnapshot(nothing, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.showStyleBase(nothing, env.showStyleBaseId))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.anyContent(nothing, selectorOrg))
+
+			// Normal user:
+			expectAllowed(() => OrganizationContentWriteAccess.organization(creator, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.studio(creator, env.studio))
+			expectAllowed(() => OrganizationContentWriteAccess.evaluation(creator))
+			expectAllowed(() => OrganizationContentWriteAccess.mediaWorkFlows(creator, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.blueprint(creator, env.studioBlueprint._id))
+			expectAllowed(() => OrganizationContentWriteAccess.snapshot(creator, snapshotId))
+			expectAllowed(() => OrganizationContentWriteAccess.dataFromSnapshot(creator, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.showStyleBase(creator, env.showStyleBaseId))
+			expectAllowed(() => OrganizationContentWriteAccess.anyContent(creator, selectorOrg))
+			// Other normal user:
+			expectAllowed(() => OrganizationContentWriteAccess.organization(userB, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.studio(userB, env.studio))
+			expectAllowed(() => OrganizationContentWriteAccess.evaluation(userB))
+			expectAllowed(() => OrganizationContentWriteAccess.mediaWorkFlows(userB, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.blueprint(userB, env.studioBlueprint._id))
+			expectAllowed(() => OrganizationContentWriteAccess.snapshot(userB, snapshotId))
+			expectAllowed(() => OrganizationContentWriteAccess.dataFromSnapshot(userB, org0._id))
+			expectAllowed(() => OrganizationContentWriteAccess.showStyleBase(userB, env.showStyleBaseId))
+			expectAllowed(() => OrganizationContentWriteAccess.anyContent(userB, selectorOrg))
+			// Non-existing user:
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.organization(nonExisting, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.studio(nonExisting, env.studio))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.evaluation(nonExisting))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.mediaWorkFlows(nonExisting, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.blueprint(nonExisting, env.studioBlueprint._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.snapshot(nonExisting, snapshotId))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.dataFromSnapshot(nonExisting, org0._id))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.showStyleBase(nonExisting, env.showStyleBaseId))
+			expectNotLoggedIn(() => OrganizationContentWriteAccess.anyContent(nonExisting, selectorOrg))
+			// User in wrong organization:
+			expectNotAllowed(() => OrganizationContentWriteAccess.organization(wrongOrg, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.studio(wrongOrg, env.studio))
+			// expectNotAllowed(() => OrganizationContentWriteAccess.evaluation(wrongOrg))
+			expectNotAllowed(() => OrganizationContentWriteAccess.mediaWorkFlows(wrongOrg, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.blueprint(wrongOrg, env.studioBlueprint._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.snapshot(wrongOrg, snapshotId))
+			expectNotAllowed(() => OrganizationContentWriteAccess.dataFromSnapshot(wrongOrg, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.showStyleBase(wrongOrg, env.showStyleBaseId))
+			expectNotAllowed(() => OrganizationContentWriteAccess.anyContent(wrongOrg, selectorOrg))
+
+			// Other SuperAdmin
+			expectNotAllowed(() => OrganizationContentWriteAccess.organization(otherSuperAdmin, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.studio(otherSuperAdmin, env.studio))
+			// expectNotAllowed(() => OrganizationContentWriteAccess.evaluation(otherSuperAdmin))
+			expectNotAllowed(() => OrganizationContentWriteAccess.mediaWorkFlows(otherSuperAdmin, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.blueprint(otherSuperAdmin, env.studioBlueprint._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.snapshot(otherSuperAdmin, snapshotId))
+			expectNotAllowed(() => OrganizationContentWriteAccess.dataFromSnapshot(otherSuperAdmin, org0._id))
+			expectNotAllowed(() => OrganizationContentWriteAccess.showStyleBase(otherSuperAdmin, env.showStyleBaseId))
+			expectNotAllowed(() => OrganizationContentWriteAccess.anyContent(otherSuperAdmin, selectorOrg))
+		})
+	})
+})


### PR DESCRIPTION
This PR contains various things that I found in a local branch from November 2020, which I've now rebased upon release33.

What it contains:
* A mock of the NTP-client, so that we can run the NTP-tests reliably
* Fixes to be able to `setupDefaultStudioEnvironment` with a organizationId, so that we can run tests in an organization-environment.
* fix: snapshots: Don't access file system when in unit tests, to avoid non-test-related issues



**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
