### PR TITLE
fix: getUnfinishedPieceInstancesReactive not considering interactions between infinite pieces

### DIFF
--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -182,7 +182,10 @@ export const AdLibRegionPanel = translateWithTracker<
 >(
 	(props: Translated<IAdLibPanelProps & IAdLibRegionPanelProps>) => {
 		const studio = props.playlist.getStudio()
-		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(props.playlist)
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
+			props.playlist,
+			props.showStyleBase
+		)
 		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist)
 		return Object.assign({}, fetchAndFilter(props), {
 			studio: studio,

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -298,7 +298,10 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 			})
 		}
 
-		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(props.playlist)
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
+			props.playlist,
+			props.showStyleBase
+		)
 		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist)
 		const bucketAdLibPieces = BucketAdLibs.find({
 			bucketId: props.bucket._id,

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -697,7 +697,6 @@ export function isAdLibOnAir(
 	unfinishedTags: IDashboardPanelTrackedProps['unfinishedTags'],
 	adLib: AdLibPieceUi
 ) {
-	console.log('isAdLibOnAir', adLib.name, adLib._id, adLib.currentPieceTags, unfinishedTags)
 	if (
 		unfinishedAdLibIds.includes(adLib._id) ||
 		(adLib.currentPieceTags && adLib.currentPieceTags.every((tag) => unfinishedTags.includes(tag)))

--- a/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
+++ b/meteor/client/ui/Shelf/PieceCountdownPanel.tsx
@@ -15,11 +15,13 @@ import { RundownTiming, TimingEvent } from '../RundownView/RundownTiming/Rundown
 import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PieceInstance } from '../../../lib/collections/PieceInstances'
 import { VTContent } from '@sofie-automation/blueprints-integration'
+import { DBShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 interface IPieceCountdownPanelProps {
 	visible?: boolean
 	layout: RundownLayoutBase
 	panel: RundownLayoutPieceCountdown
 	playlist: RundownPlaylist
+	showStyleBase: DBShowStyleBase
 }
 
 interface IPieceCountdownPanelTrackedProps {
@@ -111,7 +113,7 @@ export class PieceCountdownPanelInner extends MeteorReactComponent<
 
 export const PieceCountdownPanel = withTracker<IPieceCountdownPanelProps, IState, IPieceCountdownPanelTrackedProps>(
 	(props: IPieceCountdownPanelProps & IPieceCountdownPanelTrackedProps) => {
-		const unfinishedPieces = getUnfinishedPieceInstancesReactive(props.playlist)
+		const unfinishedPieces = getUnfinishedPieceInstancesReactive(props.playlist, props.showStyleBase)
 		const livePieceInstance: PieceInstance | undefined =
 			props.panel.sourceLayerIds && props.panel.sourceLayerIds.length
 				? _.flatten(Object.values(unfinishedPieces)).find((piece: PieceInstance) => {

--- a/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
+++ b/meteor/client/ui/Shelf/ShelfDashboardLayout.tsx
@@ -101,6 +101,7 @@ export function ShelfDashboardLayout(props: IShelfDashboardLayoutProps) {
 							panel={panel}
 							layout={rundownLayout}
 							playlist={props.playlist}
+							showStyleBase={props.showStyleBase}
 							visible={true}
 						/>
 					) : undefined

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -32,7 +32,10 @@ export const TimelineDashboardPanel = translateWithTracker<
 	AdLibFetchAndFilterProps & IDashboardPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps & IDashboardPanelProps>) => {
-		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(props.playlist)
+		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
+			props.playlist,
+			props.showStyleBase
+		)
 		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist)
 		return {
 			...fetchAndFilter(props),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When a onRundownChange piece is ended by an onRundownEnd piece, the onRundownChange one is still shown as being on-air.

This is because the piece exists, but the infinite logic prunes the piece out as it is determined to be 0 length. This causes it to not get correct playout timings, and so the ui thinks it is playing.

* **What is the new behavior (if this is a feature change)?**

The pieceInstances are run through the same infinite processing logic that is used elsewhere before filtering down to the active ones.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
