### PR TITLE
feat: multistep graphics UI

### DIFF
--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -27,6 +27,8 @@ $segment-nextline-shade-fill: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0
 $rundown-divider-color: #000000;
 $rundown-divider-background-color: #dddddd;
 
+$segment-piece-step-counter: #ffff00;
+
 $liveline-timecode-color: $general-countdown-to-next-color; //$general-live-color;
 $hold-status-color: $liveline-timecode-color;
 
@@ -1757,6 +1759,21 @@ svg.icon {
 									transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity,
 										0s visibility ($output-layer-group-collapse-animation-duration * 1/3);
 								}
+
+								.segment-timeline__piece--collapsed__step-chevron {
+									opacity: 1;
+									visibility: visible;
+									transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity
+											$output-layer-group-collapse-animation-duration * 4/3,
+										0s visibility $output-layer-group-collapse-animation-duration * 4/3;
+								}
+
+								.segment-timeline__piece--decoration__step-chevron {
+									opacity: 0;
+									visibility: hidden;
+									transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity,
+										0s visibility ($output-layer-group-collapse-animation-duration * 1/3);
+								}
 							}
 						}
 
@@ -1767,6 +1784,39 @@ svg.icon {
 						}
 					}
 				}
+			}
+
+			.segment-timeline__piece--collapsed__step-chevron {
+				opacity: 0;
+				visibility: hidden;
+				transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity,
+					0s visibility ($output-layer-group-collapse-animation-duration * 1/3);
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				background-image: url('/images/multi-step-chevrons.svg');
+				background-size: auto 100%;
+				background-position: top left;
+				background-repeat: repeat-x;
+			}
+
+			.segment-timeline__piece--decoration__step-chevron {
+				opacity: 1;
+				visibility: visible;
+				transition: ($output-layer-group-collapse-animation-duration * 1/3) opacity
+						$output-layer-group-collapse-animation-duration,
+					0s visibility $output-layer-group-collapse-animation-duration;
+				position: absolute;
+				top: 0;
+				left: 110px;
+				right: 0;
+				bottom: 0;
+				background-image: url('/images/multi-step-chevrons-default.svg');
+				background-size: auto 100%;
+				background-position: top left;
+				background-repeat: repeat-x;
 			}
 
 			.segment-timeline__piece__label {
@@ -1783,6 +1833,10 @@ svg.icon {
 				line-height: 1.5em;
 
 				transform: translate3d(0, 0, 1px); // Just to make it render in front
+
+				&.no-left-margin {
+					margin-left: 0;
+				}
 
 				&:not(.right-side) {
 					overflow: hidden;
@@ -1876,6 +1930,19 @@ svg.icon {
 					padding: 0;
 					font-size: 0.8em;
 					margin: 0;
+				}
+
+				.segment-timeline__piece__step-chevron {
+					position: relative;
+					vertical-align: top;
+					margin-right: 0.2em;
+					background: rgba(0, 0, 0, 0.4);
+					display: inline-block;
+					padding: 0 1em 0 0.4em;
+					color: $segment-piece-step-counter;
+					text-shadow: 0 0 1px #000, 0.5px 0.5px 8px rgba(0, 0, 0, 0.8);
+					clip-path: polygon(0 0, 70% 0, 100% 50%, 70% 100%, 0 100%);
+					line-height: 1.4em;
 				}
 
 				> .segment-timeline__piece__label {
@@ -2409,6 +2476,19 @@ svg.icon {
 		border: none;
 		&::before {
 			display: none;
+		}
+
+		.segment-timeline__mini-inspector--graphics--preview__step-chevron {
+			position: absolute;
+			top: 0;
+			left: 0;
+			background: $segment-layer-background-graphics;
+			padding: 0 1em;
+			clip-path: polygon(0 0, 75% 0, 100% 50%, 75% 100%, 0 100%, 25% 50%);
+			font-weight: 400;
+			text-shadow: 0 0 1px #000, 0.5px 0.5px 8px rgba(0, 0, 0, 0.8);
+			color: $segment-piece-step-counter;
+			line-height: 1.4em;
 		}
 	}
 

--- a/meteor/client/styles/rundownView.scss
+++ b/meteor/client/styles/rundownView.scss
@@ -1941,7 +1941,7 @@ svg.icon {
 					padding: 0 1em 0 0.4em;
 					color: $segment-piece-step-counter;
 					text-shadow: 0 0 1px #000, 0.5px 0.5px 8px rgba(0, 0, 0, 0.8);
-					clip-path: polygon(0 0, 70% 0, 100% 50%, 70% 100%, 0 100%);
+					clip-path: polygon(0 0, calc(100% - 0.6em) 0, 100% 50%, calc(100% - 0.6em) 100%, 0 100%);
 					line-height: 1.4em;
 				}
 
@@ -2483,12 +2483,17 @@ svg.icon {
 			top: 0;
 			left: 0;
 			background: $segment-layer-background-graphics;
-			padding: 0 1em;
-			clip-path: polygon(0 0, 75% 0, 100% 50%, 75% 100%, 0 100%, 25% 50%);
+			padding: 0 0.75em;
+			clip-path: polygon(0 0, calc(100% - 0.6em) 0, 100% 50%, calc(100% - 0.6em) 100%, 0 100%, 0.6em 50%);
 			font-weight: 400;
 			text-shadow: 0 0 1px #000, 0.5px 0.5px 8px rgba(0, 0, 0, 0.8);
 			color: $segment-piece-step-counter;
 			line-height: 1.4em;
+
+			.segment-timeline__mini-inspector--graphics--preview__step-chevron__total {
+				color: #fff;
+				text-shadow: none;
+			}
 		}
 	}
 

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -229,6 +229,11 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 						{isMultiStep && stepContent ? (
 							<div className="segment-timeline__mini-inspector--graphics--preview__step-chevron">
 								{stepContent.to === 'next' ? (stepContent.from || 0) + 1 : stepContent.to || 1}
+								{typeof stepContent.total === 'number' && stepContent.total > 0 ? (
+									<span className="segment-timeline__mini-inspector--graphics--preview__step-chevron__total">
+										/{stepContent.total}
+									</span>
+								) : null}
 							</div>
 						) : null}
 					</div>

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -207,7 +207,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 
 	render() {
 		const stepContent = this.state.noraContent?.payload?.step
-		const isMultiStep = !!this.state.noraContent?.payload?.step?.enabled
+		const isMultiStep = this.state.noraContent?.payload?.step?.enabled === true
 
 		return (
 			<React.Fragment>

--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -100,6 +100,7 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 						out: 'auto',
 						timeIn: '00:00',
 					},
+					step: noraContent.payload.step,
 				},
 			},
 			'*'
@@ -205,6 +206,9 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	render() {
+		const stepContent = this.state.noraContent?.payload?.step
+		const isMultiStep = !!this.state.noraContent?.payload?.step?.enabled
+
 		return (
 			<React.Fragment>
 				<Escape to={this.state.displayOn}>
@@ -222,6 +226,11 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 								height="1080"
 							></iframe>
 						</div>
+						{isMultiStep && stepContent ? (
+							<div className="segment-timeline__mini-inspector--graphics--preview__step-chevron">
+								{stepContent.to === 'next' ? (stepContent.from || 0) + 1 : stepContent.to || 1}
+							</div>
+						) : null}
 					</div>
 				</Escape>
 			</React.Fragment>

--- a/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
@@ -53,7 +53,7 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 		const noraContent = innerPiece.content as NoraContent | undefined
 
 		const stepContent = noraContent?.payload.step
-		const isMultiStep = !!(stepContent && stepContent.enabled)
+		const isMultiStep = stepContent?.enabled === true
 
 		return (
 			<React.Fragment>

--- a/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
@@ -5,6 +5,7 @@ import { getElementWidth } from '../../../utils/dimensions'
 import { CustomLayerItemRenderer, ICustomLayerItemProps } from './CustomLayerItemRenderer'
 import { NoraContent } from '@sofie-automation/blueprints-integration'
 import { L3rdFloatingInspector } from '../../FloatingInspectors/L3rdFloatingInspector'
+import classNames from 'classnames'
 
 interface IProps extends ICustomLayerItemProps {}
 interface IState {}
@@ -51,13 +52,23 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 		const innerPiece = this.props.piece.instance.piece
 		const noraContent = innerPiece.content as NoraContent | undefined
 
+		const stepContent = noraContent?.payload.step
+		const isMultiStep = !!(stepContent && stepContent.enabled)
+
 		return (
 			<React.Fragment>
 				<span
-					className="segment-timeline__piece__label"
+					className={classNames('segment-timeline__piece__label', {
+						'no-left-margin': isMultiStep,
+					})}
 					ref={this.setLeftLabelRef}
 					style={this.getItemLabelOffsetLeft()}
 				>
+					{isMultiStep && stepContent ? (
+						<span className="segment-timeline__piece__step-chevron">
+							{stepContent.to === 'next' ? (stepContent.from || 0) + 1 : stepContent.to || 1}
+						</span>
+					) : null}
 					<span className="segment-timeline__piece__label">{innerPiece.name}</span>
 				</span>
 				<span
@@ -68,6 +79,12 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 					{this.renderInfiniteIcon()}
 					{this.renderOverflowTimeLabel()}
 				</span>
+				{isMultiStep ? (
+					<>
+						<span className="segment-timeline__piece--collapsed__step-chevron"></span>
+						<span className="segment-timeline__piece--decoration__step-chevron"></span>
+					</>
+				) : null}
 				<L3rdFloatingInspector
 					content={noraContent}
 					itemElement={this.props.itemElement}

--- a/meteor/public/images/multi-step-chevrons-default.svg
+++ b/meteor/public/images/multi-step-chevrons-default.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 544 127" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
     <g transform="matrix(1,0,0,1,-291,-519)">
         <g transform="matrix(1,0,0,1,0,195)">

--- a/meteor/public/images/multi-step-chevrons-default.svg
+++ b/meteor/public/images/multi-step-chevrons-default.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 544 127" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-291,-519)">
+        <g transform="matrix(1,0,0,1,0,195)">
+            <path d="M291,451L355,387.5L291,324L405,324L469,387.5L405,451L291,451Z" style="fill-opacity:0.4;"/>
+        </g>
+    </g>
+</svg>

--- a/meteor/public/images/multi-step-chevrons.svg
+++ b/meteor/public/images/multi-step-chevrons.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 610 127" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-355,-324)">
+        <g>
+            <g transform="matrix(1,0,0,1,130,0)">
+                <path d="M835,387.5L835,324L771,324L771,451L771,324L835,387.5ZM835,451L771,451L835,387.5L835,451Z" style="fill-opacity:0.4;"/>
+            </g>
+            <path d="M355,451L355,324L405,324L469,387.5L405,451L355,451Z" style="fill-opacity:0.4;"/>
+        </g>
+    </g>
+</svg>

--- a/meteor/public/images/multi-step-chevrons.svg
+++ b/meteor/public/images/multi-step-chevrons.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 610 127" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
     <g transform="matrix(1,0,0,1,-355,-324)">
         <g>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature

* **What is the current behavior?** (You can also link to an open issue here)

The GUI has no special features to display the state of multi-step graphics.

* **What is the new behavior (if this is a feature change)?**

![obraz](https://user-images.githubusercontent.com/3635991/118932247-1a012a80-b948-11eb-8b11-25968fc94696.png)

Multi-step graphics are now displayed with special "chevrons" that the graphic has multiple, user-triggerable steps and indicate the step the graphics will be on - once displayed. The hoverscrub preview of graphics should follow the assigned step as well as show the total amount of steps available.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
