### PR TITLE
chore: fix vscode debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "chrome",
+            "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch Chrome",
             "url": "http://localhost:3000/",
             "sourceMaps": true,
             "webRoot": "${workspaceFolder}/meteor",
             "sourceMapPathOverrides": {
-                "meteor://💻app/*": "${webRoot}/"
+                "meteor://💻app/*": "${webRoot}/*"
             }
         },
         {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
VSCode configuration fix


* **What is the current behavior?** (You can also link to an open issue here)
Can't debug the frontend with VSCode because breakpoints are unbound


* **What is the new behavior (if this is a feature change)?**
Debugging the frontend with VSCode is possible.
Changed type to pwa-chrome to use the built-in tools instead of the deprecated extension.
Fixed the source map path override to make breakpoints bind correctly.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
