### PR TITLE
feat: untimed parts

### DIFF
--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -261,6 +261,8 @@ export const RundownTimingProvider = withTracker<
 						(itIndex >= currentAIndex && currentAIndex >= 0) ||
 						(itIndex >= nextAIndex && nextAIndex >= 0 && currentAIndex === -1)
 
+					const partIsUntimed = partInstance.part.untimed || false
+
 					// expected is just a sum of expectedDurations
 					totalRundownDuration += partInstance.part.expectedDuration || 0
 
@@ -290,7 +292,8 @@ export const RundownTimingProvider = withTracker<
 							// or there is a following member of this displayDurationGroup
 							(parts[itIndex + 1] &&
 								parts[itIndex + 1].displayDurationGroup === partInstance.part.displayDurationGroup)) &&
-						!partInstance.part.floated
+						!partInstance.part.floated &&
+						!partIsUntimed
 					) {
 						this.displayDurationGroups[partInstance.part.displayDurationGroup] =
 							(this.displayDurationGroups[partInstance.part.displayDurationGroup] || 0) +
@@ -352,13 +355,16 @@ export const RundownTimingProvider = withTracker<
 					// asPlayed is the actual duration so far and expected durations in unplayed lines.
 					// If item is onAir right now, it's duration is counted as expected duration or current
 					// playback duration whichever is larger.
-					// Parts that don't count are ignored.
-					if (lastStartedPlayback && !partInstance.timings?.duration) {
-						asPlayedRundownDuration += Math.max(partExpectedDuration, now - lastStartedPlayback)
-					} else if (partInstance.timings?.duration) {
-						asPlayedRundownDuration += partInstance.timings.duration
-					} else if (partCounts) {
-						asPlayedRundownDuration += partInstance.part.expectedDuration || 0
+					// Parts that are Untimed are ignored always.
+					// Parts that don't count are ignored, unless they are being played or have been played.
+					if (!partIsUntimed) {
+						if (lastStartedPlayback && !partInstance.timings?.duration) {
+							asPlayedRundownDuration += Math.max(partExpectedDuration, now - lastStartedPlayback)
+						} else if (partInstance.timings?.duration) {
+							asPlayedRundownDuration += partInstance.timings.duration
+						} else if (partCounts) {
+							asPlayedRundownDuration += partInstance.part.expectedDuration || 0
+						}
 					}
 
 					// asDisplayed is the actual duration so far and expected durations in unplayed lines
@@ -392,6 +398,7 @@ export const RundownTimingProvider = withTracker<
 						partInstance.part.displayDurationGroup &&
 						!partInstance.part.floated &&
 						!partInstance.part.invalid &&
+						!partIsUntimed &&
 						(partInstance.timings?.duration || partInstance.timings?.takeOut || partCounts)
 					) {
 						this.displayDurationGroups[partInstance.part.displayDurationGroup] =
@@ -418,14 +425,15 @@ export const RundownTimingProvider = withTracker<
 					// remaining is the sum of unplayed lines + whatever is left of the current segment
 					// if outOfOrderTiming is true, count parts before current part towards remaining rundown duration
 					// if false (default), past unplayed parts will not count towards remaining time
-					if (!lastStartedPlayback && !partInstance.part.floated && partCounts) {
+					if (!lastStartedPlayback && !partInstance.part.floated && partCounts && !partIsUntimed) {
 						remainingRundownDuration += partExpectedDuration || 0
 						// item is onAir right now, and it's is currently shorter than expectedDuration
 					} else if (
 						lastStartedPlayback &&
 						!partInstance.timings?.duration &&
 						playlist.currentPartInstanceId === partInstance._id &&
-						lastStartedPlayback + partExpectedDuration > now
+						lastStartedPlayback + partExpectedDuration > now &&
+						!partIsUntimed
 					) {
 						remainingRundownDuration += partExpectedDuration - (now - lastStartedPlayback)
 					}

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -24,8 +24,8 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 		let budget = 0
 		let playedOut = 0
 		props.parts.forEach((part) => {
-			budget += part.instance.orphaned ? 0 : part.instance.part.expectedDuration || 0
-			playedOut += partPlayed[unprotectString(part.instance.part._id)] || 0
+			budget += part.instance.orphaned || part.instance.part.untimed ? 0 : part.instance.part.expectedDuration || 0
+			playedOut += (!part.instance.part.untimed ? partPlayed[unprotectString(part.instance.part._id)] : 0) || 0
 		})
 
 		const duration = budget - playedOut

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -74,6 +74,7 @@ export class Part implements DBPart {
 		message: ITranslatableMessage
 		color?: string
 	}
+	public untimed?: boolean
 	public floated?: boolean
 	public gap?: boolean
 	// From IBlueprintPartDB:

--- a/meteor/server/api/blueprints/events.ts
+++ b/meteor/server/api/blueprints/events.ts
@@ -183,8 +183,9 @@ export function reportPartInstanceHasStarted(cache: CacheForPlayout, partInstanc
 		cache.Playlist.update((pl) => {
 			if (!pl.rundownsStartedPlayback) pl.rundownsStartedPlayback = {}
 			const rundownId = unprotectString(partInstance.rundownId)
-			if (!pl.rundownsStartedPlayback[rundownId]) pl.rundownsStartedPlayback[rundownId] = timestamp
-			if (!pl.startedPlayback) pl.startedPlayback = timestamp
+			if (!pl.rundownsStartedPlayback[rundownId] && !partInstance.part.untimed)
+				pl.rundownsStartedPlayback[rundownId] = timestamp
+			if (!pl.startedPlayback && !partInstance.part.untimed) pl.startedPlayback = timestamp
 			return pl
 		})
 

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -38,7 +38,6 @@ export async function takeNextPartInnerSync(cache: CacheForPlayout, now: number)
 	const playlistActivationId = cache.Playlist.doc.activationId
 
 	let timeOffset: number | null = cache.Playlist.doc.nextTimeOffset || null
-	const isFirstTake = !cache.Playlist.doc.startedPlayback
 
 	const { currentPartInstance, nextPartInstance, previousPartInstance } = getSelectedPartInstancesFromCache(cache)
 
@@ -48,6 +47,9 @@ export async function takeNextPartInnerSync(cache: CacheForPlayout, now: number)
 	const currentRundown = partInstance ? cache.Rundowns.findOne(partInstance.rundownId) : undefined
 	if (!currentRundown)
 		throw new Meteor.Error(404, `Rundown "${(partInstance && partInstance.rundownId) || ''}" could not be found!`)
+
+	// it is only a first take if the Playlist has no startedPlayback and the taken PartInstance is not untimed
+	const isFirstTake = !cache.Playlist.doc.startedPlayback && !partInstance.part.untimed
 
 	const pShowStyle = cache.activationCache.getShowStyleCompound(currentRundown)
 	const pBlueprint = pShowStyle.then((s) => loadShowStyleBlueprint(s))

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -138,6 +138,7 @@ export interface IBlueprintPart<TMetadata = unknown> extends IBlueprintMutatable
 	 * * Infinites still works as normal
 	 */
 	invalid?: boolean
+
 	/**
 	 * Provide additional information about the reason a part is invalid. The `key` is the string key from blueprints
 	 * translations. Args will be used to replace placeholders within the translated file. If `key` is not found in the
@@ -155,6 +156,17 @@ export interface IBlueprintPart<TMetadata = unknown> extends IBlueprintMutatable
 		message: ITranslatableMessage
 		color?: string
 	}
+
+	/**
+	 * Take a part out of timing considerations for a Rundown & Rundown Playlist. This part can be TAKEN but will not
+	 * update playlist's startedPlayback and will not count time in the GUI.
+	 *
+	 * Some parts shouldn't count towards the various timing information in Sofie. Specifically, it may be useful to
+	 * have some Parts execute Timelines outside of the regular flow of time, such as when doing an ad break or
+	 * performing some additional actions before a show actually begins (such as when there's a bit of a buffer before
+	 * the On Air time of a Show and when the MCR cuts to the PGM, because the previous show ended quicker).
+	 */
+	untimed?: boolean
 
 	/** When the NRCS informs us that the producer marked the part as floated, we can prevent the user from TAKE'ing and NEXT'ing it, but still have it visible and allow manipulation */
 	floated?: boolean


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature.

* **What is the current behavior?** (You can also link to an open issue here)

All playable parts are counted towards show time and as-played time - unless they are "invalid" or "floated", which renders them unplayable.

* **What is the new behavior (if this is a feature change)?**

A Part can be marked as "untimed" which will keep them playable, but cause them to:
* not trigger blueprints "firstTake" callback
* not set `startedPlayback` on a playlist when they are taken, the `startedPlayback` will be set once a not-"untimed" part is taken
* not count towards segment time budget
* there will be a countdown to the end of an "untimed" part (unless it's `expectedDuration` is 0) and the "On Air In" counter will also be affected by the duration of an "untimed" part.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
