### PR TITLE
feat: add baseline expectedPlayoutItems support

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -250,8 +250,10 @@ export function setupMockStudioBlueprint(showStyleBaseId: ShowStyleBaseId): Blue
 
 				studioConfigManifest: [],
 				studioMigrations: [],
-				getBaseline: (): TSR.TSRTimelineObjBase[] => {
-					return []
+				getBaseline: () => {
+					return {
+						timelineObjects: [],
+					}
 				},
 				getShowStyleId: (): string | null => {
 					return SHOW_STYLE_ID
@@ -302,7 +304,7 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 					return {
 						rundown,
 						globalAdLibPieces: [],
-						baseline: [],
+						baseline: { timelineObjects: [] },
 					}
 				},
 				getSegment: (context: unknown, ingestSegment: IngestSegment): BlueprintResultSegment => {

--- a/meteor/lib/collections/ExpectedPlayoutItems.ts
+++ b/meteor/lib/collections/ExpectedPlayoutItems.ts
@@ -13,18 +13,33 @@ import { registerIndex } from '../database'
  */
 export type ExpectedPlayoutItemId = ProtectedString<'ExpectedPlayoutItemId'>
 /** @deprecated */
-export interface ExpectedPlayoutItem extends ExpectedPlayoutItemGeneric {
+export interface ExpectedPlayoutItemBase extends ExpectedPlayoutItemGeneric {
 	/** Globally unique id of the item */
 	_id: ExpectedPlayoutItemId
 
 	/** The studio installation this ExpectedPlayoutItem was generated in */
 	studioId: StudioId
+}
+/** @deprecated */
+export interface ExpectedPlayoutItemRundown extends ExpectedPlayoutItemBase {
 	/** The rundown id that is the source of this PlayoutItem */
 	rundownId: RundownId
 	/** The part id that is the source of this Playout Item */
 	partId?: PartId
 	// /** The piece id that is the source of this Playout Item */
 	// pieceId: PieceId
+	/** Is created for studio/rundown baseline */
+	baseline?: 'rundown'
+}
+/** @deprecated */
+export interface ExpectedPlayoutItemStudio extends ExpectedPlayoutItemBase {
+	baseline: 'studio'
+}
+/** @deprecated */
+export type ExpectedPlayoutItem = ExpectedPlayoutItemStudio | ExpectedPlayoutItemRundown
+/** @deprecated */
+export function isExpectedPlayoutItemRundown(item: ExpectedPlayoutItem): item is ExpectedPlayoutItemRundown {
+	return item.baseline !== 'studio'
 }
 
 /** @deprecated */
@@ -39,4 +54,8 @@ registerIndex(ExpectedPlayoutItems, {
 })
 registerIndex(ExpectedPlayoutItems, {
 	rundownId: 1,
+})
+registerIndex(ExpectedPlayoutItems, {
+	studioId: 1,
+	baseline: 1,
 })

--- a/meteor/server/api/blueprints/__tests__/cache.test.ts
+++ b/meteor/server/api/blueprints/__tests__/cache.test.ts
@@ -110,7 +110,11 @@ describe('Test blueprint cache', () => {
 
 				studioConfigManifest: [],
 				studioMigrations: [],
-				getBaseline: () => [],
+				getBaseline: () => {
+					return {
+						timelineObjects: [],
+					}
+				},
 				getShowStyleId: () => null,
 			})
 
@@ -250,7 +254,11 @@ describe('Test blueprint cache', () => {
 
 				studioConfigManifest: [],
 				studioMigrations: [],
-				getBaseline: () => [],
+				getBaseline: () => {
+					return {
+						timelineObjects: [],
+					}
+				},
 				getShowStyleId: () => null,
 			})
 

--- a/meteor/server/api/blueprints/__tests__/context.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context.test.ts
@@ -110,7 +110,11 @@ describe('Test blueprint api context', () => {
 				] as ConfigManifestEntry[],
 
 				studioMigrations: [],
-				getBaseline: () => [],
+				getBaseline: () => {
+					return {
+						timelineObjects: [],
+					}
+				},
 				getShowStyleId: () => null,
 			})
 			const blueprint = generateFakeBlueprint('', BlueprintManifestType.STUDIO, manifest)

--- a/meteor/server/api/blueprints/__tests__/lib.ts
+++ b/meteor/server/api/blueprints/__tests__/lib.ts
@@ -13,7 +13,11 @@ export function generateFakeBlueprint(id: string, type?: BlueprintManifestType, 
   TSRVersion: '0.0.0',
   studioConfigManifest: [],
   studioMigrations: [],
-  getBaseline: () => [],
+  getBaseline: () => {
+	return {
+      timelineObjects: [],
+    }
+  },
   getShowStyleId: () => null
 })`
 

--- a/meteor/server/api/ingest/cleanup.ts
+++ b/meteor/server/api/ingest/cleanup.ts
@@ -1,3 +1,4 @@
+import { isExpectedPlayoutItemRundown } from '../../../lib/collections/ExpectedPlayoutItems'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { CacheForIngest } from './cache'
 
@@ -14,7 +15,9 @@ export function removeSegmentContents(cache: CacheForIngest, segmentIds: Set<Seg
 			// Clean up all the db items that belong to the removed Parts
 			const removedPartIds2 = new Set(removedPartIds)
 			cache.Pieces.remove((p) => removedPartIds2.has(p.startPartId))
-			cache.ExpectedPlayoutItems.remove((e) => e.partId && removedPartIds2.has(e.partId))
+			cache.ExpectedPlayoutItems.remove(
+				(e) => isExpectedPlayoutItemRundown(e) && e.partId && removedPartIds2.has(e.partId)
+			)
 			cache.ExpectedMediaItems.remove((e) => 'partId' in e && e.partId && removedPartIds2.has(e.partId))
 			cache.AdLibPieces.remove((e) => e.partId && removedPartIds2.has(e.partId))
 			cache.AdLibActions.remove((e) => removedPartIds2.has(e.partId))

--- a/meteor/server/api/ingest/expectedPackages.ts
+++ b/meteor/server/api/ingest/expectedPackages.ts
@@ -17,19 +17,25 @@ import {
 	getContentVersionHash,
 } from '../../../lib/collections/ExpectedPackages'
 import { Studio, Studios } from '../../../lib/collections/Studios'
-import { ExpectedPackage } from '@sofie-automation/blueprints-integration'
+import { BlueprintResultBaseline, ExpectedPackage } from '@sofie-automation/blueprints-integration'
 import { Piece, PieceId } from '../../../lib/collections/Pieces'
 import { BucketAdLibAction, BucketAdLibActionId, BucketAdLibActions } from '../../../lib/collections/BucketAdlibActions'
 import { Meteor } from 'meteor/meteor'
 import { BucketAdLib, BucketAdLibId, BucketAdLibs } from '../../../lib/collections/BucketAdlibs'
 import { RundownBaselineAdLibAction } from '../../../lib/collections/RundownBaselineAdLibActions'
-import { updateExpectedPlayoutItemsOnRundown } from './expectedPlayoutItems'
+import {
+	updateBaselineExpectedPlayoutItemsOnRundown,
+	updateBaselineExpectedPlayoutItemsOnStudio,
+	updateExpectedPlayoutItemsOnRundown,
+} from './expectedPlayoutItems'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { PieceInstances } from '../../../lib/collections/PieceInstances'
 import { CacheForIngest } from './cache'
 import { asyncCollectionRemove, saveIntoDb } from '../../lib/database'
 import { saveIntoCache } from '../../cache/lib'
 import { ReadonlyDeep } from 'type-fest'
+import { CacheForPlayout } from '../playout/cache'
+import { CacheForStudio } from '../studio/cache'
 
 export function updateExpectedPackagesOnRundown(cache: CacheForIngest): void {
 	// @todo: this call is for backwards compatibility and soon to be removed
@@ -252,4 +258,24 @@ export async function cleanUpExpectedPackagesForBucketAdLibsActions(adLibIds: Ad
 			$in: adLibIds,
 		},
 	})
+}
+
+export function updateBaselineExpectedPackagesOnRundown(
+	cache: CacheForIngest,
+	baseline: BlueprintResultBaseline
+): void {
+	// @todo: this call is for backwards compatibility and soon to be removed
+	updateBaselineExpectedPlayoutItemsOnRundown(cache, baseline.expectedPlayoutItems)
+
+	// @todo: implement
+}
+
+export function updateBaselineExpectedPackagesOnStudio(
+	cache: CacheForStudio | CacheForPlayout,
+	baseline: BlueprintResultBaseline
+): void {
+	// @todo: this call is for backwards compatibility and soon to be removed
+	updateBaselineExpectedPlayoutItemsOnStudio(cache, baseline.expectedPlayoutItems)
+
+	// @todo: implement
 }

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -32,6 +32,7 @@ import { profiler } from '../profiler'
 import { selectShowStyleVariant } from '../rundown'
 import { getShowStyleCompoundForRundown } from '../showStyles'
 import { CacheForIngest } from './cache'
+import { updateBaselineExpectedPackagesOnRundown } from './expectedPackages'
 import { LocalIngestRundown, LocalIngestSegment } from './ingestCache'
 import {
 	getSegmentId,
@@ -463,7 +464,7 @@ export async function updateRundownFromIngestData(
 		identifier: `rundownId=${dbRundown._id}`,
 	})
 	logger.info(`Building baseline objects for ${dbRundown._id}...`)
-	logger.info(`... got ${rundownRes.baseline.length} objects from baseline.`)
+	logger.info(`... got ${rundownRes.baseline.timelineObjects.length} objects from baseline.`)
 	logger.info(`... got ${rundownRes.globalAdLibPieces.length} adLib objects from baseline.`)
 	logger.info(`... got ${(rundownRes.globalActions || []).length} adLib actions from baseline.`)
 
@@ -475,7 +476,7 @@ export async function updateRundownFromIngestData(
 				objects: postProcessRundownBaselineItems(
 					blueprintRundownContext,
 					showStyle.base.blueprintId,
-					rundownRes.baseline
+					rundownRes.baseline.timelineObjects
 				),
 			},
 		]),
@@ -536,6 +537,8 @@ export async function updateRundownFromIngestData(
 		segmentChanges.adlibPieces.push(...cache.AdLibPieces.findFetch((p) => p.partId && oldPartIds.has(p.partId)))
 		segmentChanges.adlibActions.push(...cache.AdLibActions.findFetch((p) => p.partId && oldPartIds.has(p.partId)))
 	}
+
+	updateBaselineExpectedPackagesOnRundown(cache, rundownRes.baseline)
 
 	await saveSegmentChangesToCache(cache, segmentChanges, true)
 

--- a/meteor/server/api/system.ts
+++ b/meteor/server/api/system.ts
@@ -192,6 +192,25 @@ function cleanupOldDataInner(actuallyCleanup: boolean = false): CollectionCleanu
 			studioId: { $nin: studioIds },
 		})
 	}
+	const ownedByRundownIdOrStudioId = <
+		Class extends DBInterface,
+		DBInterface extends { _id: ProtectedString<any>; rundownId?: RundownId; studioId: StudioId }
+	>(
+		collectionName,
+		collection: TransformedCollection<Class, DBInterface>
+	): CollectionCleanupResult => {
+		return removeByQuery(collectionName, collection as TransformedCollection<any, any>, {
+			$or: [
+				{
+					rundownId: { $exists: true, $nin: rundownIds },
+				},
+				{
+					rundownId: { $exists: false },
+					studioId: { $nin: studioIds },
+				},
+			],
+		})
+	}
 	const ownedByOrganizationId = <
 		Class extends DBInterface,
 		DBInterface extends { _id: ProtectedString<any>; organizationId: OrganizationId | null | undefined }
@@ -304,7 +323,7 @@ function cleanupOldDataInner(actuallyCleanup: boolean = false): CollectionCleanu
 	}
 	// ExpectedPlayoutItems
 	{
-		results.push(ownedByRundownId('ExpectedPlayoutItems', ExpectedPlayoutItems))
+		results.push(ownedByRundownIdOrStudioId('ExpectedPlayoutItems', ExpectedPlayoutItems))
 	}
 	// ExternalMessageQueue
 	{

--- a/meteor/server/migration/__tests__/migrations.test.ts
+++ b/meteor/server/migration/__tests__/migrations.test.ts
@@ -289,7 +289,11 @@ describe('Migrations', () => {
 					},
 				},
 			],
-			getBaseline: () => [],
+			getBaseline: () => {
+				return {
+					timelineObjects: [],
+				}
+			},
 			getShowStyleId: () => null,
 		})
 
@@ -344,7 +348,11 @@ describe('Migrations', () => {
 					},
 				},
 			],
-			getBaseline: () => [],
+			getBaseline: () => {
+				return {
+					timelineObjects: [],
+				}
+			},
 			getShowStyleId: () => null,
 			getShowStyleVariantId: () => null,
 			getRundown: () => ({
@@ -353,7 +361,7 @@ describe('Migrations', () => {
 					name: '',
 				},
 				globalAdLibPieces: [],
-				baseline: [],
+				baseline: { timelineObjects: [] },
 			}),
 			getSegment: () => ({
 				segment: { name: '' },

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -32,10 +32,12 @@ import {
 	IBlueprintPartInstance,
 	IBlueprintAdLibPieceDB,
 	IBlueprintPartDB,
+	ExpectedPlayoutItemGeneric,
 } from './rundown'
 import { IBlueprintShowStyleBase, IBlueprintShowStyleVariant } from './showStyle'
 import { OnGenerateTimelineObj } from './timeline'
 import { IBlueprintConfig } from './common'
+import { ExpectedPackage } from './package'
 
 export enum BlueprintManifestType {
 	SYSTEM = 'system',
@@ -83,7 +85,7 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	translations?: string
 
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
-	getBaseline: (context: IStudioContext) => TSRTimelineObjBase[]
+	getBaseline: (context: IStudioContext) => BlueprintResultStudioBaseline
 
 	/** Returns the id of the show style to use for a rundown, return null to ignore that rundown */
 	getShowStyleId: (
@@ -204,12 +206,18 @@ export interface BlueprintResultTimeline {
 	timeline: OnGenerateTimelineObj[]
 	persistentState: TimelinePersistentState
 }
-
+export interface BlueprintResultBaseline {
+	timelineObjects: TSRTimelineObjBase[]
+	/** @deprecated */
+	expectedPlayoutItems?: ExpectedPlayoutItemGeneric[]
+	expectedPackages?: ExpectedPackage.Any[]
+}
+export type BlueprintResultStudioBaseline = BlueprintResultBaseline
 export interface BlueprintResultRundown {
 	rundown: IBlueprintRundown
 	globalAdLibPieces: IBlueprintAdLibPiece[]
 	globalActions?: IBlueprintActionManifest[]
-	baseline: TSRTimelineObjBase[]
+	baseline: BlueprintResultBaseline
 }
 export interface BlueprintResultSegment {
 	segment: IBlueprintSegment


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature.


* **What is the current behavior?** (You can also link to an open issue here)
No way of making Expected Playout Items (Expected Packages in the future) for items from the studio and rundown baseline.


* **What is the new behavior (if this is a feature change)?**
Changes `getBaseline` and `getRundown` return types to include Expected Playout Items (Expected Packages).
Logic for Expected Packages not implemented yet.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
