### PR TITLE
Fix: media status polling

### DIFF
--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -79,6 +79,8 @@ class RundownViewNotifier extends WithManagedTracker {
 
 	private _unsentExternalMessagesStatus: Notification | undefined = undefined
 	private _unsentExternalMessageStatusDep: Tracker.Dependency
+	private mediaObjectsPollInterval = 0
+	private allNotesPollInterval = 0
 
 	constructor(playlistId: RundownPlaylistId | undefined, showStyleBase: ShowStyleBase, studio: Studio) {
 		super()
@@ -150,6 +152,8 @@ class RundownViewNotifier extends WithManagedTracker {
 
 		Object.values(this._mediaStatusComps).forEach((element) => element.stop())
 		this._notifier.stop()
+		if (this.mediaObjectsPollInterval) clearInterval(this.mediaObjectsPollInterval)
+		if (this.allNotesPollInterval) clearInterval(this.allNotesPollInterval)
 	}
 
 	private reactiveRundownStatus(playlistId: RundownPlaylistId) {
@@ -376,7 +380,6 @@ class RundownViewNotifier extends WithManagedTracker {
 	}
 
 	private reactivePartNotes(playlistId: RundownPlaylistId) {
-		let allNotesPollInterval: number
 		let allNotesPollLock: boolean = false
 		const NOTES_POLL_INTERVAL = MEDIASTATUS_POLL_INTERVAL
 
@@ -393,8 +396,8 @@ class RundownViewNotifier extends WithManagedTracker {
 
 		this.autorun(() => {
 			const rundownIds = rRundowns.get().map((r) => r._id)
-			clearInterval(allNotesPollInterval)
-			allNotesPollInterval = Meteor.setInterval(() => {
+			if (this.allNotesPollInterval) clearInterval(this.allNotesPollInterval)
+			this.allNotesPollInterval = Meteor.setInterval(() => {
 				if (allNotesPollLock) return
 				allNotesPollLock = true
 				MeteorCall.rundownNotifications
@@ -476,7 +479,6 @@ class RundownViewNotifier extends WithManagedTracker {
 	}
 
 	private reactiveMediaStatus(playlistId: RundownPlaylistId, showStyleBase: ShowStyleBase, studio: Studio) {
-		let mediaObjectsPollInterval: number
 		let mediaObjectsPollLock: boolean = false
 		const MEDIAOBJECTS_POLL_INTERVAL = MEDIASTATUS_POLL_INTERVAL
 
@@ -505,8 +507,8 @@ class RundownViewNotifier extends WithManagedTracker {
 				.get()
 				.map((rundown) => rundown._id)
 
-			clearInterval(mediaObjectsPollInterval)
-			mediaObjectsPollInterval = Meteor.setInterval(() => {
+			if (this.mediaObjectsPollInterval) clearInterval(this.mediaObjectsPollInterval)
+			this.mediaObjectsPollInterval = Meteor.setInterval(() => {
 				if (mediaObjectsPollLock) return
 				mediaObjectsPollLock = true
 

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -35,7 +35,7 @@ import { handleRundownReloadResponse } from '../RundownView'
 import { RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
 import { getSegmentPartNotes } from '../../../lib/rundownNotifications'
-import { RankedNote, IMediaObjectIssue } from '../../../lib/api/rundownNotifications'
+import { RankedNote, IMediaObjectIssue, MEDIASTATUS_POLL_INTERVAL } from '../../../lib/api/rundownNotifications'
 import { isTranslatableMessage, translateMessage } from '../../../lib/api/TranslatableMessage'
 import { getAllowStudio } from '../../lib/localStorage'
 
@@ -52,7 +52,6 @@ export interface RONotificationEvent {
 	}
 }
 
-const BACKEND_POLL_INTERVAL = 10 * 1000
 const SEGMENT_DELIMITER = ' • '
 
 class RundownViewNotifier extends WithManagedTracker {
@@ -379,7 +378,7 @@ class RundownViewNotifier extends WithManagedTracker {
 	private reactivePartNotes(playlistId: RundownPlaylistId) {
 		let allNotesPollInterval: number
 		let allNotesPollLock: boolean = false
-		const NOTES_POLL_INTERVAL = BACKEND_POLL_INTERVAL
+		const NOTES_POLL_INTERVAL = MEDIASTATUS_POLL_INTERVAL
 
 		const rRundowns = reactiveData.getRRundowns(playlistId, {
 			fields: {
@@ -479,7 +478,7 @@ class RundownViewNotifier extends WithManagedTracker {
 	private reactiveMediaStatus(playlistId: RundownPlaylistId, showStyleBase: ShowStyleBase, studio: Studio) {
 		let mediaObjectsPollInterval: number
 		let mediaObjectsPollLock: boolean = false
-		const MEDIAOBJECTS_POLL_INTERVAL = BACKEND_POLL_INTERVAL
+		const MEDIAOBJECTS_POLL_INTERVAL = MEDIASTATUS_POLL_INTERVAL
 
 		const fullMediaStatus: ReactiveVar<IMediaObjectIssue[]> = new ReactiveVar([], _.isEqual)
 		const localMediaStatus: ReactiveVar<IMediaObjectIssue[]> = new ReactiveVar([], _.isEqual)

--- a/meteor/lib/api/rundownNotifications.ts
+++ b/meteor/lib/api/rundownNotifications.ts
@@ -26,6 +26,8 @@ export enum RundownNotificationsAPIMethods {
 export type RankedNote = (PartNote | SegmentNote | RundownNote) & {
 	rank: number
 }
+/** How often the client polls for updates on media statuses */
+export const MEDIASTATUS_POLL_INTERVAL = 10 * 1000
 
 export interface RundownNotificationsAPI {
 	getSegmentPartNotes(rundownIds: RundownId[]): Promise<RankedNote[]>

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -374,7 +374,24 @@ export function cacheResult<T>(name: string, fcn: () => T, limitTime: number = 1
 	}
 	const cache = cacheResultCache[name]
 	if (!cache || cache.ttl < Date.now()) {
-		const value = fcn()
+		const value: T = fcn()
+		cacheResultCache[name] = {
+			ttl: Date.now() + limitTime,
+			value: value,
+		}
+		return value
+	} else {
+		return cache.value
+	}
+}
+/** Cache the result of function for a limited time */
+export async function cacheResultAsync<T>(name: string, fcn: () => Promise<T>, limitTime: number = 1000): Promise<T> {
+	if (Math.random() < 0.01) {
+		Meteor.setTimeout(cleanOldCacheResult, 10000)
+	}
+	const cache = cacheResultCache[name]
+	if (!cache || cache.ttl < Date.now()) {
+		const value: Promise<T> = fcn()
 		cacheResultCache[name] = {
 			ttl: Date.now() + limitTime,
 			value: value,
@@ -632,7 +649,7 @@ export function mongoWhere<T>(o: any, selector: MongoQuery<T>): boolean {
 				}
 			}
 		} catch (e) {
-			logger.warn(e || e.reason || e.toString()) // todo: why this logs empty message for TypeError (or any Error)?
+			logger.warn(e || (e as any).reason || (e as any).toString()) // todo: why this logs empty message for TypeError (or any Error)?
 			ok = false
 		}
 	})


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix + performance improvement


**What is the new behavior (if this is a feature change)?**
* The first commits adds a cache in front of the method `getMediaObjectIssues`, so that when having multiple clients open that request the same status, the result is reused.
* The second commit fixes a bug, where an interval isn't cleaned up when leaving the rundown view. (can be a problem if going into and out of rundowns many times, as the setIntervals accumulates.)


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
