### PR TITLE
chore: add new index to PartInstance and PieceInstance for populating CacheForPlayout

### DIFF
--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -158,6 +158,11 @@ export const PartInstances = createMongoCollection<PartInstance, DBPartInstance>
 registerCollection('PartInstances', PartInstances)
 registerIndex(PartInstances, {
 	rundownId: 1,
+	playlistActivationId: 1,
+	reset: 1,
+})
+registerIndex(PartInstances, {
+	rundownId: 1,
 	segmentId: 1,
 	takeCount: 1,
 	reset: 1,

--- a/meteor/lib/collections/PieceInstances.ts
+++ b/meteor/lib/collections/PieceInstances.ts
@@ -121,3 +121,10 @@ registerIndex(PieceInstances, {
 	partInstanceId: 1,
 	reset: -1,
 })
+
+registerIndex(PieceInstances, {
+	rundownId: 1,
+	playlistActivationId: 1,
+	partInstanceId: 1,
+	reset: -1,
+})

--- a/meteor/server/api/playout/cache.ts
+++ b/meteor/server/api/playout/cache.ts
@@ -220,8 +220,8 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 			DbCacheReadCollection.createFromDatabase(Segments, { rundownId: { $in: loadRundownIds } }),
 			DbCacheReadCollection.createFromDatabase(Parts, { rundownId: { $in: loadRundownIds } }),
 			DbCacheWriteCollection.createFromDatabase(PartInstances, {
-				playlistActivationId: playlist.activationId,
 				rundownId: { $in: rundownIds },
+				playlistActivationId: playlist.activationId,
 				$or: [
 					{
 						reset: { $ne: true },
@@ -232,8 +232,8 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 				],
 			}),
 			DbCacheWriteCollection.createFromDatabase(PieceInstances, {
-				playlistActivationId: playlist.activationId,
 				rundownId: { $in: rundownIds },
+				playlistActivationId: playlist.activationId,
 				partInstanceId: { $in: selectedPartInstanceIds },
 			}),
 			// Future: This could be defered until we get to updateTimeline. It could be a small performance boost


### PR DESCRIPTION

Thinking about the slowness with old rundowns, I discovered that CacheForPlayout was using queries that did not have an appropriate index.
Hopefully these are close enough to help it, but I am not sure if the PartInstance one is good enough

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
