### PR TITLE
fix: Add vMix Config Manifest

### DIFF
--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -17,6 +17,7 @@ import {
 	MappingPanasonicPtzType,
 	MappingSisyfosType,
 	QuantelControlMode,
+	MappingVMixType,
 } from 'timeline-state-resolver'
 
 const PLAYOUT_SUBDEVICE_COMMON: SubDeviceConfigManifestEntry[] = [
@@ -387,6 +388,7 @@ const PLAYOUT_SUBDEVICE_CONFIG: SubDeviceConfigManifest['config'] = {
 		},
 	],
 	[TSRDeviceType.SHOTOKU]: [...PLAYOUT_SUBDEVICE_COMMON, ...PLAYOUT_SUBDEVICE_HOST_PORT],
+	[TSRDeviceType.VMIX]: [...PLAYOUT_SUBDEVICE_COMMON, ...PLAYOUT_SUBDEVICE_HOST_PORT],
 }
 
 // TODO: should come from types
@@ -527,7 +529,29 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			name: 'Set channel label to layer name',
 		},
 	],
-	// TODO - add VMix?
+	[TSRDeviceType.VMIX]: [
+		{
+			id: 'mappingType',
+			type: ConfigManifestEntryType.ENUM,
+			values: MappingVMixType,
+			name: 'Mapping Type',
+			includeInSummary: true,
+		},
+		{
+			id: 'index',
+			type: ConfigManifestEntryType.STRING,
+			name: 'Index',
+			includeInSummary: true,
+			optional: true
+		},
+		{
+			id: 'inputLayer',
+			type: ConfigManifestEntryType.STRING,
+			name: 'Input Layer',
+			includeInSummary: true,
+			optional: true
+		},
+	],
 }
 
 export const PLAYOUT_DEVICE_CONFIG: DeviceConfigManifest = {

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -542,14 +542,14 @@ const MAPPING_MANIFEST: MappingsManifest = {
 			type: ConfigManifestEntryType.STRING,
 			name: 'Index',
 			includeInSummary: true,
-			optional: true
+			optional: true,
 		},
 		{
 			id: 'inputLayer',
 			type: ConfigManifestEntryType.STRING,
 			name: 'Input Layer',
 			includeInSummary: true,
-			optional: true
+			optional: true,
 		},
 	],
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds in the missing vMix Config Manifest details to allow configuration in the Sofie UI


* **What is the current behavior?** (You can also link to an open issue here)
You can't configure vMix devices via the UI


* **What is the new behavior (if this is a feature change)?**
You can configure vMix devices via the UI


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
