### PR TITLE
fix: rewinding and scrolling next part

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -523,14 +523,14 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 				this.context.durations.partDisplayStartsAt[unprotectString(currentNextPart.partId)]
 			const partOffset =
 				nextPartDisplayStartsAt -
-					this.context.durations.partDisplayStartsAt[unprotectString(this.props.parts[0].instance.part._id)] || 0
+					(this.props.parts.length > 0 ? this.context.durations.partDisplayStartsAt[unprotectString(this.props.parts[0].instance.part._id)] ?? 0 : 0)
 			const nextPartIdOrOffsetHasChanged =
 				currentNextPart &&
 				this.props.playlist.nextPartInstanceId &&
 				(prevProps.playlist.nextPartInstanceId !== this.props.playlist.nextPartInstanceId ||
 					this.nextPartOffset !== partOffset)
 			const isBecomingNextSegment = this.state.isNextSegment === false && isNextSegment
-			// Setting the correct scroll position on parts when setting as next
+			// the segment isn't live, will be next, and either the nextPartId has changed or it is just becoming next
 			if (
 				!isLiveSegment &&
 				isNextSegment &&

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -517,7 +517,6 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 				this.stopLive()
 			}
 
-			// Setting the correct scroll position on parts when setting is next
 			const nextPartDisplayStartsAt =
 				currentNextPart &&
 				this.context.durations?.partDisplayStartsAt &&
@@ -530,7 +529,8 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 				this.props.playlist.nextPartInstanceId &&
 				(prevProps.playlist.nextPartInstanceId !== this.props.playlist.nextPartInstanceId ||
 					this.nextPartOffset !== partOffset)
-			const isBecomingNextSegment = this.state.isNextSegment === false
+			const isBecomingNextSegment = this.state.isNextSegment === false && isNextSegment
+			// Setting the correct scroll position on parts when setting as next
 			if (
 				!isLiveSegment &&
 				isNextSegment &&

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -741,8 +741,8 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 
 				return {
 					scrollLeft,
-					timeScale: newScale ?? this.state.timeScale,
-					showingAllSegment: newScale !== undefined ? false : this.state.showingAllSegment,
+					timeScale: newScale ?? state.timeScale,
+					showingAllSegment: newScale !== undefined ? false : state.showingAllSegment,
 				}
 			})
 		}

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -336,7 +336,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 		timelineDiv: HTMLDivElement
 		intersectionObserver: IntersectionObserver | undefined
 		mountedTime: number
-		nextPartDisplayStartsAt: number
+		nextPartOffset: number
 
 		private pastInfinitesComp: Tracker.Computation | undefined
 
@@ -518,21 +518,25 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			}
 
 			// Setting the correct scroll position on parts when setting is next
-			const nextPartIdHasChanged =
+			const nextPartDisplayStartsAt =
+				currentNextPart &&
+				this.context.durations?.partDisplayStartsAt &&
+				this.context.durations.partDisplayStartsAt[unprotectString(currentNextPart.partId)]
+			const partOffset =
+				nextPartDisplayStartsAt -
+					this.context.durations.partDisplayStartsAt[unprotectString(this.props.parts[0].instance.part._id)] || 0
+			const nextPartIdOrOffsetHasChanged =
 				currentNextPart &&
 				this.props.playlist.nextPartInstanceId &&
 				(prevProps.playlist.nextPartInstanceId !== this.props.playlist.nextPartInstanceId ||
-					this.nextPartDisplayStartsAt !==
-						(this.context.durations?.partDisplayStartsAt &&
-							this.context.durations.partDisplayStartsAt[unprotectString(currentNextPart.partId)]))
+					this.nextPartOffset !== partOffset)
 			const isBecomingNextSegment = this.state.isNextSegment === false
-			if (!isLiveSegment && isNextSegment && currentNextPart && (nextPartIdHasChanged || isBecomingNextSegment)) {
-				const nextPartDisplayStartsAt =
-					this.context.durations?.partDisplayStartsAt &&
-					this.context.durations.partDisplayStartsAt[unprotectString(currentNextPart.partId)]
-				const partOffset =
-					nextPartDisplayStartsAt -
-						this.context.durations.partDisplayStartsAt[unprotectString(this.props.parts[0].instance.part._id)] || 0
+			if (
+				!isLiveSegment &&
+				isNextSegment &&
+				currentNextPart &&
+				(nextPartIdOrOffsetHasChanged || isBecomingNextSegment)
+			) {
 				const timelineWidth = getElementWidth(this.timelineDiv)
 				// If part is not within viewport scroll to its start
 				if (
@@ -543,7 +547,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 						scrollLeft: partOffset,
 					})
 				}
-				this.nextPartDisplayStartsAt = nextPartDisplayStartsAt
+				this.nextPartOffset = partOffset
 			}
 
 			// rewind all scrollLeft's to 0 on rundown activate


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

1. Sometimes segments doesn't rewind, with autoRewindLeavingSegment enabled.
2. When setting a part as next, it is not scrolled into the viewport, when it should be.

* **What is the new behavior (if this is a feature change)?**
1. Segments rewind with autoRewindLeavingSegment enabled.
The bug was caused from a condition dependent on a state attribute that was set asynchronous with setState. Thus the condition sometimes received the old and sometimes the new state.

2. When setting a part as next, if the segment is not live and the part is outside of the SegmentTimelineContainer viewport, the part is scrolled to the start of the SegmentTimelineContainer viewport.
The reason was that the condition triggering scrollLeft change, did not cover all use cases and some conditions were incorrect; onGoToPartInner wrote an old value of scrollLeft into state.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
