### PR TITLE
Feat: dataPlaylistGet

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -394,6 +394,7 @@ export enum PeripheralDeviceAPIMethods {
 	'mosRoReadyToAir' = 'peripheralDevice.mos.roReadyToAir',
 	'mosRoFullStory' = 'peripheralDevice.mos.roFullStory',
 
+	'dataPlaylistGet' = 'peripheralDevice.playlist.playlistGet',
 	'dataRundownList' = 'peripheralDevice.rundown.rundownList',
 	'dataRundownGet' = 'peripheralDevice.rundown.rundownGet',
 	'dataRundownDelete' = 'peripheralDevice.rundown.rundownDelete',

--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -3,7 +3,7 @@ import { getCurrentTime, getRandomId } from '../lib'
 import { PeripheralDeviceCommands, PeripheralDeviceCommandId } from '../collections/PeripheralDeviceCommands'
 import { PubSub, meteorSubscribe } from './pubsub'
 import { DeviceConfigManifest } from './deviceConfig'
-import { ExpectedPackageStatusAPI, TSR } from '@sofie-automation/blueprints-integration'
+import { ExpectedPackageStatusAPI, IngestPlaylist, TSR } from '@sofie-automation/blueprints-integration'
 import { PartInstanceId } from '../collections/PartInstances'
 import { PeripheralDeviceId, PeripheralDevice } from '../collections/PeripheralDevices'
 import { PieceInstanceId } from '../collections/PieceInstances'
@@ -95,6 +95,11 @@ export interface NewPeripheralDeviceAPI {
 		resolveDuration: number
 	)
 
+	dataPlaylistGet(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		playlistExternalId: string
+	): Promise<IngestPlaylist>
 	dataRundownList(deviceId: PeripheralDeviceId, deviceToken: string): Promise<string[]>
 	dataRundownGet(deviceId: PeripheralDeviceId, deviceToken: string, rundownExternalId: string): Promise<IngestRundown>
 	dataRundownDelete(deviceId: PeripheralDeviceId, deviceToken: string, rundownExternalId: string): Promise<void>

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor'
 import { check } from '../../../lib/check'
 import { PeripheralDevice, PeripheralDeviceId, PeripheralDevices } from '../../../lib/collections/PeripheralDevices'
 import { DBRundown, Rundowns } from '../../../lib/collections/Rundowns'
-import { getCurrentTime, unprotectString, waitForPromise } from '../../../lib/lib'
-import { IngestRundown, IngestSegment, IngestPart } from '@sofie-automation/blueprints-integration'
+import { getCurrentTime, literal, unprotectString, waitForPromise } from '../../../lib/lib'
+import { IngestRundown, IngestSegment, IngestPart, IngestPlaylist } from '@sofie-automation/blueprints-integration'
 import { logger } from '../../../lib/logging'
 import { Studio, StudioId } from '../../../lib/collections/Studios'
 import { SegmentId, Segments } from '../../../lib/collections/Segments'
@@ -30,6 +30,17 @@ import { removeRundownsFromDb } from '../rundownPlaylist'
 import { RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
 
 export namespace RundownInput {
+	export function dataPlaylistGet(
+		context: MethodContext,
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		playlistExternalId: string
+	) {
+		const peripheralDevice = checkAccessAndGetPeripheralDevice(deviceId, deviceToken, context)
+		logger.info('dataPlaylistGet', playlistExternalId)
+		check(playlistExternalId, String)
+		return getIngestPlaylist(peripheralDevice, playlistExternalId)
+	}
 	// Get info on the current rundowns from this device:
 	export function dataRundownList(context: MethodContext, deviceId: PeripheralDeviceId, deviceToken: string) {
 		const peripheralDevice = checkAccessAndGetPeripheralDevice(deviceId, deviceToken, context)
@@ -195,6 +206,27 @@ export namespace RundownInput {
 	}
 }
 
+function getIngestPlaylist(peripheralDevice: PeripheralDevice, playlistExternalId: string): IngestPlaylist {
+	const rundowns = Rundowns.find({
+		peripheralDeviceId: peripheralDevice._id,
+		playlistExternalId,
+	}).fetch()
+
+	const ingestPlaylist: IngestPlaylist = literal<IngestPlaylist>({
+		externalId: playlistExternalId,
+		rundowns: [],
+	})
+
+	for (const rundown of rundowns) {
+		const ingestCache = waitForPromise(RundownIngestDataCache.create(rundown._id))
+		const ingestData = ingestCache.fetchRundown()
+		if (ingestData) {
+			ingestPlaylist.rundowns.push(ingestData)
+		}
+	}
+
+	return ingestPlaylist
+}
 function getIngestRundown(peripheralDevice: PeripheralDevice, rundownExternalId: string): IngestRundown {
 	const rundown = Rundowns.findOne({
 		peripheralDeviceId: peripheralDevice._id,

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -825,6 +825,9 @@ class ServerPeripheralDeviceAPIClass extends MethodContextAPI implements NewPeri
 	}
 
 	// ------ Ingest methods: ------------
+	dataPlaylistGet(deviceId: PeripheralDeviceId, deviceToken: string, playlistExternalId: string) {
+		return makePromise(() => RundownInput.dataPlaylistGet(this, deviceId, deviceToken, playlistExternalId))
+	}
 	dataRundownList(deviceId: PeripheralDeviceId, deviceToken: string) {
 		return makePromise(() => RundownInput.dataRundownList(this, deviceId, deviceToken))
 	}

--- a/packages/blueprints-integration/src/ingest.ts
+++ b/packages/blueprints-integration/src/ingest.ts
@@ -1,5 +1,11 @@
 import { IBlueprintRundownDBData } from './rundown'
 
+export interface IngestPlaylist {
+	/** Id of the playlist. */
+	externalId: string
+	/** Ingest cache of rundowns in this playlist. */
+	rundowns: IngestRundown[]
+}
 export interface IngestRundown {
 	/** Id of the rundown as reported by the ingest gateway. Must be unique for each rundown owned by the gateway */
 	externalId: string

--- a/packages/server-core-integration/src/lib/corePeripherals.ts
+++ b/packages/server-core-integration/src/lib/corePeripherals.ts
@@ -130,6 +130,7 @@ export namespace PeripheralDeviceAPI {
 		'mosRoReadyToAir' = 'peripheralDevice.mos.roReadyToAir',
 		'mosRoFullStory' = 'peripheralDevice.mos.roFullStory',
 
+		'dataPlaylistGet' = 'peripheralDevice.playlist.playlistGet',
 		'dataRundownList' = 'peripheralDevice.rundown.rundownList',
 		'dataRundownGet' = 'peripheralDevice.rundown.rundownGet',
 		'dataRundownDelete' = 'peripheralDevice.rundown.rundownDelete',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds the `dataPlaylistGet` peripheral device API method.

* **What is the current behavior?** (You can also link to an open issue here)

New feature.

* **What is the new behavior (if this is a feature change)?**

The `dataPlaylistGet` method can be used to get the ingest data cache for an entire rundown playlist, similar to how `dataRundownGet` gets the ingest data for an individual rundown. This PR does not implement any of the other `dataRundown*` methods for playlists.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
