### PR TITLE
feat: add baseline expectedPlayoutItems support to Playout Gateway

### DIFF
--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -377,8 +377,8 @@ const PLAYOUT_SUBDEVICE_CONFIG: SubDeviceConfigManifest['config'] = {
 			type: ConfigManifestEntryType.BOOLEAN,
 		},
 		{
-			id: 'options.onlyPreloadActiveRundown',
-			name: 'Only preload elements in active Rundown',
+			id: 'options.onlyPreloadActivePlaylist',
+			name: 'Only preload elements in active Playlist',
 			type: ConfigManifestEntryType.BOOLEAN,
 		},
 		{

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -332,6 +332,11 @@ const PLAYOUT_SUBDEVICE_CONFIG: SubDeviceConfigManifest['config'] = {
 			type: ConfigManifestEntryType.NUMBER,
 		},
 		{
+			id: 'options.engineRestPort',
+			name: '(Optional) Viz Engines REST port',
+			type: ConfigManifestEntryType.INT,
+		},
+		{
 			id: 'options.showID',
 			name: 'Show ID',
 			type: ConfigManifestEntryType.STRING,

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -72,6 +72,7 @@ export class CoreHandler {
 	private _studioId: string | undefined
 	private _timelineSubscription: string | null = null
 	private _expectedItemsSubscription: string | null = null
+	private _rundownsSubscription: string | null = null
 
 	private _statusInitialized = false
 	private _statusDestroyed = false
@@ -276,6 +277,22 @@ export class CoreHandler {
 						this.logger.error(err)
 					})
 				this.logger.debug('VIZDEBUG: Subscription to expectedPlayoutItems done')
+				// Set up rundowns data subscription:
+				if (this._rundownsSubscription) {
+					this.core.unsubscribe(this._rundownsSubscription)
+					this._rundownsSubscription = null
+				}
+				this.core
+					.autoSubscribe('rundowns', {
+						studioId: studioId,
+					})
+					.then((subscriptionId) => {
+						this._rundownsSubscription = subscriptionId
+					})
+					.catch((err) => {
+						this.logger.error(err)
+					})
+				this.logger.debug('VIZDEBUG: Subscription to rundowns done')
 			}
 
 			if (this._tsrHandler) {

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -827,6 +827,12 @@ export class TSRHandler {
 		const expectedItems = expectedPlayoutItems.find({
 			studioId: peripheralDevice.studioId,
 		})
+		const rundowns = _.indexBy(
+			this._coreHandler.core.getCollection('rundowns').find({
+				studioId: peripheralDevice.studioId,
+			}),
+			'_id'
+		)
 
 		this.logger.debug(`VIZDEBUG: Items after filter ${JSON.stringify(expectedItems)}`)
 
@@ -848,7 +854,8 @@ export class TSRHandler {
 								const newItem: ExpectedPlayoutItem = {
 									...itemContent,
 									rundownId: item.rundownId,
-									playlistId: item.playlistId,
+									playlistId: item.rundownId && rundowns[item.rundownId]?.playlistId,
+									baseline: item.baseline,
 								}
 								return newItem
 							}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A feature and minor config manifest changes related to https://github.com/nrkno/tv-automation-state-timeline-resolver/pull/182


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

  - Adds baseline expectedPlayoutItems support
  - Adds config for Viz Engine REST port config
  - Fixes config property name

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
