### PR TITLE
fix: Assign ranks according to playlist order by rundownExternalId

### DIFF
--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -378,9 +378,8 @@ async function generatePlaylistAndRundownsCollectionInner(
 		// Update the ranks of the rundowns
 		if (!newPlaylist.rundownRanksAreSetInSofie) {
 			// Update the rundown ranks
-			for (const [id, rank] of Object.entries(newRundownOrder)) {
-				const id2 = protectString(id)
-				rundownsCollection.update(id2, { $set: { _rank: rank } })
+			for (const [externalId, rank] of Object.entries(newRundownOrder)) {
+				rundownsCollection.update({ externalId: externalId }, { $set: { _rank: rank } })
 			}
 		} else if (changedRundownId) {
 			// This rundown is new, so push to the end of the manually ordered playlist


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Rundowns appear out of order due to function that assigns the ranks from blueprints treating the keys in the ranks map as `_id` values, when they are `rundownExternalId` values according to the `blueprints-integration` typings. This results in every rundown getting the default rank of 0 as a result, as all the assignments fail.

* **What is the new behavior (if this is a feature change)?**

Ranks are assigned using `rundownExternalId` as the typings direct, resulting in the correct ordering.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
