### PR TITLE
feat: cache local storage UI flags

### DIFF
--- a/meteor/client/lib/localStorage.ts
+++ b/meteor/client/lib/localStorage.ts
@@ -24,14 +24,14 @@ function localStorageGetCachedItem(key: LocalStorageProperty): string | null {
 		return cacheHit
 	}
 
-	const uncachedVal = localStorageGetCachedItem(key)
+	const uncachedVal = localStorage.getItem(key)
 	GUI_FLAGS[key] = uncachedVal
 	return uncachedVal
 }
 
 function localStorageSetCachedItem(key: LocalStorageProperty, value: string): void {
 	GUI_FLAGS[key] = value
-	localStorageSetCachedItem(key, value)
+	localStorage.setItem(key, value)
 }
 
 export function setAllowStudio(studioMode: boolean) {

--- a/meteor/client/lib/localStorage.ts
+++ b/meteor/client/lib/localStorage.ts
@@ -10,90 +10,112 @@ enum LocalStorageProperty {
 	SERVICE = 'serviceMode',
 	SHOW_HIDDEN_SOURCE_LAYERS = 'showHiddenSourceLayers',
 	IGNORE_PIECE_CONTENT_STATUS = 'ignorePieceContentStatus',
+	UI_ZOOM_LEVEL = 'uiZoomLevel',
+	HELP_MODE = 'helpMode',
+}
+
+const GUI_FLAGS: {
+	[key in LocalStorageProperty]?: string | null
+} = {}
+
+function localStorageGetCachedItem(key: LocalStorageProperty): string | null {
+	const cacheHit = GUI_FLAGS[key]
+	if (cacheHit !== undefined) {
+		return cacheHit
+	}
+
+	const uncachedVal = localStorageGetCachedItem(key)
+	GUI_FLAGS[key] = uncachedVal
+	return uncachedVal
+}
+
+function localStorageSetCachedItem(key: LocalStorageProperty, value: string): void {
+	GUI_FLAGS[key] = value
+	localStorageSetCachedItem(key, value)
 }
 
 export function setAllowStudio(studioMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.STUDIO, studioMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.STUDIO, studioMode ? '1' : '0')
 }
 export function getAllowStudio(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().studio
 	}
-	return localStorage.getItem(LocalStorageProperty.STUDIO) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.STUDIO) === '1'
 }
 
 export function setAllowConfigure(configureMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.CONFIGURE, configureMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.CONFIGURE, configureMode ? '1' : '0')
 }
 export function getAllowConfigure(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().configurator
 	}
-	return localStorage.getItem(LocalStorageProperty.CONFIGURE) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.CONFIGURE) === '1'
 }
 
 export function setAllowService(serviceMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.SERVICE, serviceMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.SERVICE, serviceMode ? '1' : '0')
 }
 export function getAllowService(): boolean {
-	return localStorage.getItem(LocalStorageProperty.SERVICE) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.SERVICE) === '1'
 }
 
 export function setAllowDeveloper(developerMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.DEVELOPER, developerMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.DEVELOPER, developerMode ? '1' : '0')
 }
 export function getAllowDeveloper(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().developer
 	}
-	return localStorage.getItem(LocalStorageProperty.DEVELOPER) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.DEVELOPER) === '1'
 }
 
 export function setAllowTesting(testingMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.TESTING, testingMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.TESTING, testingMode ? '1' : '0')
 }
 export function getAllowTesting(): boolean {
 	if (Settings.enableUserAccounts) {
 		return !!getUserRoles().developer
 	}
-	return localStorage.getItem(LocalStorageProperty.TESTING) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.TESTING) === '1'
 }
 
 // GUI features: ----------------------------------
 
 export function setAllowSpeaking(speakingMode: boolean) {
-	localStorage.setItem(LocalStorageProperty.SPEAKING, speakingMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.SPEAKING, speakingMode ? '1' : '0')
 }
 export function getAllowSpeaking(): boolean {
-	return localStorage.getItem(LocalStorageProperty.SPEAKING) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.SPEAKING) === '1'
 }
 
 export function setHelpMode(helpMode: boolean) {
-	localStorage.setItem('helpMode', helpMode ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.HELP_MODE, helpMode ? '1' : '0')
 }
 
 export function getHelpMode(): boolean {
-	return localStorage.getItem('helpMode') === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.HELP_MODE) === '1'
 }
 
 export function setUIZoom(uiZoomLevel: number) {
-	localStorage.setItem('uiZoomLevel', uiZoomLevel + '')
+	localStorageSetCachedItem(LocalStorageProperty.UI_ZOOM_LEVEL, uiZoomLevel + '')
 }
 
 export function getUIZoom(): number {
-	return parseFloat(localStorage.getItem('uiZoomLevel') || '1') || 1
+	return parseFloat(localStorageGetCachedItem(LocalStorageProperty.UI_ZOOM_LEVEL) || '1') || 1
 }
 
 export function setShowHiddenSourceLayers(show: boolean) {
-	localStorage.setItem(LocalStorageProperty.SHOW_HIDDEN_SOURCE_LAYERS, show ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.SHOW_HIDDEN_SOURCE_LAYERS, show ? '1' : '0')
 }
 export function getShowHiddenSourceLayers(): boolean {
-	return localStorage.getItem(LocalStorageProperty.SHOW_HIDDEN_SOURCE_LAYERS) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.SHOW_HIDDEN_SOURCE_LAYERS) === '1'
 }
 
 export function setIgnorePieceContentStatus(show: boolean) {
-	localStorage.setItem(LocalStorageProperty.IGNORE_PIECE_CONTENT_STATUS, show ? '1' : '0')
+	localStorageSetCachedItem(LocalStorageProperty.IGNORE_PIECE_CONTENT_STATUS, show ? '1' : '0')
 }
 export function getIgnorePieceContentStatus(): boolean {
-	return localStorage.getItem(LocalStorageProperty.IGNORE_PIECE_CONTENT_STATUS) === '1'
+	return localStorageGetCachedItem(LocalStorageProperty.IGNORE_PIECE_CONTENT_STATUS) === '1'
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature improvement

* **What is the current behavior?** (You can also link to an open issue here)

All queries for one of the GUI flags go directly to localStorage. While it's fast, it's still at least 100x slower than normal variable lookup ([1](https://stackoverflow.com/questions/8074218/speed-cost-of-localstorage))

* **What is the new behavior (if this is a feature change)?**

Puts an in-memory cache in front of the localStorage get/set.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
