### PR TITLE
Fix/device logging

### DIFF
--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -59,7 +59,7 @@
 		"@sofie-automation/blueprints-integration": "1.37.0-in-testing.0",
 		"@sofie-automation/server-core-integration": "1.37.0-in-testing.0",
 		"fast-clone": "^1.5.13",
-		"timeline-state-resolver": "6.2.0-release37.3",
+		"timeline-state-resolver": "6.2.0-release37.4",
 		"tslib": "^2.3.1",
 		"underscore": "^1.12.1",
 		"winston": "^2.4.2"

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -23,6 +23,11 @@ import {
 
 const PLAYOUT_SUBDEVICE_COMMON: SubDeviceConfigManifestEntry[] = [
 	{
+		id: 'debug',
+		name: 'Activate debug logging for device',
+		type: ConfigManifestEntryType.BOOLEAN,
+	},
+	{
 		id: 'disable',
 		name: 'Disable',
 		type: ConfigManifestEntryType.BOOLEAN,
@@ -640,7 +645,7 @@ export const PLAYOUT_DEVICE_CONFIG: DeviceConfigManifest = {
 	deviceConfig: [
 		{
 			id: 'debugLogging',
-			name: 'Activate Debug Logging',
+			name: 'Activate Debug Logging (of everything)',
 			type: ConfigManifestEntryType.BOOLEAN,
 		},
 		{

--- a/packages/playout-gateway/src/configManifest.ts
+++ b/packages/playout-gateway/src/configManifest.ts
@@ -645,7 +645,7 @@ export const PLAYOUT_DEVICE_CONFIG: DeviceConfigManifest = {
 	deviceConfig: [
 		{
 			id: 'debugLogging',
-			name: 'Activate Debug Logging (of everything)',
+			name: 'Activate Debug Logging',
 			type: ConfigManifestEntryType.BOOLEAN,
 		},
 		{

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -203,7 +203,6 @@ export class TSRHandler {
 		})
 
 		this.tsr.on('setTimelineTriggerTime', (r: TimelineTriggerTimeResult) => {
-			this.logger.debug('setTimelineTriggerTime')
 			this._coreHandler.core.callMethod(P.methods.timelineTriggerTime, [r]).catch((e) => {
 				this.logger.error('Error in setTimelineTriggerTime', e)
 			})
@@ -308,7 +307,6 @@ export class TSRHandler {
 			this._triggerupdateExpectedPlayoutItems()
 		}
 		this._observers.push(expectedPlayoutItemsObserver)
-		this.logger.debug('VIZDEBUG: Observer to expectedPlayoutItems set up')
 	}
 	private resendStatuses(): void {
 		_.each(this._coreTsrHandlers, (tsrHandler) => {
@@ -798,9 +796,7 @@ export class TSRHandler {
 		delete this._coreTsrHandlers[deviceId]
 	}
 	private _triggerupdateExpectedPlayoutItems() {
-		this.logger.debug('VIZDEBUG: Trigger update expected playout items called')
 		if (!this._initialized) return
-		this.logger.debug("VIZDEBUG: And we're initialized")
 		if (this._triggerupdateExpectedPlayoutItemsTimeout) {
 			clearTimeout(this._triggerupdateExpectedPlayoutItemsTimeout)
 		}
@@ -811,12 +807,8 @@ export class TSRHandler {
 		}, 200)
 	}
 	private async _updateExpectedPlayoutItems() {
-		this.logger.debug('VIZDEBUG: Update expected playout items called')
-
 		const expectedPlayoutItems = this._coreHandler.core.getCollection('expectedPlayoutItems')
 		const peripheralDevice = this._getPeripheralDevice()
-
-		this.logger.debug(`VIZDEBUG: Items before filter ${JSON.stringify(expectedPlayoutItems)}`)
 
 		const expectedItems = expectedPlayoutItems.find({
 			studioId: peripheralDevice.studioId,
@@ -828,13 +820,9 @@ export class TSRHandler {
 			'_id'
 		)
 
-		this.logger.debug(`VIZDEBUG: Items after filter ${JSON.stringify(expectedItems)}`)
-
 		await Promise.all(
 			_.map(this.tsr.getDevices(), async (container) => {
 				if (await container.device.supportsExpectedPlayoutItems) {
-					this.logger.debug(`VIZDEBUG: Supports expected playout items`)
-
 					await container.device.handleExpectedPlayoutItems(
 						_.map(
 							_.filter(expectedItems, (item) => {

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -8505,17 +8505,17 @@ timeline-state-resolver-types@6.2.0-nightly-release37-20210920-094335-6d1ddb522.
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver-types@6.2.0-release37.1:
-  version "6.2.0-release37.1"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-6.2.0-release37.1.tgz#fafe37c2547301c3ec0c528822368c7e88fd8302"
-  integrity sha512-YrSCbfz7ZPs6icpJpT61IjFxx1T3334DK0bWpCjgRAHz7C+eb28POtXTgblh/Umq77qoweowmp529ZX/0eB2AQ==
+timeline-state-resolver-types@6.2.0-release37.4:
+  version "6.2.0-release37.4"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-6.2.0-release37.4.tgz#593f59d4b44c5fb4032207c09c4f411cb3488b50"
+  integrity sha512-jv1i0HOvl0ZeiAmgpC8GmB89XMbJ+kroYxEqLILqEsDtHd1LzaYOHZdgM8j3KkvgcHq8rP0XQL8yMWu0p5WcAg==
   dependencies:
     tslib "^2.3.1"
 
-timeline-state-resolver@6.2.0-release37.3:
-  version "6.2.0-release37.3"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-6.2.0-release37.3.tgz#9309cf484e788616ff41a8fc74c270d2a6d9faac"
-  integrity sha512-x3cs5+I9uTkhDZIZ1l7v+jRUQcApN62Rz/BtygaM1lPNhIDXIlCkeSJwKj4pr7korXkVg+c079SXaRbvQuTHMA==
+timeline-state-resolver@6.2.0-release37.4:
+  version "6.2.0-release37.4"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver/-/timeline-state-resolver-6.2.0-release37.4.tgz#2b2696a3268ff3aac3cbd84af2e5beeb5d824f2a"
+  integrity sha512-9zLolo4A0vIzjuzI6ZWe7E8pWb/yOFqJNbrbIb063Zf9rzDXkskQo3I75XfcN/xh6zYQBaCHM7HJASIE6mAhSw==
   dependencies:
     "@tv2media/v-connection" "^5.1.0"
     atem-connection "^2.3.0"
@@ -8537,7 +8537,7 @@ timeline-state-resolver@6.2.0-release37.3:
     sprintf-js "^1.1.2"
     superfly-timeline "^8.2.1"
     threadedclass "0.8.3"
-    timeline-state-resolver-types "6.2.0-release37.1"
+    timeline-state-resolver-types "6.2.0-release37.4"
     tslib "^2.3.1"
     tv-automation-quantel-gateway-client "^2.0.4"
     underscore "^1.12.0"


### PR DESCRIPTION
This PR adds a "debug" property to the playout devices.
When checked, their debug messages are logged, otherwise they are not sent from the devices.

For backwards compatibility, their messages are logged as usual when the old debug flag on the playout-gateay is set.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
