### PR TITLE
fix: search bar cleared when switching tabs in shelf

### DIFF
--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -597,7 +597,9 @@ export class DashboardPanelInner extends MeteorReactComponent<
 						style={dashboardElementPosition(filter)}
 					>
 						<h4 className="dashboard-panel__header">{this.props.filter.name}</h4>
-						{filter.enableSearch && <AdLibPanelToolbar onFilterChange={this.onFilterChange} />}
+						{filter.enableSearch && (
+							<AdLibPanelToolbar onFilterChange={this.onFilterChange} searchFilter={this.state.searchFilter} />
+						)}
 						<div
 							className={ClassNames('dashboard-panel__panel', {
 								'dashboard-panel__panel--horizontal': filter.overflowHorizontally,

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -659,7 +659,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		renderListView() {
 			return (
 				<React.Fragment>
-					<AdLibPanelToolbar onFilterChange={this.onFilterChange} noSegments={true} />
+					<AdLibPanelToolbar onFilterChange={this.onFilterChange} noSegments={true} searchFilter={this.state.filter} />
 					<AdLibListView
 						onSelectAdLib={this.onSelectAdLib}
 						onToggleAdLib={this.onToggleAdLib}

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -95,7 +95,9 @@ export const TimelineDashboardPanel = translateWithTracker<
 					return (
 						<div className="dashboard-panel dashboard-panel--timeline-style" style={dashboardElementPosition(filter)}>
 							<h4 className="dashboard-panel__header">{this.props.filter.name}</h4>
-							{filter.enableSearch && <AdLibPanelToolbar onFilterChange={this.onFilterChange} />}
+							{filter.enableSearch && (
+								<AdLibPanelToolbar onFilterChange={this.onFilterChange} searchFilter={this.state.searchFilter} />
+							)}
 							<div
 								className={ClassNames('dashboard-panel__panel', {
 									'dashboard-panel__panel--horizontal': filter.overflowHorizontally,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Search for ad lib in shelf, change to a different tab, go back to first tab: search bar is clear but the results (or lack thereof) from the previous search are still there. looks like a bunch of adlibs have disappeared magically.

* **What is the new behavior (if this is a feature change)?**

When the search filter should now be persisted until the page is refreshed or user navigates away.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
