### PR TITLE
fix: invalid notifications

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -919,9 +919,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 									(this.props.autoNextPart || this.props.part.willProbablyAutoNext) && !this.state.isNext,
 							})}
 						>
-							{innerPart.invalid && !innerPart.gap ? (
-								<span>{t('Invalid')}</span>
-							) : (
+							{innerPart.invalid && !innerPart.gap ? null : (
 								<React.Fragment>
 									{((this.state.isNext && this.props.autoNextPart) ||
 										(!this.state.isNext && this.props.part.willProbablyAutoNext)) &&

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelinePart.tsx
@@ -940,7 +940,12 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						this.state.isNext && ( // This is the off-set line
 							<div
 								className={ClassNames('segment-timeline__part__nextline', {
-									'auto-next': this.props.part.willProbablyAutoNext,
+									// This is the base, basic line
+									'auto-next':
+										!innerPart.invalid &&
+										!innerPart.gap &&
+										((this.state.isNext && this.props.autoNextPart) ||
+											(!this.state.isNext && this.props.part.willProbablyAutoNext)),
 									invalid: innerPart.invalid && !innerPart.gap,
 									floated: innerPart.floated,
 								})}
@@ -959,9 +964,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 											(this.props.autoNextPart || this.props.part.willProbablyAutoNext) && !this.state.isNext,
 									})}
 								>
-									{innerPart.invalid ? (
-										!innerPart.gap && <span>{t('Invalid')}</span>
-									) : (
+									{innerPart.invalid && !innerPart.gap ? null : (
 										<React.Fragment>
 											{(this.props.autoNextPart || this.props.part.willProbablyAutoNext) && t('Auto') + ' '}
 											{this.state.isNext && t('Next')}

--- a/meteor/lib/rundownNotifications.ts
+++ b/meteor/lib/rundownNotifications.ts
@@ -176,15 +176,17 @@ export function getBasicNotesForSegment(
 	for (const part of parts) {
 		const newNotes = part.notes?.slice() || []
 
-		if (part.invalidReason) {
-			newNotes.push({
-				type: NoteType.ERROR,
-				message: part.invalidReason.message,
-				origin: {
-					name: part.title,
-				},
-			})
-		}
+		// Temporarily disable showing invalidReason notifications
+		//		-- Jan Starzak, 2021/06/30
+		// if (part.invalidReason) {
+		// 	newNotes.push({
+		// 		type: NoteType.ERROR,
+		// 		message: part.invalidReason.message,
+		// 		origin: {
+		// 			name: part.title,
+		// 		},
+		// 	})
+		// }
 
 		if (newNotes.length > 0) {
 			notes.push(

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -3578,9 +3578,9 @@
 					"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
 				},
 				"timeline-state-resolver-types": {
-					"version": "6.0.0-nightly-release35-20210608-165921-e8c0d0dbb.0",
-					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-6.0.0-nightly-release35-20210608-165921-e8c0d0dbb.0.tgz",
-					"integrity": "sha512-SqOfKD5orC4HcIX/pVEwfdL+B6LEsP+47McAqljUS7Ha64WC6OxSQfA9TL8I2TEHt07rj85ZbtkXZOBhxO+lFw==",
+					"version": "6.1.0-nightly-release36-20210629-102259-87b8c9e2a.0",
+					"resolved": "https://registry.npmjs.org/timeline-state-resolver-types/-/timeline-state-resolver-types-6.1.0-nightly-release36-20210629-102259-87b8c9e2a.0.tgz",
+					"integrity": "sha512-W6dFWD22cwZY9Omfw48cWWe0IcYf1NI7NkJReEy0Fz7gasdhzLOX7/K+F7JrQ3yONgwjH21HoQtGv7xoMErcBQ==",
 					"requires": {
 						"tslib": "^2.1.0"
 					}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix/feature change

* **What is the current behavior?** (You can also link to an open issue here)

If there is a media status-having Pieces in an invalid Parts, they still produce notifications.

* **What is the new behavior (if this is a feature change)?**

Notifications from invalid Parts will not be produced. Plus, invalid Parts will not produce notifications if `.invalidReason` is set. Plus, an "Invalid" label is removed from invalid Parts.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
