### PR TITLE
fix(Prompter): show changes in played-out Parts

### DIFF
--- a/meteor/lib/api/prompter.ts
+++ b/meteor/lib/api/prompter.ts
@@ -62,7 +62,13 @@ export namespace PrompterAPI {
 			playlist,
 			undefined,
 			undefined,
-			undefined,
+			// unless this is the current or next PartInstance, we actually don't want the PartInstances,
+			// we want it to behave as if all other PartInstances are reset.
+			{
+				_id: {
+					$in: [currentPartInstance?._id, nextPartInstance?._id].filter(Boolean) as PartInstanceId[],
+				},
+			},
 			undefined,
 			undefined,
 			{


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Changes in script of played-out Parts is not shown, because they are not reset. This includes having the rundown in a "parked" state after a rehearsal.

* **What is the new behavior (if this is a feature change)?**

Non-current or next partInstances are treated as if they were reset, for the purpose of the prompter script.

* **Other information**:
