### PR TITLE
chore: remove hotkey props

### DIFF
--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -616,19 +616,6 @@ const SourceLayerSettings = withTranslation()(
 											</div>
 											<div className="mod mvs mhs">
 												<label className="field">
-													{t('Activate Sticky Piece Shortcut')}
-													<EditAttribute
-														modifiedClassName="bghl"
-														attribute={'sourceLayers.' + item.index + '.activateStickyKeyboardHotkey'}
-														obj={this.props.showStyleBase}
-														type="text"
-														collection={ShowStyleBases}
-														className="input text-input input-l"
-													></EditAttribute>
-												</label>
-											</div>
-											<div className="mod mvs mhs">
-												<label className="field">
 													<EditAttribute
 														modifiedClassName="bghl"
 														attribute={'sourceLayers.' + item.index + '.allowDisable'}

--- a/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
+++ b/meteor/client/ui/Settings/ShowStyleBaseSettings.tsx
@@ -577,41 +577,15 @@ const SourceLayerSettings = withTranslation()(
 											</div>
 											<div className="mod mvs mhs">
 												<label className="field">
-													{t('Shortcut List')}
 													<EditAttribute
 														modifiedClassName="bghl"
-														attribute={'sourceLayers.' + item.index + '.activateKeyboardHotkeys'}
-														obj={this.props.showStyleBase}
-														type="text"
-														collection={ShowStyleBases}
-														className="input text-input input-l"
-													></EditAttribute>
-												</label>
-											</div>
-											<div className="mod mvs mhs">
-												<label className="field">
-													{t('Clear Shortcut')}
-													<EditAttribute
-														modifiedClassName="bghl"
-														attribute={'sourceLayers.' + item.index + '.clearKeyboardHotkey'}
-														obj={this.props.showStyleBase}
-														type="text"
-														collection={ShowStyleBases}
-														className="input text-input input-l"
-													></EditAttribute>
-												</label>
-											</div>
-											<div className="mod mvs mhs">
-												<label className="field">
-													<EditAttribute
-														modifiedClassName="bghl"
-														attribute={'sourceLayers.' + item.index + '.assignHotkeysToGlobalAdlibs'}
+														attribute={'sourceLayers.' + item.index + '.isClearable'}
 														obj={this.props.showStyleBase}
 														type="checkbox"
 														collection={ShowStyleBases}
 														className=""
 													></EditAttribute>
-													{t('Assign Hotkeys to Global AdLibs')}
+													{t('Pieces on this layer can be cleared')}
 												</label>
 											</div>
 											<div className="mod mvs mhs">

--- a/meteor/client/ui/Shelf/AdLibListItem.tsx
+++ b/meteor/client/ui/Shelf/AdLibListItem.tsx
@@ -22,7 +22,6 @@ export interface IAdLibListItem extends AdLibPieceUi {
 	contentPackageInfos?: ScanInfoForPackages
 	sourceLayer?: ISourceLayer
 	outputLayer?: IOutputLayer
-	hotkey?: string
 	isHidden?: boolean
 	invalid?: boolean
 	floated?: boolean

--- a/meteor/client/ui/Shelf/AdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibPanel.tsx
@@ -738,7 +738,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 					).fetch()
 					rundownBaselineAdLibs = rundownAdLibItems.concat(
 						props.showStyleBase.sourceLayers
-							.filter((i) => i.isSticky && i.activateStickyKeyboardHotkey)
+							.filter((i) => i.isSticky)
 							.sort((a, b) => a._rank - b._rank)
 							.map((layer) =>
 								literal<AdLibPieceUi>({
@@ -815,7 +815,7 @@ export function fetchAndFilter(props: Translated<IAdLibPanelProps>): AdLibFetchA
 			const rundownBaselineClearAdLibs = memoizedIsolatedAutorun(
 				(sourceLayers: ISourceLayer[]) => {
 					return sourceLayers
-						.filter((i) => !!i.clearKeyboardHotkey)
+						.filter((i) => !!i.isClearable)
 						.sort((a, b) => a._rank - b._rank)
 						.map((layer) =>
 							literal<AdLibPieceUi>({

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -509,10 +509,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 								)
 							)
 						} else {
-							if (
-								!this.isAdLibOnAir(piece as any as AdLibPieceUi) ||
-								!(sourceLayer && sourceLayer.clearKeyboardHotkey)
-							) {
+							if (!this.isAdLibOnAir(piece as any as AdLibPieceUi) || !(sourceLayer && sourceLayer.isClearable)) {
 								const currentPartInstanceId = this.props.playlist.currentPartInstanceId
 
 								doUserAction(t, e, UserAction.START_BUCKET_ADLIB, (e) =>
@@ -525,7 +522,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 									)
 								)
 							} else {
-								if (sourceLayer && sourceLayer.clearKeyboardHotkey) {
+								if (sourceLayer && sourceLayer.isClearable) {
 									this.onClearAllSourceLayer(sourceLayer, e)
 								}
 							}

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -312,7 +312,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		}
 		if (this.props.playlist && this.props.playlist.currentPartInstanceId) {
 			const currentPartInstanceId = this.props.playlist.currentPartInstanceId
-			if (!this.isAdLibOnAir(adlibPiece) || !(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
+			if (!this.isAdLibOnAir(adlibPiece) || !(sourceLayer && sourceLayer.isClearable)) {
 				if (adlibPiece.isAction && adlibPiece.adlibAction) {
 					const action = adlibPiece.adlibAction
 					doUserAction(t, e, adlibPiece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB, (e) =>
@@ -349,7 +349,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 					this.onToggleSticky(adlibPiece.sourceLayerId, e)
 				}
 			} else {
-				if (sourceLayer && sourceLayer.clearKeyboardHotkey) {
+				if (sourceLayer && sourceLayer.isClearable) {
 					this.onClearAllSourceLayers([sourceLayer], e)
 				}
 			}
@@ -393,7 +393,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 			const piece = this.state.selectedAdLib
 			const sourceLayer = this.props.sourceLayerLookup && this.props.sourceLayerLookup[piece.sourceLayerId]
 			if (this.props.playlist && this.props.playlist.currentPartInstanceId) {
-				if (!this.isAdLibOnAir(piece) || !(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
+				if (!this.isAdLibOnAir(piece) || !(sourceLayer && sourceLayer.isClearable)) {
 					if (piece.isAction && piece.adlibAction) {
 						const action = piece.adlibAction
 						doUserAction(t, e, piece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB, (e) =>
@@ -437,7 +437,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 		if (this.state.selectedAdLib) {
 			const piece = this.state.selectedAdLib
 			const sourceLayer = this.props.sourceLayerLookup && this.props.sourceLayerLookup[piece.sourceLayerId]
-			if (sourceLayer && (sourceLayer.clearKeyboardHotkey || outButton)) {
+			if (sourceLayer && (sourceLayer.isClearable || outButton)) {
 				this.onClearAllSourceLayers([sourceLayer], e)
 			}
 		}

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -117,7 +117,6 @@ const AdLibListView = withTranslation()(
 								.map((layer) =>
 									literal<IAdLibListItem & { souceLayer?: ISourceLayer; isSticky: boolean }>({
 										_id: protectString(layer._id),
-										hotkey: layer.activateStickyKeyboardHotkey ? layer.activateStickyKeyboardHotkey.split(',')[0] : '',
 										name: t('Last {{layerName}}', { layerName: layer.abbreviation || layer.name }),
 										status: RundownAPI.PieceStatusCode.UNKNOWN,
 										sourceLayer: layer,

--- a/meteor/lib/api/triggers/actionFilterChainCompilers.ts
+++ b/meteor/lib/api/triggers/actionFilterChainCompilers.ts
@@ -220,8 +220,7 @@ function compileAndRunClearFilter(filterChain: IAdLibFilterLink[], showStyleBase
 		result = showStyleBase.sourceLayers
 			.filter(
 				(sourceLayer) =>
-					(sourceLayerIds ? sourceLayerIds.includes(sourceLayer._id) : true) &&
-					sourceLayer.clearKeyboardHotkey !== undefined
+					(sourceLayerIds ? sourceLayerIds.includes(sourceLayer._id) : true) && sourceLayer.isClearable
 			)
 			.map((sourceLayer) => {
 				return {

--- a/meteor/server/migration/1_37_0.ts
+++ b/meteor/server/migration/1_37_0.ts
@@ -450,22 +450,15 @@ export const addSteps = addMigrationSteps('1.37.0', [
 			return false
 		},
 		migrate: () => {
-			ShowStyleBases.find(
-				{
-					sourceLayers: {
-						$elemMatch: {
-							clearKeyboardHotkey: {
-								$exists: true,
-							},
+			ShowStyleBases.find({
+				sourceLayers: {
+					$elemMatch: {
+						clearKeyboardHotkey: {
+							$exists: true,
 						},
 					},
 				},
-				{
-					fields: {
-						name: 1,
-					},
-				}
-			).forEach((showStyleBase) => {
+			}).forEach((showStyleBase) => {
 				ShowStyleBases.update(showStyleBase._id, {
 					$set: {
 						sourceLayers: showStyleBase.sourceLayers.map((sourceLayer) => {

--- a/meteor/server/migration/1_37_0.ts
+++ b/meteor/server/migration/1_37_0.ts
@@ -471,6 +471,9 @@ export const addSteps = addMigrationSteps('1.37.0', [
 						sourceLayers: showStyleBase.sourceLayers.map((sourceLayer) => {
 							sourceLayer.isClearable = !!sourceLayer['clearKeyboardHotkey']
 							delete sourceLayer['clearKeyboardHotkey']
+							delete sourceLayer['activateKeyboardHotkeys']
+							delete sourceLayer['assignHotkeysToGlobalAdlibs']
+							delete sourceLayer['activateStickyKeyboardHotkey']
 							return sourceLayer
 						}),
 					},

--- a/meteor/server/migration/1_37_0.ts
+++ b/meteor/server/migration/1_37_0.ts
@@ -14,6 +14,7 @@ import {
 import { logger } from '../logging'
 import { Rundown, Rundowns } from '../../lib/collections/Rundowns'
 import { TriggeredActions } from '../../lib/collections/TriggeredActions'
+import { ShowStyleBases } from '../../lib/collections/ShowStyleBases'
 
 let j = 0
 
@@ -419,6 +420,64 @@ const DEFAULT_CORE_TRIGGERS: IBlueprintTriggeredActions[] = [
 
 // Release 37
 export const addSteps = addMigrationSteps('1.37.0', [
+	{
+		id: 'ShowStyleBase.sourceLayers.clearKeyboardHotkey',
+		canBeRunAutomatically: true,
+		validate: () => {
+			const outdatedShowStyleBases = ShowStyleBases.find(
+				{
+					sourceLayers: {
+						$elemMatch: {
+							clearKeyboardHotkey: {
+								$exists: true,
+							},
+						},
+					},
+				},
+				{
+					fields: {
+						name: 1,
+					},
+				}
+			).map((showStyleBase) => showStyleBase._id)
+
+			if (outdatedShowStyleBases.length > 0) {
+				return `Show Styles: ${outdatedShowStyleBases
+					.map((name) => `"${name}"`)
+					.join(', ')} need to have their Source Layers clearable settings migrated.`
+			}
+
+			return false
+		},
+		migrate: () => {
+			ShowStyleBases.find(
+				{
+					sourceLayers: {
+						$elemMatch: {
+							clearKeyboardHotkey: {
+								$exists: true,
+							},
+						},
+					},
+				},
+				{
+					fields: {
+						name: 1,
+					},
+				}
+			).forEach((showStyleBase) => {
+				ShowStyleBases.update(showStyleBase._id, {
+					$set: {
+						sourceLayers: showStyleBase.sourceLayers.map((sourceLayer) => {
+							sourceLayer.isClearable = !!sourceLayer['clearKeyboardHotkey']
+							delete sourceLayer['clearKeyboardHotkey']
+							return sourceLayer
+						}),
+					},
+				})
+			})
+		},
+	},
 	{
 		id: 'TriggeredActions.core',
 		canBeRunAutomatically: true,

--- a/packages/blueprints-integration/src/showStyle.ts
+++ b/packages/blueprints-integration/src/showStyle.ts
@@ -39,18 +39,12 @@ export interface ISourceLayer {
 	isRemoteInput?: boolean
 	/** Use special treatment for guest inputs */
 	isGuestInput?: boolean
-	/** Available shortcuts to be used for ad-lib items assigned to this sourceLayer - comma separated list allowing for chords (keyboard sequences) */
-	activateKeyboardHotkeys?: string
-	/** Single 'clear all from this sourceLayer' keyboard shortcut */
-	clearKeyboardHotkey?: string
-	/** Do global objects get to be assigned hotkeys? */
-	assignHotkeysToGlobalAdlibs?: boolean
+	/** Should this layer be clearable */
+	isClearable?: boolean
 	/** Last used sticky item on a layer is remembered and can be returned to using the sticky hotkey */
 	isSticky?: boolean
 	/** Whether sticky items should only use original pieces on this layer (not inserted via an adlib) */
 	stickyOriginalOnly?: boolean
-	/** Keyboard shortcut to be used to reuse a sticky item on this layer */
-	activateStickyKeyboardHotkey?: string
 	/** Should adlibs on this source layer be queueable */
 	isQueueable?: boolean
 	/** If set to true, the layer will be hidden from the user in Rundown View */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is mostly a clean-up PR, removing old hotkey properties on ISourceLayer that were superseded by Action Triggers.

* **What is the current behavior?** (You can also link to an open issue here)

Properties describing GUI hotkey behavior were placed on ISourceLayer objects of ShowStyleBase objects.

* **What is the new behavior (if this is a feature change)?**

These properties are now removed and `clearKeyboardHotkey` is migrated to a boolean `isClearable` value.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
