### PR TITLE
feat: Remove delayed initialisation from DbCacheReadObject and DbCacheReadCollection

### DIFF
--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -14460,6 +14460,11 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
+		"p-lazy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-3.1.0.tgz",
+			"integrity": "sha512-sCJn0Cdahs6G6SX9+DUihVFUhrzDEduzE5xeViVBGtoqy5dBWko7W8T6Kk6TjR2uevRXJO7CShfWrqdH5s3w3g=="
+		},
 		"p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -78,6 +78,7 @@
 		"mousetrap": "^1.6.5",
 		"ntp-client": "^0.5.3",
 		"object-path": "^0.11.5",
+		"p-lazy": "^3.1.0",
 		"promise.allsettled": "^1.0.4",
 		"prop-types": "^15.7.2",
 		"query-string": "^6.14.1",

--- a/meteor/server/api/__tests__/rundownPlaylist.test.ts
+++ b/meteor/server/api/__tests__/rundownPlaylist.test.ts
@@ -66,8 +66,9 @@ describe('Rundown', () => {
 		expect(rundown00.playlistId).toEqual(playlistId0)
 
 		// This should set the default sorting of the rundowns in the plylist:
-		const rundownsCollection = new DbCacheWriteCollection(Rundowns)
-		await rundownsCollection.prepareInit({ playlistId: playlist0._id }, true)
+		const rundownsCollection = await DbCacheWriteCollection.createFromDatabase(Rundowns, {
+			playlistId: playlist0._id,
+		})
 		const rundownPlaylistInfo = produceRundownPlaylistInfoFromRundown(
 			env.studio,
 			undefined,

--- a/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
+++ b/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
@@ -1,4 +1,3 @@
-import { clone } from 'underscore'
 import { ContextInfo, RundownContext } from './context'
 import {
 	IBlueprintPiece,
@@ -24,6 +23,7 @@ import {
 	protectStringArray,
 	unprotectStringArray,
 	normalizeArrayToMap,
+	clone,
 } from '../../../../lib/lib'
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { DbCacheWriteCollection } from '../../../cache/CacheCollection'
@@ -60,11 +60,8 @@ export class SyncIngestUpdateToPartInstanceContext
 		super(contextInfo, studio, showStyleCompound, rundown)
 
 		// Create temporary cache databases
-		this._pieceInstanceCache = new DbCacheWriteCollection(PieceInstances)
-		this._pieceInstanceCache.fillWithDataFromArray(pieceInstances)
-
-		this._partInstanceCache = new DbCacheWriteCollection(PartInstances)
-		this._partInstanceCache.fillWithDataFromArray([partInstance])
+		this._pieceInstanceCache = DbCacheWriteCollection.createFromArray(PieceInstances, pieceInstances)
+		this._partInstanceCache = DbCacheWriteCollection.createFromArray(PartInstances, [partInstance])
 
 		this._proposedPieceInstances = normalizeArrayToMap(proposedPieceInstances, '_id')
 	}

--- a/meteor/server/api/ingest/cache.ts
+++ b/meteor/server/api/ingest/cache.ts
@@ -23,48 +23,7 @@ import { profiler } from '../profiler'
 import { removeRundownsFromDb } from '../rundownPlaylist'
 import { getRundownId } from './lib'
 import { ExpectedPackageDB, ExpectedPackages } from '../../../lib/collections/ExpectedPackages'
-import PLazy from 'p-lazy'
-
-export class Lazy<T> {
-	private value!: T
-	private loading: PLazy<void> | undefined
-
-	public constructor(init: () => Promise<T>) {
-		this.loading = new PLazy((resolve, reject) => {
-			try {
-				init()
-					.then((v) => {
-						this.value = v
-						this.loading = undefined
-						resolve()
-					})
-					.catch(() => reject())
-			} catch (e) {
-				reject()
-			}
-		})
-	}
-
-	public async get(): Promise<T> {
-		if (this.loading) {
-			await this.loading
-		}
-
-		return this.value
-	}
-
-	public getIfLoaded(): T | undefined {
-		if (!this.loading) {
-			return this.value
-		} else {
-			return undefined
-		}
-	}
-
-	public isLoaded(): boolean {
-		return !this.loading
-	}
-}
+import { LazyInitialise } from '../../lib/lazy'
 
 export class CacheForIngest extends CacheBase<CacheForIngest> {
 	public readonly isIngest = true
@@ -85,11 +44,11 @@ export class CacheForIngest extends CacheBase<CacheForIngest> {
 	public readonly ExpectedPlayoutItems: DbCacheWriteCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>
 	public readonly ExpectedPackages: DbCacheWriteCollection<ExpectedPackageDB, ExpectedPackageDB>
 
-	public readonly RundownBaselineObjs: Lazy<DbCacheWriteCollection<RundownBaselineObj, RundownBaselineObj>>
-	public readonly RundownBaselineAdLibPieces: Lazy<
+	public readonly RundownBaselineObjs: LazyInitialise<DbCacheWriteCollection<RundownBaselineObj, RundownBaselineObj>>
+	public readonly RundownBaselineAdLibPieces: LazyInitialise<
 		DbCacheWriteCollection<RundownBaselineAdLibItem, RundownBaselineAdLibItem>
 	>
-	public readonly RundownBaselineAdLibActions: Lazy<
+	public readonly RundownBaselineAdLibActions: LazyInitialise<
 		DbCacheWriteCollection<RundownBaselineAdLibAction, RundownBaselineAdLibAction>
 	>
 
@@ -127,13 +86,13 @@ export class CacheForIngest extends CacheBase<CacheForIngest> {
 		this.ExpectedPlayoutItems = expectedPlayoutItems
 		this.ExpectedPackages = expectedPackages
 
-		this.RundownBaselineObjs = new Lazy(async () =>
+		this.RundownBaselineObjs = new LazyInitialise(async () =>
 			DbCacheWriteCollection.createFromDatabase(RundownBaselineObjs, { rundownId: this.RundownId })
 		)
-		this.RundownBaselineAdLibPieces = new Lazy(async () =>
+		this.RundownBaselineAdLibPieces = new LazyInitialise(async () =>
 			DbCacheWriteCollection.createFromDatabase(RundownBaselineAdLibPieces, { rundownId: this.RundownId })
 		)
-		this.RundownBaselineAdLibActions = new Lazy(async () =>
+		this.RundownBaselineAdLibActions = new LazyInitialise(async () =>
 			DbCacheWriteCollection.createFromDatabase(RundownBaselineAdLibActions, { rundownId: this.RundownId })
 		)
 	}

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -232,7 +232,7 @@ export async function CommitIngestOperation(
 					])
 
 					// Create the full playout cache, now we have the rundowns and playlist updated
-					const playoutCache = await CacheForPlayout.from(
+					const playoutCache = await CacheForPlayout.fromIngest(
 						newPlaylist,
 						rundownsCollection.findFetch({}),
 						ingestCache
@@ -348,13 +348,13 @@ async function generatePlaylistAndRundownsCollectionInner(
 	}
 
 	// Load existing playout data
-	const rundownsCollection = existingRundownsCollection ?? new DbCacheWriteCollection(Rundowns)
-	const [existingPlaylist, studioBlueprint] = await Promise.all([
+	const [existingPlaylist, studioBlueprint, rundownsCollection] = await Promise.all([
 		existingPlaylist0
 			? existingPlaylist0
 			: (RundownPlaylists.findOneAsync(newPlaylistId) as Promise<ReadonlyDeep<RundownPlaylist>>),
 		loadStudioBlueprint(studio),
-		existingRundownsCollection ? null : rundownsCollection.prepareInit({ playlistId: newPlaylistId }, true),
+		existingRundownsCollection ??
+			DbCacheWriteCollection.createFromDatabase(Rundowns, { playlistId: newPlaylistId }),
 	])
 	if (changedRundown) {
 		rundownsCollection.replace(changedRundown)

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -432,8 +432,9 @@ export async function updateRundownFromIngestData(
 	logger.info(`... got ${rundownRes.globalAdLibPieces.length} adLib objects from baseline.`)
 	logger.info(`... got ${(rundownRes.globalActions || []).length} adLib actions from baseline.`)
 
+	const { baselineObjects, baselineAdlibPieces, baselineAdlibActions } = await cache.loadBaselineCollections()
 	const rundownBaselineChanges = sumChanges(
-		saveIntoCache<RundownBaselineObj, RundownBaselineObj>(cache.RundownBaselineObjs, {}, [
+		saveIntoCache<RundownBaselineObj, RundownBaselineObj>(baselineObjects, {}, [
 			{
 				_id: protectString<RundownBaselineObjId>(Random.id(7)),
 				rundownId: dbRundown._id,
@@ -446,7 +447,7 @@ export async function updateRundownFromIngestData(
 		]),
 		// Save the global adlibs
 		saveIntoCache<RundownBaselineAdLibItem, RundownBaselineAdLibItem>(
-			cache.RundownBaselineAdLibPieces,
+			baselineAdlibPieces,
 			{},
 			postProcessAdLibPieces(
 				blueprintRundownContext,
@@ -457,7 +458,7 @@ export async function updateRundownFromIngestData(
 			)
 		),
 		saveIntoCache<RundownBaselineAdLibAction, RundownBaselineAdLibAction>(
-			cache.RundownBaselineAdLibActions,
+			baselineAdlibActions,
 			{},
 			postProcessGlobalAdLibActions(
 				blueprintRundownContext,

--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -52,14 +52,15 @@ export function makeNewIngestPart(ingestPart: IngestPart): LocalIngestPart {
 }
 
 export class RundownIngestDataCache {
-	private readonly collection = new DbCacheWriteCollection<IngestDataCacheObj, IngestDataCacheObj>(IngestDataCache)
-
-	private constructor(private readonly rundownId: RundownId) {}
+	private constructor(
+		private readonly rundownId: RundownId,
+		private readonly collection: DbCacheWriteCollection<IngestDataCacheObj, IngestDataCacheObj>
+	) {}
 
 	static async create(rundownId: RundownId): Promise<RundownIngestDataCache> {
-		const ingestObjCache = new RundownIngestDataCache(rundownId)
+		const col = await DbCacheWriteCollection.createFromDatabase(IngestDataCache, { rundownId })
 
-		await ingestObjCache.collection.prepareInit({ rundownId }, true)
+		const ingestObjCache = new RundownIngestDataCache(rundownId, col)
 
 		return ingestObjCache
 	}

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -264,11 +264,12 @@ export namespace ServerPeripheralDeviceAPI {
 								const rundownIDs = Rundowns.find({ playlistId }).map((r) => r._id)
 
 								// We only need the PieceInstances, so load just them
-								const pieceInstanceCache = new DbCacheWriteCollection<PieceInstance, PieceInstance>(
-									PieceInstances
+								const pieceInstanceCache = await DbCacheWriteCollection.createFromDatabase(
+									PieceInstances,
+									{
+										rundownId: { $in: rundownIDs },
+									}
 								)
-
-								await pieceInstanceCache.prepareInit({ rundownId: { $in: rundownIDs } }, true)
 
 								// Take ownership of the playlist in the db, so that we can mutate the timeline and piece instances
 								timelineTriggerTimeInner(studioCache, results, pieceInstanceCache, activePlaylist)

--- a/meteor/server/api/playout/lockFunction.ts
+++ b/meteor/server/api/playout/lockFunction.ts
@@ -232,17 +232,17 @@ function playoutLockFunctionInner<T>(
 	options?: PlayoutLockOptions
 ): Awaited<T> {
 	async function doPlaylistInner() {
-		const cache = await CacheForPlayout.create(tmpPlaylist)
+		const initCache = await CacheForPlayout.createPreInit(tmpPlaylist)
 
 		if (preInitFcn) {
-			await preInitFcn(cache)
+			await preInitFcn(initCache)
 		}
 
-		await cache.initContent(null)
+		const fullCache = await CacheForPlayout.fromInit(initCache)
 
-		const res = await fcn(cache)
+		const res = await fcn(fullCache)
 
-		await cache.saveAllToDatabase()
+		await fullCache.saveAllToDatabase()
 
 		return res
 	}

--- a/meteor/server/api/rundownPlaylist.ts
+++ b/meteor/server/api/rundownPlaylist.ts
@@ -336,10 +336,11 @@ export function moveRundownIntoPlaylist(
 				intoPlaylist,
 				PlayoutLockFunctionPriority.MISC,
 				async (intoPlaylistLock) => {
-					const rundownsCollection = new DbCacheWriteCollection(Rundowns)
-					const [playlist] = await Promise.all([
+					const [playlist, rundownsCollection] = await Promise.all([
 						RundownPlaylists.findOneAsync(intoPlaylistLock._playlistId),
-						rundownsCollection.prepareInit({ playlistId: intoPlaylistLock._playlistId }, true),
+						DbCacheWriteCollection.createFromDatabase(Rundowns, {
+							playlistId: intoPlaylistLock._playlistId,
+						}),
 					])
 
 					if (!playlist)

--- a/meteor/server/api/studio/cache.ts
+++ b/meteor/server/api/studio/cache.ts
@@ -31,28 +31,32 @@ export class CacheForStudio extends CacheBase<CacheForStudio> implements CacheFo
 	public readonly RundownPlaylists: DbCacheReadCollection<RundownPlaylist, DBRundownPlaylist>
 	public readonly Timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
 
-	private constructor() {
+	private constructor(
+		studio: DbCacheReadObject<Studio, Studio>,
+		peripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>,
+		rundownPlaylists: DbCacheReadCollection<RundownPlaylist, DBRundownPlaylist>,
+		timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+	) {
 		super()
 
-		this.Studio = new DbCacheReadObject(Studios, false)
-		this.PeripheralDevices = new DbCacheReadCollection(PeripheralDevices)
+		this.Studio = studio
+		this.PeripheralDevices = peripheralDevices
 
-		this.RundownPlaylists = new DbCacheReadCollection(RundownPlaylists)
-		this.Timeline = new DbCacheWriteCollection(Timeline)
+		this.RundownPlaylists = rundownPlaylists
+		this.Timeline = timeline
 	}
 
 	static async create(studioId: StudioId): Promise<CacheForStudio> {
-		const res = new CacheForStudio()
+		const studio = new DbCacheReadObject(Studios, false)
+		await studio._initialize(studioId)
 
-		await res.Studio._initialize(studioId)
-
-		await Promise.all([
-			res.PeripheralDevices.prepareInit({ studioId }, true),
-			res.RundownPlaylists.prepareInit({ studioId }, true),
-			res.Timeline.prepareInit({ _id: studioId }, true),
+		const collections = await Promise.all([
+			DbCacheReadCollection.createFromDatabase(PeripheralDevices, { studioId }),
+			DbCacheReadCollection.createFromDatabase(RundownPlaylists, { studioId }),
+			DbCacheWriteCollection.createFromDatabase(Timeline, { _id: studioId }),
 		])
 
-		return res
+		return new CacheForStudio(studio, ...collections)
 	}
 
 	public getActiveRundownPlaylists(excludeRundownPlaylistId?: RundownPlaylistId): RundownPlaylist[] {

--- a/meteor/server/api/studio/cache.ts
+++ b/meteor/server/api/studio/cache.ts
@@ -47,8 +47,7 @@ export class CacheForStudio extends CacheBase<CacheForStudio> implements CacheFo
 	}
 
 	static async create(studioId: StudioId): Promise<CacheForStudio> {
-		const studio = new DbCacheReadObject(Studios, false)
-		await studio._initialize(studioId)
+		const studio = await DbCacheReadObject.createFromDatabase(Studios, false, studioId)
 
 		const collections = await Promise.all([
 			DbCacheReadCollection.createFromDatabase(PeripheralDevices, { studioId }),

--- a/meteor/server/cache/CacheBase.ts
+++ b/meteor/server/cache/CacheBase.ts
@@ -8,6 +8,7 @@ import { profiler } from '../api/profiler'
 import { DbCacheReadCollection, DbCacheWriteCollection } from './CacheCollection'
 import { DbCacheReadObject, DbCacheWriteObject, DbCacheWriteOptionalObject } from './CacheObject'
 import { anythingChanged, sumChanges } from '../lib/database'
+import { Lazy } from '../api/ingest/cache'
 
 type DeferredFunction<Cache> = (cache: Cache) => void | Promise<void>
 
@@ -66,8 +67,12 @@ export abstract class ReadOnlyCacheBase<T extends ReadOnlyCacheBase<never>> {
 		const lowPrioDBs: DbCacheWritable<any, any>[] = []
 
 		_.map(_.keys(this), (key) => {
-			const db = this[key]
-			if (isDbCacheWritable(db)) {
+			let db = this[key]
+			if (typeof db === 'object' && 'getIfLoaded' in db) {
+				// If wrapped in a lazy
+				db = db.getIfLoaded()
+			}
+			if (db && isDbCacheWritable(db)) {
 				if (key.match(/timeline/i)) {
 					highPrioDBs.push(db)
 				} else {

--- a/meteor/server/cache/CacheBase.ts
+++ b/meteor/server/cache/CacheBase.ts
@@ -8,7 +8,6 @@ import { profiler } from '../api/profiler'
 import { DbCacheReadCollection, DbCacheWriteCollection } from './CacheCollection'
 import { DbCacheReadObject, DbCacheWriteObject, DbCacheWriteOptionalObject } from './CacheObject'
 import { anythingChanged, sumChanges } from '../lib/database'
-import { Lazy } from '../api/ingest/cache'
 
 type DeferredFunction<Cache> = (cache: Cache) => void | Promise<void>
 

--- a/meteor/server/lib/lazy.ts
+++ b/meteor/server/lib/lazy.ts
@@ -1,0 +1,47 @@
+import PLazy from 'p-lazy'
+
+/** Lazy initialise a value */
+export class LazyInitialise<T> {
+	#value!: T
+	#loading: PLazy<void> | undefined
+
+	/** Create the lazy wrapper, and provide the init function to be called when first fetched */
+	public constructor(init: () => Promise<T>) {
+		this.#loading = new PLazy<void>((resolve, reject) => {
+			try {
+				init()
+					.then((v) => {
+						this.#value = v
+						this.#loading = undefined
+						resolve()
+					})
+					.catch((e) => reject(e))
+			} catch (e) {
+				reject()
+			}
+		})
+	}
+
+	/** Return the value, loading it if required */
+	public async get(): Promise<T> {
+		if (this.#loading) {
+			await this.#loading
+		}
+
+		return this.#value
+	}
+
+	/** Get the value if it is already loaded */
+	public getIfLoaded(): T | undefined {
+		if (!this.#loading) {
+			return this.#value
+		} else {
+			return undefined
+		}
+	}
+
+	/** Check if the value has been loaded */
+	public isLoaded(): boolean {
+		return !this.#loading
+	}
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

code cleanup

* **What is the current behavior?** (You can also link to an open issue here)

The DbCacheReadObject and DbCacheReadCollection support being lazy initialised.
We only make use of this for a couple of collections, and supporting it makes it hard to understand whether an operation on the cache collection will yield the fiber or not.

Additionally, for the cases where we were lazy initialising, by knowing we might be doing so, we can optimise by running the loads in parallel. Currently we would be loading them one at a time, as the code was not aware they would need loading

* **What is the new behavior (if this is a feature change)?**

The collections no longer support being lazy initialised. Instead they should be wrapped in the LazyInitialise wrapper. This makes the api slightly less clean to do the operations, as it requires an explicit await to get a reference to the collection, but this makes it explicit that it may be an async operation.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
