### PR TITLE
fix: AdLibs from other Rundowns in a Playlist can't be started, even uf they use the same ShowStyleVariant

### DIFF
--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -197,11 +197,22 @@ export namespace ServerPlayoutAdLibAPI {
 				const rundown = cache.Rundowns.findOne(partInstance.rundownId)
 				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
 
+				// Rundows that share the same showstyle variant as the current rundown, so adlibs from these rundowns are safe to play
+				const safeRundownIds = cache.Rundowns.findFetch(
+					{ showStyleVariantId: rundown.showStyleVariantId },
+					{ fields: { _id: 1 } }
+				).map((r) => r._id)
+
 				const adLibPiece = AdLibPieces.findOne({
 					_id: adLibPieceId,
-					rundownId: partInstance.rundownId,
 				})
 				if (!adLibPiece) throw new Meteor.Error(404, `Part Ad Lib Item "${adLibPieceId}" not found!`)
+				if (!safeRundownIds.includes(adLibPiece.rundownId)) {
+					throw new Meteor.Error(
+						403,
+						`Cannot take Part Ad Lib Item "${adLibPieceId}", it does not share a showstyle with the current rundown!`
+					)
+				}
 				if (adLibPiece.invalid)
 					throw new Meteor.Error(404, `Cannot take invalid Part Ad Lib Item "${adLibPieceId}"!`)
 				if (adLibPiece.floated)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Only adLibs from the current rundown can be taken. AdLibs from future or previous rundowns cannot be started.

* **What is the new behavior (if this is a feature change)?**

AdLibs from any rundown can be taken as long as the rundown they originate from has the same showstyle variant as the current rundown.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
