### PR TITLE
fix: Update playlist after removing rundown

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -299,6 +299,11 @@ export function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariant
 						// expectedDuration?: number;
 						metaData: ingestRundown.payload,
 					}
+
+					// Allow the rundown to specify a playlistExternalId that should be used
+					const playlistId = ingestRundown.payload?.ForcePlaylistExternalId
+					if (playlistId) rundown.playlistExternalId = playlistId
+
 					return {
 						rundown,
 						globalAdLibPieces: [],

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -6179,12 +6179,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"lodash": {
-					"version": "4.17.21",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -8681,9 +8675,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
@@ -11526,9 +11520,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",

--- a/meteor/server/api/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/__tests__/rundownPlaylist.test.ts
@@ -76,7 +76,6 @@ describe('Rundown', () => {
 			playlist0.externalId,
 			rundownsCollection.findFetch()
 		)
-		// rundownPlaylistInfo.rundownPlaylist.rundownRanksAreSetInSofie = true
 		updateRundownsInPlaylist(rundownPlaylistInfo.rundownPlaylist, rundownPlaylistInfo.order, rundownsCollection)
 		waitForPromise(rundownsCollection.updateDatabaseWithData())
 
@@ -92,21 +91,6 @@ describe('Rundown', () => {
 
 		playlist0 = RundownPlaylists.findOne(playlistId0) as RundownPlaylist
 		expect(playlist0).toBeTruthy()
-
-		// // This should do no change, since rank is now controlled by Sofie:
-		// rundownsCollection = new DbCacheWriteCollection(Rundowns)
-		// waitForPromise(rundownsCollection.prepareInit({ playlistId: playlist0._id }, true))
-		// rundownPlaylistInfo = produceRundownPlaylistInfoFromRundown(
-		// 	env.studio,
-		// 	undefined,
-		// 	playlist0,
-		// 	playlist0._id,
-		// 	playlist0.externalId,
-		// 	rundownsCollection.findFetch()
-		// )
-		// updateRundownsInPlaylist(rundownPlaylistInfo.rundownPlaylist, rundownPlaylistInfo.order, rundownsCollection)
-		// waitForPromise(rundownsCollection.updateDatabaseWithData())
-		// expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown02', 'rundown00'])
 
 		Meteor.call(RundownAPIMethods.moveRundown, rundownId02, playlist0, ['rundown02', 'rundown01', 'rundown00'])
 		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown02', 'rundown01', 'rundown00'])

--- a/meteor/server/api/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/__tests__/rundownPlaylist.test.ts
@@ -76,6 +76,7 @@ describe('Rundown', () => {
 			playlist0.externalId,
 			rundownsCollection.findFetch()
 		)
+		// rundownPlaylistInfo.rundownPlaylist.rundownRanksAreSetInSofie = true
 		updateRundownsInPlaylist(rundownPlaylistInfo.rundownPlaylist, rundownPlaylistInfo.order, rundownsCollection)
 		waitForPromise(rundownsCollection.updateDatabaseWithData())
 
@@ -92,20 +93,20 @@ describe('Rundown', () => {
 		playlist0 = RundownPlaylists.findOne(playlistId0) as RundownPlaylist
 		expect(playlist0).toBeTruthy()
 
-		// This should do no change, since rank is now controlled by Sofie:
-		rundownsCollection = new DbCacheWriteCollection(Rundowns)
-		waitForPromise(rundownsCollection.prepareInit({ playlistId: playlist0._id }, true))
-		rundownPlaylistInfo = produceRundownPlaylistInfoFromRundown(
-			env.studio,
-			undefined,
-			playlist0,
-			playlist0._id,
-			playlist0.externalId,
-			rundownsCollection.findFetch()
-		)
-		updateRundownsInPlaylist(rundownPlaylistInfo.rundownPlaylist, rundownPlaylistInfo.order, rundownsCollection)
-		waitForPromise(rundownsCollection.updateDatabaseWithData())
-		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown02', 'rundown00'])
+		// // This should do no change, since rank is now controlled by Sofie:
+		// rundownsCollection = new DbCacheWriteCollection(Rundowns)
+		// waitForPromise(rundownsCollection.prepareInit({ playlistId: playlist0._id }, true))
+		// rundownPlaylistInfo = produceRundownPlaylistInfoFromRundown(
+		// 	env.studio,
+		// 	undefined,
+		// 	playlist0,
+		// 	playlist0._id,
+		// 	playlist0.externalId,
+		// 	rundownsCollection.findFetch()
+		// )
+		// updateRundownsInPlaylist(rundownPlaylistInfo.rundownPlaylist, rundownPlaylistInfo.order, rundownsCollection)
+		// waitForPromise(rundownsCollection.updateDatabaseWithData())
+		// expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown02', 'rundown00'])
 
 		Meteor.call(RundownAPIMethods.moveRundown, rundownId02, playlist0, ['rundown02', 'rundown01', 'rundown00'])
 		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown02', 'rundown01', 'rundown00'])
@@ -149,7 +150,7 @@ describe('Rundown', () => {
 		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown00'])
 		// Note: the order here will be ignored, new rundowns are placed last:
 		Meteor.call(RundownAPIMethods.moveRundown, rundownId02, playlist0, ['rundown01', 'rundown02', 'rundown00'])
-		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown00', 'rundown02'])
+		expect(playlist0.getRundowns().map((r) => r._id)).toEqual(['rundown01', 'rundown02', 'rundown00'])
 		expect(playlist1.getRundowns().map((r) => r._id)).toEqual(['rundown10'])
 		expect(RundownPlaylists.find().count()).toEqual(2) // A playlist was removed
 

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -1,9 +1,5 @@
 import { ShowStyleCompound } from '../../../lib/collections/ShowStyleVariants'
-import {
-	loadShowStyleBlueprint,
-	loadStudioBlueprint,
-	WrappedShowStyleBlueprint,
-} from '../blueprints/cache'
+import { loadShowStyleBlueprint, loadStudioBlueprint, WrappedShowStyleBlueprint } from '../blueprints/cache'
 import { CacheForPlayout, getSelectedPartInstancesFromCache } from '../playout/cache'
 import { triggerUpdateTimelineAfterIngestData } from '../playout/playout'
 import { allowedToMoveRundownOutOfPlaylist, ChangedSegmentsRankInfo, updatePartInstanceRanks } from '../rundown'
@@ -299,7 +295,7 @@ async function generatePlaylistAndRundownsCollection(
 		ingestCache.Studio.doc,
 		finalRundown,
 		newPlaylistId,
-		newPlaylistExternalId,
+		newPlaylistExternalId
 	)
 
 	// Update the ingestCache to keep them in sync
@@ -324,17 +320,25 @@ async function generatePlaylistAndRundownsCollectionInner(
 ): Promise<[RundownPlaylist, DbCacheWriteCollection<Rundown, DBRundown>]> {
 	if (existingPlaylist0) {
 		if (existingPlaylist0._id !== newPlaylistId) {
-			throw new Meteor.Error(500, `ingest.generatePlaylistAndRundownsCollection requires existingPlaylist0("${existingPlaylist0._id}") newPlaylistId("${newPlaylistId}") to be the same`)
+			throw new Meteor.Error(
+				500,
+				`ingest.generatePlaylistAndRundownsCollection requires existingPlaylist0("${existingPlaylist0._id}") newPlaylistId("${newPlaylistId}") to be the same`
+			)
 		}
 		if (existingPlaylist0.externalId !== newPlaylistExternalId) {
-			throw new Meteor.Error(500, `ingest.generatePlaylistAndRundownsCollection requires existingPlaylist0("${existingPlaylist0.externalId}") newPlaylistExternalId("${newPlaylistExternalId}") to be the same`)
+			throw new Meteor.Error(
+				500,
+				`ingest.generatePlaylistAndRundownsCollection requires existingPlaylist0("${existingPlaylist0.externalId}") newPlaylistExternalId("${newPlaylistExternalId}") to be the same`
+			)
 		}
 	}
 
 	// Load existing playout data
 	const rundownsCollection = existingRundownsCollection ?? new DbCacheWriteCollection(Rundowns)
 	const [existingPlaylist, studioBlueprint] = await Promise.all([
-		existingPlaylist0 ? existingPlaylist0 : (asyncCollectionFindOne(RundownPlaylists, newPlaylistId) as Promise<ReadonlyDeep<RundownPlaylist>>) ,
+		existingPlaylist0
+			? existingPlaylist0
+			: (asyncCollectionFindOne(RundownPlaylists, newPlaylistId) as Promise<ReadonlyDeep<RundownPlaylist>>),
 		makePromise(() => loadStudioBlueprint(studio)),
 		existingRundownsCollection ? null : rundownsCollection.prepareInit({ playlistId: newPlaylistId }, true),
 	])

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -4357,9 +4357,9 @@ highland@^3.0.0-beta.6:
   integrity sha512-fBxAarP4g0AFWRKd+SJBWsKmkyw1WZdQZ1jjFSAVrxLXIhEo5NnEBy+rDEM695Z/i4/tP2lMYW6iuotStDFHYw==
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

When a rundown is removed from a playlist, the playlist is not regenerated.
This means that the name, timing or any other properties can refer to the recently removed rundown.

* **What is the new behavior (if this is a feature change)?**

Whenever a rundown is removed from a playlist (or moved out of a playlist), that playlist gets regenerated in the same way as when we add/update a rundown in the playlist.
If the ordering is calculated by the blueprints, the order of the remaining rundowns will be updated too.

* **Other information**:

I am unsure if this is targetting the correct release, it might want to be delayed to r34/r35 depending on how criticial the bug is

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
