### PR TITLE
fix: moveNext when using segmentDelta

### DIFF
--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -425,7 +425,7 @@ export namespace ServerPlayoutAPI {
 
 			// find the allowable segment ids
 			const allowedSegments =
-				segmentDelta < 0
+				segmentDelta > 0
 					? considerSegments.slice(targetSegmentIndex)
 					: considerSegments.slice(0, targetSegmentIndex + 1).reverse()
 			// const allowedSegmentIds = new Set(allowedSegments.map((s) => s._id))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When playing a segment with just one part, the Next Up action (shift+f10) doesn't work, because the logic for selecting allowed segments is reversed. 


* **What is the new behavior (if this is a feature change)?**



* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
