### PR TITLE
fix: it's not possible to select bucket adlibs and rename them

### DIFF
--- a/meteor/client/ui/SegmentTimeline/Renderers/EvsLayerItemRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/EvsLayerItemRenderer.tsx
@@ -4,7 +4,7 @@ import { EvsContent } from '@sofie-automation/blueprints-integration'
 
 import { CustomLayerItemRenderer, ICustomLayerItemProps } from './CustomLayerItemRenderer'
 type IProps = ICustomLayerItemProps
-interface IState { }
+interface IState {}
 
 export class LocalLayerItemRenderer extends CustomLayerItemRenderer<IProps, IState> {
 	leftLabel: HTMLSpanElement | null

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -184,7 +184,10 @@ export function actionToAdLibPieceUi(
 
 	return literal<BucketAdLibActionUi>({
 		_id: protectString(`${action._id}`),
-		name: translateMessage(action.display.label, i18nTranslator),
+		name:
+			typeof action.display.label === 'string'
+				? action.display.label
+				: translateMessage(action.display.label, i18nTranslator),
 		status: RundownAPI.PieceStatusCode.UNKNOWN,
 		isAction: true,
 		expectedDuration: 0,
@@ -458,8 +461,6 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						)
 					}
 				}
-
-				onSelectAdLib = (_piece: BucketAdLibItem, _e: any) => {}
 
 				onToggleAdLib = (piece: BucketAdLibItem, queue: boolean, e: any, mode?: IBlueprintActionTriggerMode) => {
 					const { t } = this.props
@@ -799,7 +800,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 													layer={this.props.sourceLayers[adlib.sourceLayerId]}
 													outputLayer={this.props.outputLayers[adlib.outputLayerId]}
 													onToggleAdLib={this.onToggleAdLib as any}
-													onSelectAdLib={this.onSelectAdLib as any}
+													onSelectAdLib={this.props.onSelectAdlib}
 													playlist={this.props.playlist}
 													isOnAir={this.isAdLibOnAir(adlib as any as AdLibPieceUi)}
 													mediaPreviewUrl={

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -441,7 +441,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 							  (this.props.heightScale as number) * DEFAULT_BUTTON_HEIGHT + 'em'
 							: undefined,
 				}}
-				onClickCapture={this.handleClick}
+				onClick={this.handleClick}
 				onDoubleClick={this.handleDoubleClick}
 				ref={this.setRef}
 				onMouseDown={this.handleOnMouseDown}

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -336,9 +336,19 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 
 	private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
 		const { toggleOnSingleClick } = this.props
-		if (toggleOnSingleClick) {
-			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
-		} else {
+		if (e.button === 0) {
+			// this is a main-button-click
+			if (toggleOnSingleClick) {
+				this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
+			} else {
+				this.props.onSelectAdLib(this.props.piece, e)
+			}
+		}
+	}
+
+	private handleOnMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (e.button) {
+			// this is some other button, main button is 0
 			this.props.onSelectAdLib(this.props.piece, e)
 		}
 	}
@@ -431,9 +441,10 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 							  (this.props.heightScale as number) * DEFAULT_BUTTON_HEIGHT + 'em'
 							: undefined,
 				}}
-				onClick={this.handleClick}
+				onClickCapture={this.handleClick}
 				onDoubleClick={this.handleDoubleClick}
 				ref={this.setRef}
+				onMouseDown={this.handleOnMouseDown}
 				onMouseEnter={this.handleOnMouseEnter}
 				onMouseLeave={this.handleOnMouseLeave}
 				onMouseMove={this.handleOnMouseMove}

--- a/meteor/lib/collections/BucketAdlibActions.ts
+++ b/meteor/lib/collections/BucketAdlibActions.ts
@@ -30,7 +30,8 @@ export interface BucketAdLibAction extends Omit<IBlueprintActionManifest, 'partI
 
 	// How this AdLib Action should be displayed to the User
 	display: IBlueprintActionManifest['display'] & {
-		label: ITranslatableMessage
+		// this property can be a string if the name is modified by the User
+		label: ITranslatableMessage | string
 		triggerLabel?: ITranslatableMessage
 		description?: ITranslatableMessage
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix

* **What is the current behavior?** (You can also link to an open issue here)

It's not possible to select and rename Bucket Adlibs, because they aren't selectable and the infrastructure for TranslatableMessages in AdLib Action names makes it impossible to pick up on the user-defined name.

* **What is the new behavior (if this is a feature change)?**

These bugs are fixed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
