### PR TITLE
Fix/touch scrolling in ta panel

### DIFF
--- a/meteor/client/lib/lib.tsx
+++ b/meteor/client/lib/lib.tsx
@@ -23,7 +23,7 @@ export function isTouchDevice(): boolean {
 	if (touchDeviceCache !== undefined) return touchDeviceCache
 
 	touchDeviceCache = false
-	if (window.matchMedia('(pointer: coarse)').matches) {
+	if (window.matchMedia('(any-pointer: coarse)').matches) {
 		touchDeviceCache = true
 	}
 	return touchDeviceCache

--- a/meteor/client/styles/main.scss
+++ b/meteor/client/styles/main.scss
@@ -12,6 +12,15 @@ input {
 @import '_header';
 @import '_colorScheme';
 
+body {
+	overscroll-behavior: none;
+	touch-action: pan-x pan-y;
+}
+
+.scroll-sink {
+	overscroll-behavior: none;
+}
+
 /* Don't show visited status, since people will browse around the app a lot */
 a:visited {
 	color: $ui-button-primary;

--- a/meteor/client/styles/shelf/shelf.scss
+++ b/meteor/client/styles/shelf/shelf.scss
@@ -21,6 +21,7 @@
 		right: 0;
 		bottom: 0;
 		box-shadow: none;
+		touch-action: none;
 	}
 
 	.rundown-view__shelf__handle {

--- a/meteor/client/ui/Shelf/DashboardPieceButton.tsx
+++ b/meteor/client/ui/Shelf/DashboardPieceButton.tsx
@@ -73,7 +73,7 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 		height: number
 	} | null = null
 	private _labelEl: HTMLTextAreaElement
-	private activeTouch: React.Touch | null = null
+	private pointerId: number | null = null
 
 	constructor(props: IDashboardButtonProps) {
 		super(props)
@@ -241,12 +241,6 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 
 	private setRef = (el: HTMLDivElement | null) => {
 		this.element = el
-
-		if (this.element) {
-			this.element.addEventListener('touchstart', this.handleTouchStart)
-			this.element.addEventListener('touchend', this.handleTouchEnd)
-			this.element.addEventListener('touchcancel', this.handleTouchCancel)
-		}
 	}
 
 	private handleOnMouseEnter = (_e: React.MouseEvent<HTMLDivElement>) => {
@@ -362,45 +356,22 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 		}
 	}
 
-	private handleTouchStart = (e: TouchEvent) => {
-		this.activeTouch = e.changedTouches.item(0) || null
-		e.preventDefault()
-		e.stopPropagation()
-		e.stopImmediatePropagation()
-		if (this.activeTouch) {
-			this.setState({
-				active: true,
-			})
+	private handleOnPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+		if (e.pointerType !== 'mouse') {
+			this.pointerId = e.pointerId
 		}
 	}
 
-	private handleTouchCancel = (e: TouchEvent) => {
-		const targetTouch = Array.from(e.changedTouches).find((touch) => touch.identifier === this.activeTouch?.identifier)
-		if (targetTouch) {
-			this.activeTouch = null
-
-			this.setState({
-				active: false,
-			})
+	private handleOnPointerOut = (e: React.PointerEvent<HTMLDivElement>) => {
+		if (e.pointerId === this.pointerId) {
+			this.pointerId = null
 		}
 	}
 
-	private handleTouchEnd = (e: TouchEvent) => {
-		const targetTouch = Array.from(e.changedTouches).find((touch) => touch.identifier === this.activeTouch?.identifier)
-		if (
-			targetTouch &&
-			targetTouch.screenX === this.activeTouch?.screenX &&
-			targetTouch.screenY === this.activeTouch?.screenY
-		) {
+	private handleOnPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+		if (e.pointerId === this.pointerId) {
 			this.props.onToggleAdLib(this.props.piece, e.shiftKey || !!this.props.queueAllAdlibs, e)
 			e.preventDefault()
-			e.stopPropagation()
-			e.stopImmediatePropagation()
-			this.activeTouch = null
-
-			this.setState({
-				active: false,
-			})
 		}
 	}
 
@@ -448,6 +419,9 @@ export class DashboardPieceButtonBase<T = {}> extends MeteorReactComponent<
 				onMouseEnter={this.handleOnMouseEnter}
 				onMouseLeave={this.handleOnMouseLeave}
 				onMouseMove={this.handleOnMouseMove}
+				onPointerDown={this.handleOnPointerDown}
+				onPointerOut={this.handleOnPointerOut}
+				onPointerUp={this.handleOnPointerUp}
 				data-obj-id={this.props.piece._id}
 			>
 				{!this.props.layer

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -130,17 +130,11 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 			this.blurActiveElement()
 			this.props.onChangeExpanded(e.state === 'toggle' ? !this.props.isExpanded : e.state)
 		})
-
-		document.body.addEventListener('wheel', this.preventWheelPropagation, {
-			passive: false,
-		})
 	}
 
 	componentWillUnmount() {
 		RundownViewEventBus.off(RundownViewEvents.SWITCH_SHELF_TAB, this.onSwitchShelfTab)
 		RundownViewEventBus.off(RundownViewEvents.SELECT_PIECE, this.onSelectPiece)
-
-		document.body.removeEventListener('wheel', this.preventWheelPropagation)
 	}
 
 	componentDidUpdate(prevProps: IShelfProps, prevState: IState) {
@@ -364,26 +358,6 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 		this.setState({
 			shouldQueue,
 		})
-	}
-
-	private preventWheelPropagation = (e: WheelEvent) => {
-		const composedPath = e.composedPath()
-
-		if (this.element && composedPath.includes(this.element)) {
-			const scrollSink = composedPath.find(
-				(element) => element instanceof HTMLElement && element.classList.contains('scroll-sink')
-			)
-			if (scrollSink instanceof HTMLElement) {
-				if (e.deltaY < 0 && scrollSink.scrollTop <= 0) {
-					e.preventDefault()
-				} else if (
-					e.deltaY > 0 &&
-					Math.round(scrollSink.scrollTop) >= scrollSink.scrollHeight - scrollSink.clientHeight
-				) {
-					e.preventDefault()
-				}
-			}
-		}
 	}
 
 	render() {

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -1940,9 +1940,9 @@
 			}
 		},
 		"@jstarpl/react-contextmenu": {
-			"version": "2.14.3",
-			"resolved": "https://registry.npmjs.org/@jstarpl/react-contextmenu/-/react-contextmenu-2.14.3.tgz",
-			"integrity": "sha512-e3QrRAetaETVr5XdPaj54iq8DlsonnIwmPF1M1gsC9z97rgQFf1j+St34xSToHES8P+Jw96gI5kXL9UC4GD82A==",
+			"version": "2.14.4",
+			"resolved": "https://registry.npmjs.org/@jstarpl/react-contextmenu/-/react-contextmenu-2.14.4.tgz",
+			"integrity": "sha512-3W8Fv623nsZPvKQJsAs7bHfDijjpx4jMuB8oW8Uv0XT51cfOsv3bJF5lsUQk3AuCCDaNMDxIXpDbN/1iYtR2bw==",
 			"requires": {
 				"classnames": "^2.2.5",
 				"object-assign": "^4.1.0"
@@ -4577,7 +4577,7 @@
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
 				"ansi-styles": "^2.2.1",

--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -4577,7 +4577,7 @@
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
 				"ansi-styles": "^2.2.1",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -49,7 +49,7 @@
 		"@fortawesome/fontawesome-svg-core": "^1.2.36",
 		"@fortawesome/free-solid-svg-icons": "^5.15.4",
 		"@fortawesome/react-fontawesome": "^0.1.15",
-		"@jstarpl/react-contextmenu": "^2.14.3",
+		"@jstarpl/react-contextmenu": "^2.14.4",
 		"@nrk/core-icons": "^9.2.2",
 		"@popperjs/core": "^2.10.1",
 		"@slack/webhook": "^6.0.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is a bug fix that prevents a context menu opening when scrolling dashboard panels on a touch device


**What is the current behavior?** (You can also link to an open issue here)
Currently, scrolling a dashboard panel using touch gestures will eventually open an adlib context menu if the starting touch point was over an adlib element.


**What is the new behavior (if this is a feature change)?**
The context menu will no longer trigger when the user scrolls the dashboard.


**Status**
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
