### PR TITLE
feat: expose PartEndState to the adlib actions (#518) [publish]

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -68,7 +68,6 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 
 	part: DBPart
 
-
 	/** The transition props as used when entering this PartInstance */
 	allowedToUseTransition?: boolean
 }

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -68,8 +68,6 @@ export interface DBPartInstance extends InternalIBlueprintPartInstance {
 
 	part: DBPart
 
-	/** The end state of the previous part, to allow for bits of this to part to be based on what the previous did/was */
-	previousPartEndState?: PartEndState
 
 	/** The transition props as used when entering this PartInstance */
 	allowedToUseTransition?: boolean

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -223,7 +223,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		})
 		if (!pieceDB) throw new Error(`Cannot find Piece ${piece._id}`)
 
-		return Parts.findOne({ _id: pieceDB.startPartId })
+		return this._cache.Parts.findOne({ _id: pieceDB.startPartId })
 	}
 
 	insertPiece(part: 'current' | 'next', rawPiece: IBlueprintPiece): IBlueprintPieceInstance {

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -19,7 +19,7 @@ import { PartEndState, ShowStyleBlueprintManifest, VTContent } from '@sofie-auto
 import { getResolvedPieces } from './pieces'
 import { PieceInstance, PieceInstanceId, PieceInstanceInfiniteId } from '../../../lib/collections/PieceInstances'
 import { PartEventContext, RundownContext } from '../blueprints/context/context'
-import { PartInstance } from '../../../lib/collections/PartInstances'
+import { PartInstance, unprotectPartInstance } from '../../../lib/collections/PartInstances'
 import { IngestActions } from '../ingest/actions'
 import { PeripheralDeviceAPI } from '../../../lib/api/peripheralDevice'
 import { reportPartInstanceHasStarted } from '../blueprints/events'
@@ -304,7 +304,7 @@ export function updatePartInstanceOnTake(
 		previousPartEndState = blueprint.getEndStateForPart(
 			context,
 			playlist.previousPersistentState,
-			currentPartInstance.previousPartEndState,
+			unprotectPartInstance(clone(currentPartInstance)),
 			unprotectObjectArray(resolvedPieces),
 			time
 		)

--- a/packages/blueprints-integration/src/api.ts
+++ b/packages/blueprints-integration/src/api.ts
@@ -180,7 +180,7 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 	getEndStateForPart?: (
 		context: IRundownContext,
 		previousPersistentState: TimelinePersistentState | undefined,
-		previousPartEndState: PartEndState | undefined,
+		partInstance: IBlueprintPartInstance,
 		resolvedPieces: IBlueprintResolvedPieceInstance[],
 		time: number
 	) => PartEndState

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -8,6 +8,7 @@ import {
 	IBlueprintRundownDB,
 	IBlueprintMutatablePart,
 	IBlueprintSegmentDB,
+	IBlueprintPieceDB,
 } from './rundown'
 import { BlueprintMappings } from './studio'
 import { OnGenerateTimelineObj } from './timeline'
@@ -136,8 +137,10 @@ export interface IActionExecutionContext extends IShowStyleUserContext, IEventCo
 			pieceMetaDataFilter?: any
 		}
 	): IBlueprintPiece | undefined
-	/** Gets the PartInstance for a PieceInstane retrieved from findLastPieceOnLayer. This primarily allows for accessing metadata of the PartInstance */
+	/** Gets the PartInstance for a PieceInstance retrieved from findLastPieceOnLayer. This primarily allows for accessing metadata of the PartInstance */
 	getPartInstanceForPreviousPiece(piece: IBlueprintPieceInstance): IBlueprintPartInstance
+	/** Gets the Part for a Piece retrieved from findLastScriptedPieceOnLayer. This primarily allows for accessing metadata of the Part */
+	getPartForPreviousPiece(piece: IBlueprintPieceDB): IBlueprintPart | undefined
 	/** Fetch the showstyle config for the specified part */
 	// getNextShowStyleConfig(): Readonly<{ [key: string]: ConfigItemValue }>
 

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -3,6 +3,7 @@ import { Time } from './common'
 import { ExpectedPackage, ListenToPackageUpdate } from './package'
 import { SomeTimelineContent } from './content'
 import { ITranslatableMessage } from './translations'
+import { PartEndState } from './api'
 
 export interface IBlueprintRundownPlaylistInfo {
 	/** Rundown playlist slug - user-presentable name */
@@ -192,6 +193,9 @@ export interface IBlueprintPartInstance<TMetadata = unknown> {
 	rehearsal: boolean
 	/** Playout timings, in here we log times when playout happens */
 	timings?: IBlueprintPartInstanceTimings
+
+	/** The end state of the previous part, to allow for bits of this to part to be based on what the previous did/was */
+	previousPartEndState?: PartEndState
 
 	/** Whether the PartInstance is an orphan (the Part referenced does not exist). Indicates the reason it is orphaned */
 	orphaned?: 'adlib-part' | 'deleted'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Adlib actions are unable to access the `PartEndState` of the previous part. This data is owned by the blueprints, and is currently only consumed by `onTimelineGenerate` and future calls to `getPartEndState`

* **What is the new behavior (if this is a feature change)?**

Adlib actions are now able to get access this `PartEndState` directly on any `IBlueprintPartInstance`.

`getPartEndState` has been modified to have access to the full `IBlueprintPartInstance` too, so that it can use the `metaData` or other properties.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
