### PR TITLE
feat: pieces can specify how to be direct-played

### DIFF
--- a/meteor/server/api/blueprints/context/lib.ts
+++ b/meteor/server/api/blueprints/context/lib.ts
@@ -3,6 +3,7 @@ import {
 	PartHoldMode,
 	IBlueprintMutatablePart,
 	PieceLifespan,
+	IBlueprintDirectPlayType,
 } from '@sofie-automation/blueprints-integration'
 
 const IBlueprintPieceSample: Required<IBlueprintPiece> = {
@@ -28,7 +29,7 @@ const IBlueprintPieceSample: Required<IBlueprintPiece> = {
 	tags: [],
 	expectedPackages: [],
 	hasSideEffects: false,
-	allowDirectPlay: { type: 'adlib' },
+	allowDirectPlay: { type: IBlueprintDirectPlayType.AdLibPiece },
 }
 // Compile a list of the keys which are allowed to be set
 export const IBlueprintPieceSampleKeys = Object.keys(IBlueprintPieceSample) as Array<keyof IBlueprintPiece>

--- a/meteor/server/api/blueprints/context/lib.ts
+++ b/meteor/server/api/blueprints/context/lib.ts
@@ -28,6 +28,7 @@ const IBlueprintPieceSample: Required<IBlueprintPiece> = {
 	tags: [],
 	expectedPackages: [],
 	hasSideEffects: false,
+	allowDirectPlay: { type: 'adlib' },
 }
 // Compile a list of the keys which are allowed to be set
 export const IBlueprintPieceSampleKeys = Object.keys(IBlueprintPieceSample) as Array<keyof IBlueprintPiece>

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import * as _ from 'underscore'
-import { SourceLayerType, PieceLifespan } from '@sofie-automation/blueprints-integration'
+import { SourceLayerType, PieceLifespan, IBlueprintDirectPlayType } from '@sofie-automation/blueprints-integration'
 import {
 	getCurrentTime,
 	literal,
@@ -113,7 +113,7 @@ export namespace ServerPlayoutAdLibAPI {
 					await pieceTakeNowAsAdlib(cache, showStyleBase, partInstance, pieceToCopy, pieceInstanceToCopy)
 				} else {
 					switch (pieceToCopy.allowDirectPlay.type) {
-						case 'adlib':
+						case IBlueprintDirectPlayType.AdLibPiece:
 							await pieceTakeNowAsAdlib(
 								cache,
 								showStyleBase,
@@ -122,7 +122,7 @@ export namespace ServerPlayoutAdLibAPI {
 								pieceInstanceToCopy
 							)
 							break
-						case 'action': {
+						case IBlueprintDirectPlayType.AdLibAction: {
 							const executeProps = pieceToCopy.allowDirectPlay
 							await ServerPlayoutAPI.executeActionInner(
 								cache,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -32,15 +32,19 @@ import {
 	PieceInstance,
 	PieceInstanceId,
 	rewrapPieceToInstance,
+	PieceInstancePiece,
 } from '../../../lib/collections/PieceInstances'
 import { PartInstance, PartInstanceId } from '../../../lib/collections/PartInstances'
 import { BucketAdLib, BucketAdLibs } from '../../../lib/collections/BucketAdlibs'
 import { MongoQuery } from '../../../lib/typings/meteor'
-import { fetchPiecesThatMayBeActiveForPart, syncPlayheadInfinitesForNextPartInstance } from './infinites'
+import {
+	fetchPiecesThatMayBeActiveForPart,
+	syncPlayheadInfinitesForNextPartInstance,
+	getPieceInstancesForPart,
+} from './infinites'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { profiler } from '../profiler'
-import { getPieceInstancesForPart } from './infinites'
 import { PlayoutLockFunctionPriority, runPlayoutOperationWithCache } from './lockFunction'
 import {
 	CacheForPlayout,
@@ -51,6 +55,8 @@ import {
 import { ReadonlyDeep } from 'type-fest'
 import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBaselineAdLibPieces'
 import { VerifiedRundownPlaylistContentAccess } from '../lib'
+import { ServerPlayoutAPI } from './playout'
+import { loadShowStyleBlueprint } from '../blueprints/cache'
 
 export namespace ServerPlayoutAdLibAPI {
 	export async function pieceTakeNow(
@@ -72,10 +78,6 @@ export namespace ServerPlayoutAdLibAPI {
 					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a current part!`)
 			},
 			async (cache) => {
-				const playlist = cache.Playlist.doc
-				if (!playlist.activationId)
-					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
-
 				const rundownIds = getRundownIDsFromCache(cache)
 
 				const pieceInstanceToCopy = cache.PieceInstances.findOne({
@@ -99,74 +101,130 @@ export namespace ServerPlayoutAdLibAPI {
 				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
 
 				const showStyleBase = rundown.getShowStyleBase() // todo: database
-				const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === pieceToCopy.sourceLayerId)
-				if (sourceLayer && (sourceLayer.type !== SourceLayerType.LOWER_THIRD || sourceLayer.exclusiveGroup))
-					throw new Meteor.Error(
-						403,
-						`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" is not a LOWER_THIRD item!`
-					)
+				if (!pieceToCopy.allowDirectPlay) {
+					// Not explicitly allowed, use legacy route
+					const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === pieceToCopy.sourceLayerId)
+					if (sourceLayer && (sourceLayer.type !== SourceLayerType.LOWER_THIRD || sourceLayer.exclusiveGroup))
+						throw new Meteor.Error(
+							403,
+							`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" cannot be direct played!`
+						)
 
-				const newPieceInstance = convertAdLibToPieceInstance(
-					playlist.activationId,
-					pieceToCopy,
-					partInstance,
-					false
-				)
-				if (newPieceInstance.piece.content && newPieceInstance.piece.content.timelineObjects) {
-					newPieceInstance.piece.content.timelineObjects = prefixAllObjectIds(
-						_.map(newPieceInstance.piece.content.timelineObjects, (obj) => {
-							return literal<TimelineObjGeneric>({
-								...obj,
-								// @ts-ignore _id
-								_id: obj.id || obj._id,
-								studioId: protectString(''), // set later
-								objectType: TimelineObjType.RUNDOWN,
-							})
-						}),
-						unprotectString(newPieceInstance._id)
-					)
-				}
-
-				// Disable the original piece if from the same Part
-				if (pieceInstanceToCopy && pieceInstanceToCopy.partInstanceId === partInstance._id) {
-					// Ensure the piece being copied isnt currently live
-					if (
-						pieceInstanceToCopy.startedPlayback &&
-						pieceInstanceToCopy.startedPlayback <= getCurrentTime()
-					) {
-						const resolvedPieces = getResolvedPieces(cache, showStyleBase, partInstance)
-						const resolvedPieceBeingCopied = resolvedPieces.find((p) => p._id === pieceInstanceToCopy._id)
-
-						if (
-							resolvedPieceBeingCopied &&
-							resolvedPieceBeingCopied.resolvedDuration !== undefined &&
-							(resolvedPieceBeingCopied.infinite ||
-								resolvedPieceBeingCopied.resolvedStart + resolvedPieceBeingCopied.resolvedDuration >=
-									getCurrentTime())
-						) {
-							// logger.debug(`Piece "${piece._id}" is currently live and cannot be used as an ad-lib`)
-							throw new Meteor.Error(
-								409,
-								`PieceInstance "${pieceInstanceToCopy._id}" is currently live and cannot be used as an ad-lib`
+					await pieceTakeNowAsAdlib(cache, showStyleBase, partInstance, pieceToCopy, pieceInstanceToCopy)
+				} else {
+					switch (pieceToCopy.allowDirectPlay.type) {
+						case 'adlib':
+							await pieceTakeNowAsAdlib(
+								cache,
+								showStyleBase,
+								partInstance,
+								pieceToCopy,
+								pieceInstanceToCopy
 							)
+							break
+						case 'action': {
+							const executeProps = pieceToCopy.allowDirectPlay
+							await ServerPlayoutAPI.executeActionInner(
+								cache,
+								null, // TODO: should this be able to retrieve any watched packages?
+								async (actionContext, _rundown) => {
+									const blueprint = await loadShowStyleBlueprint(actionContext.showStyleCompound)
+									if (!blueprint.blueprint.executeAction) {
+										throw new Meteor.Error(
+											400,
+											`ShowStyle blueprint "${blueprint.blueprintId}" does not support executing actions`
+										)
+									}
+
+									logger.info(
+										`Executing AdlibAction "${executeProps.actionId}": ${JSON.stringify(
+											executeProps.userData
+										)}`
+									)
+
+									blueprint.blueprint.executeAction(
+										actionContext,
+										executeProps.actionId,
+										executeProps.userData
+									)
+								}
+							)
+							break
 						}
+						default:
+							assertNever(pieceToCopy.allowDirectPlay)
+							throw new Meteor.Error(
+								500,
+								`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" is not direct playable!`
+							)
 					}
-
-					cache.PieceInstances.update(pieceInstanceToCopy._id, {
-						$set: {
-							disabled: true,
-							hidden: true,
-						},
-					})
 				}
-
-				cache.PieceInstances.insert(newPieceInstance)
-
-				await syncPlayheadInfinitesForNextPartInstance(cache)
-
-				await updateTimeline(cache)
 			}
 		)
+	}
+
+	async function pieceTakeNowAsAdlib(
+		cache: CacheForPlayout,
+		showStyleBase: ShowStyleBase,
+		partInstance: PartInstance,
+		pieceToCopy: PieceInstancePiece,
+		pieceInstanceToCopy: PieceInstance | undefined
+	): Promise<void> {
+		const playlist = cache.Playlist.doc
+		if (!playlist.activationId)
+			throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
+
+		const newPieceInstance = convertAdLibToPieceInstance(playlist.activationId, pieceToCopy, partInstance, false)
+		if (newPieceInstance.piece.content && newPieceInstance.piece.content.timelineObjects) {
+			newPieceInstance.piece.content.timelineObjects = prefixAllObjectIds(
+				_.map(newPieceInstance.piece.content.timelineObjects, (obj) => {
+					return literal<TimelineObjGeneric>({
+						...obj,
+						// @ts-ignore _id
+						_id: obj.id || obj._id,
+						studioId: protectString(''), // set later
+						objectType: TimelineObjType.RUNDOWN,
+					})
+				}),
+				unprotectString(newPieceInstance._id)
+			)
+		}
+
+		// Disable the original piece if from the same Part
+		if (pieceInstanceToCopy && pieceInstanceToCopy.partInstanceId === partInstance._id) {
+			// Ensure the piece being copied isnt currently live
+			if (pieceInstanceToCopy.startedPlayback && pieceInstanceToCopy.startedPlayback <= getCurrentTime()) {
+				const resolvedPieces = getResolvedPieces(cache, showStyleBase, partInstance)
+				const resolvedPieceBeingCopied = resolvedPieces.find((p) => p._id === pieceInstanceToCopy._id)
+
+				if (
+					resolvedPieceBeingCopied &&
+					resolvedPieceBeingCopied.resolvedDuration !== undefined &&
+					(resolvedPieceBeingCopied.infinite ||
+						resolvedPieceBeingCopied.resolvedStart + resolvedPieceBeingCopied.resolvedDuration >=
+							getCurrentTime())
+				) {
+					// logger.debug(`Piece "${piece._id}" is currently live and cannot be used as an ad-lib`)
+					throw new Meteor.Error(
+						409,
+						`PieceInstance "${pieceInstanceToCopy._id}" is currently live and cannot be used as an ad-lib`
+					)
+				}
+			}
+
+			cache.PieceInstances.update(pieceInstanceToCopy._id, {
+				$set: {
+					disabled: true,
+					hidden: true,
+				},
+			})
+		}
+
+		cache.PieceInstances.insert(newPieceInstance)
+
+		await syncPlayheadInfinitesForNextPartInstance(cache)
+
+		await updateTimeline(cache)
 	}
 	export async function segmentAdLibPieceStart(
 		access: VerifiedRundownPlaylistContentAccess,

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -74,10 +74,11 @@ import { runStudioOperationWithCache, StudioLockFunctionPriority } from '../stud
 import { CacheForStudio } from '../studio/cache'
 import { VerifiedRundownPlaylistContentAccess } from '../lib'
 import { WatchedPackagesHelper } from '../blueprints/context/watchedPackages'
-import { ExpectedPackageDBType } from '../../../lib/collections/ExpectedPackages'
+import { ExpectedPackageDBBase, ExpectedPackageDBType } from '../../../lib/collections/ExpectedPackages'
 import { AdLibActionId } from '../../../lib/collections/AdLibActions'
 import { RundownBaselineAdLibActionId } from '../../../lib/collections/RundownBaselineAdLibActions'
 import { profiler } from '../profiler'
+import { MongoQuery } from '../../../lib/typings/meteor'
 
 /**
  * debounce time in ms before we accept another report of "Part started playing that was not selected by core"
@@ -1124,34 +1125,6 @@ export namespace ServerPlayoutAPI {
 		check(userData, Match.Any)
 		check(triggerMode, Match.Maybe(String))
 
-		return executeActionInner(access, rundownPlaylistId, actionDocId, async (actionContext, _cache, _rundown) => {
-			const blueprint = await loadShowStyleBlueprint(actionContext.showStyleCompound)
-			if (!blueprint.blueprint.executeAction) {
-				throw new Meteor.Error(
-					400,
-					`ShowStyle blueprint "${blueprint.blueprintId}" does not support executing actions`
-				)
-			}
-
-			logger.info(`Executing AdlibAction "${actionId}": ${JSON.stringify(userData)}`)
-
-			blueprint.blueprint.executeAction(actionContext, actionId, userData, triggerMode)
-		})
-	}
-
-	export async function executeActionInner(
-		access: VerifiedRundownPlaylistContentAccess,
-		rundownPlaylistId: RundownPlaylistId,
-		actionDocId: AdLibActionId | RundownBaselineAdLibActionId,
-		func: (
-			context: ActionExecutionContext,
-			cache: CacheForPlayout,
-			rundown: Rundown,
-			currentPartInstance: PartInstance
-		) => Promise<void>
-	): Promise<void> {
-		const now = getCurrentTime()
-
 		return runPlayoutOperationWithCache(
 			access,
 			'executeActionInner',
@@ -1166,66 +1139,91 @@ export namespace ServerPlayoutAPI {
 					throw new Meteor.Error(400, `A part needs to be active to execute an action`)
 			},
 			async (cache) => {
-				const playlist = cache.Playlist.doc
-
-				const currentPartInstance = playlist.currentPartInstanceId
-					? cache.PartInstances.findOne(playlist.currentPartInstanceId)
-					: undefined
-				if (!currentPartInstance)
-					throw new Meteor.Error(
-						501,
-						`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
-					)
-
-				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
-				if (!rundown)
-					throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
-
-				const [showStyle, watchedPackages] = await Promise.all([
-					cache.activationCache.getShowStyleCompound(rundown),
-					WatchedPackagesHelper.create(cache.Studio.doc._id, {
+				return executeActionInner(
+					cache,
+					{
 						pieceId: actionDocId,
 						fromPieceType: {
 							$in: [ExpectedPackageDBType.ADLIB_ACTION, ExpectedPackageDBType.BASELINE_ADLIB_ACTION],
 						},
-					}),
-				])
-				const actionContext = new ActionExecutionContext(
-					{
-						name: `${rundown.name}(${playlist.name})`,
-						identifier: `playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
-							currentPartInstance._id
-						},execution=${getRandomId()}`,
-						tempSendUserNotesIntoBlackHole: true, // TODO-CONTEXT store these notes
 					},
-					cache,
-					showStyle,
-					rundown,
-					watchedPackages
-				)
+					async (actionContext, _rundown) => {
+						const blueprint = await loadShowStyleBlueprint(actionContext.showStyleCompound)
+						if (!blueprint.blueprint.executeAction) {
+							throw new Meteor.Error(
+								400,
+								`ShowStyle blueprint "${blueprint.blueprintId}" does not support executing actions`
+							)
+						}
 
-				// If any action cannot be done due to timings, that needs to be rejected by the context
-				await func(actionContext, cache, rundown, currentPartInstance)
+						logger.info(`Executing AdlibAction "${actionId}": ${JSON.stringify(userData)}`)
 
-				if (
-					actionContext.currentPartState !== ActionPartChange.NONE ||
-					actionContext.nextPartState !== ActionPartChange.NONE
-				) {
-					await syncPlayheadInfinitesForNextPartInstance(cache)
-				}
-
-				if (actionContext.takeAfterExecute) {
-					await ServerPlayoutAPI.callTakeWithCache(cache, now)
-				} else {
-					if (
-						actionContext.currentPartState !== ActionPartChange.NONE ||
-						actionContext.nextPartState !== ActionPartChange.NONE
-					) {
-						await updateTimeline(cache)
+						blueprint.blueprint.executeAction(actionContext, actionId, userData, triggerMode)
 					}
-				}
+				)
 			}
 		)
+	}
+
+	export async function executeActionInner(
+		cache: CacheForPlayout,
+		watchedPackagesFilter: MongoQuery<Omit<ExpectedPackageDBBase, 'studioId'>> | null,
+		func: (context: ActionExecutionContext, rundown: Rundown, currentPartInstance: PartInstance) => Promise<void>
+	): Promise<void> {
+		const now = getCurrentTime()
+
+		const playlist = cache.Playlist.doc
+
+		const currentPartInstance = playlist.currentPartInstanceId
+			? cache.PartInstances.findOne(playlist.currentPartInstanceId)
+			: undefined
+		if (!currentPartInstance)
+			throw new Meteor.Error(501, `Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`)
+
+		const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
+		if (!rundown)
+			throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
+
+		const [showStyle, watchedPackages] = await Promise.all([
+			cache.activationCache.getShowStyleCompound(rundown),
+			watchedPackagesFilter
+				? WatchedPackagesHelper.create(cache.Studio.doc._id, watchedPackagesFilter)
+				: WatchedPackagesHelper.empty(),
+		])
+		const actionContext = new ActionExecutionContext(
+			{
+				name: `${rundown.name}(${playlist.name})`,
+				identifier: `playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
+					currentPartInstance._id
+				},execution=${getRandomId()}`,
+				tempSendUserNotesIntoBlackHole: true, // TODO-CONTEXT store these notes
+			},
+			cache,
+			showStyle,
+			rundown,
+			watchedPackages
+		)
+
+		// If any action cannot be done due to timings, that needs to be rejected by the context
+		await func(actionContext, rundown, currentPartInstance)
+
+		if (
+			actionContext.currentPartState !== ActionPartChange.NONE ||
+			actionContext.nextPartState !== ActionPartChange.NONE
+		) {
+			await syncPlayheadInfinitesForNextPartInstance(cache)
+		}
+
+		if (actionContext.takeAfterExecute) {
+			await ServerPlayoutAPI.callTakeWithCache(cache, now)
+		} else {
+			if (
+				actionContext.currentPartState !== ActionPartChange.NONE ||
+				actionContext.nextPartState !== ActionPartChange.NONE
+			) {
+				await updateTimeline(cache)
+			}
+		}
 	}
 	/**
 	 * This exists for the purpose of mocking this call for testing.

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -392,13 +392,14 @@ export async function pieceTakeNow(
 	})
 	if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
 
-	const showStyleBase = rundown.getShowStyleBase()
-	const sourceLayerId = pieceToCopy.sourceLayerId
-	const sourceL = showStyleBase.sourceLayers.find((i) => i._id === sourceLayerId)
-	if (sourceL && (sourceL.type !== SourceLayerType.LOWER_THIRD || sourceL.exclusiveGroup))
-		return ClientAPI.responseError(
-			`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" is not a LOWER_THIRD piece!`
-		)
+	if (!pieceToCopy.allowDirectPlay) {
+		// Not explicitly allowed, use legacy route
+		const showStyleBase = rundown.getShowStyleBase()
+		const sourceLayerId = pieceToCopy.sourceLayerId
+		const sourceL = showStyleBase.sourceLayers.find((i) => i._id === sourceLayerId)
+		if (sourceL && (sourceL.type !== SourceLayerType.LOWER_THIRD || sourceL.exclusiveGroup))
+			return ClientAPI.responseError(`PieceInstance or Piece "${pieceToCopy.name}" cannot be direct played!`)
+	}
 
 	return ClientAPI.responseSuccess(
 		await ServerPlayoutAPI.pieceTakeNow(access, rundownPlaylistId, partInstanceId, pieceInstanceIdOrPieceIdToCopy)

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -284,17 +284,24 @@ export interface PieceTransition {
 	duration: number
 }
 
-export interface IBlueprintDirectPlayAdLibPiece {
-	type: 'adlib'
+export enum IBlueprintDirectPlayType {
+	AdLibPiece = 'adlib',
+	AdLibAction = 'action',
 }
-export interface IBlueprintDirectPlayAdLibAction {
-	type: 'action'
+export interface IBlueprintDirectPlayBase {
+	type: IBlueprintDirectPlayType
+}
+export interface IBlueprintDirectPlayAdLibPiece extends IBlueprintDirectPlayBase {
+	type: IBlueprintDirectPlayType.AdLibPiece
+}
+export interface IBlueprintDirectPlayAdLibAction extends IBlueprintDirectPlayBase {
+	type: IBlueprintDirectPlayType.AdLibAction
 	/** Id of the action */
 	actionId: string
 	/** Properties defining the action behaviour */
 	userData: ActionUserData
 }
-export type IBlueprintSomeDirectPlay = IBlueprintDirectPlayAdLibPiece | IBlueprintDirectPlayAdLibAction
+export type IBlueprintDirectPlay = IBlueprintDirectPlayAdLibPiece | IBlueprintDirectPlayAdLibAction
 
 export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 	/** ID of the source object in the gateway */
@@ -340,7 +347,7 @@ export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 	tags?: string[]
 
 	/** Allow this part to be direct played (eg, by double clicking in the rundown timeline view) */
-	allowDirectPlay?: IBlueprintSomeDirectPlay
+	allowDirectPlay?: IBlueprintDirectPlay
 
 	/**
 	 * An array of which Packages this Piece uses. This is used by a Package Manager to ensure that the Package is in place for playout.

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -4,6 +4,7 @@ import { ExpectedPackage } from './package'
 import { SomeTimelineContent } from './content'
 import { ITranslatableMessage } from './translations'
 import { PartEndState } from './api'
+import { ActionUserData } from './action'
 
 export interface IBlueprintRundownPlaylistInfo {
 	/** Rundown playlist slug - user-presentable name */
@@ -283,6 +284,18 @@ export interface PieceTransition {
 	duration: number
 }
 
+export interface IBlueprintDirectPlayAdLibPiece {
+	type: 'adlib'
+}
+export interface IBlueprintDirectPlayAdLibAction {
+	type: 'action'
+	/** Id of the action */
+	actionId: string
+	/** Properties defining the action behaviour */
+	userData: ActionUserData
+}
+export type IBlueprintSomeDirectPlay = IBlueprintDirectPlayAdLibPiece | IBlueprintDirectPlayAdLibAction
+
 export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 	/** ID of the source object in the gateway */
 	externalId: string
@@ -325,6 +338,9 @@ export interface IBlueprintPieceGeneric<TMetadata = unknown> {
 	adlibDisableOutTransition?: boolean
 	/** User-defined tags that can be used for filtering adlibs in the shelf and identifying pieces by actions */
 	tags?: string[]
+
+	/** Allow this part to be direct played (eg, by double clicking in the rundown timeline view) */
+	allowDirectPlay?: IBlueprintSomeDirectPlay
 
 	/**
 	 * An array of which Packages this Piece uses. This is used by a Package Manager to ensure that the Package is in place for playout.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

When a piece is double clicked, it gets 'direct played' as an adlib piece. This is only allowed for LOWER_THIRD pieces, as they are known to be safe to do this with.

* **What is the new behavior (if this is a feature change)?**

This introduces a new rule that lets the blueprints say which pieces are safe to use as an adlib like this.
Additionally, it states whether it should be used as an adlib or if an adlib-action should be executed instead.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
