### PR TITLE
Feat: rundown metadata update

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -110,6 +110,11 @@ export interface NewPeripheralDeviceAPI {
 	dataRundownDelete(deviceId: PeripheralDeviceId, deviceToken: string, rundownExternalId: string): Promise<void>
 	dataRundownCreate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown): Promise<void>
 	dataRundownUpdate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown): Promise<void>
+	dataRundownMetaDataUpdate(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		ingestRundown: Omit<IngestRundown, 'segments'>
+	): Promise<void>
 	dataSegmentGet(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,
@@ -405,6 +410,7 @@ export enum PeripheralDeviceAPIMethods {
 	'dataRundownDelete' = 'peripheralDevice.rundown.rundownDelete',
 	'dataRundownCreate' = 'peripheralDevice.rundown.rundownCreate',
 	'dataRundownUpdate' = 'peripheralDevice.rundown.rundownUpdate',
+	'dataRundownMetaDataUpdate' = 'peripheralDevice.rundown.rundownMetaDataUpdate',
 	'dataSegmentGet' = 'peripheralDevice.rundown.segmentGet',
 	'dataSegmentDelete' = 'peripheralDevice.rundown.segmentDelete',
 	'dataSegmentCreate' = 'peripheralDevice.rundown.segmentCreate',

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -25,7 +25,6 @@ import {
 	IBlueprintSegmentDB,
 	IBlueprintPartInstance,
 	IBlueprintPieceInstance,
-	IBlueprintRundownDB,
 	IBlueprintExternalMessageQueueObj,
 	IShowStyleContext,
 	IRundownContext,
@@ -38,6 +37,7 @@ import {
 	PackageInfo,
 	IStudioBaselineContext,
 	IShowStyleUserContext,
+	IBlueprintSegmentRundown,
 	NoteSeverity,
 } from '@sofie-automation/blueprints-integration'
 import { Studio, StudioId } from '../../../../lib/collections/Studios'
@@ -306,7 +306,7 @@ export class ShowStyleUserContext extends ShowStyleContext implements IShowStyle
 
 export class RundownContext extends ShowStyleContext implements IRundownContext {
 	readonly rundownId: string
-	readonly rundown: Readonly<IBlueprintRundownDB>
+	readonly rundown: Readonly<IBlueprintSegmentRundown>
 	readonly _rundown: ReadonlyDeep<Rundown>
 	readonly playlistId: RundownPlaylistId
 
@@ -319,7 +319,7 @@ export class RundownContext extends ShowStyleContext implements IRundownContext 
 		super(contextInfo, studio, showStyleCompound)
 
 		this.rundownId = unprotectString(rundown._id)
-		this.rundown = unprotectObject(rundown)
+		this.rundown = rundownToSegmentRundown(rundown)
 		this._rundown = rundown
 		this.playlistId = rundown.playlistId
 	}
@@ -757,5 +757,12 @@ export class RundownTimingEventContext extends RundownDataChangedEventContext im
 				rundownId: this._rundown._id,
 			})
 		)
+	}
+}
+
+function rundownToSegmentRundown(rundown: ReadonlyDeep<Rundown>): IBlueprintSegmentRundown {
+	return {
+		externalId: rundown.externalId,
+		metaData: rundown.metaData,
 	}
 }

--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -464,6 +464,40 @@ describe('Test ingest actions for rundowns and segments', () => {
 		expect(parts1).toHaveLength(1)
 	})
 
+	testInFiber('dataRundownMetaDataUpdate change name, does not remove segments', () => {
+		expect(Rundowns.findOne()).toBeTruthy()
+		const rundownData: Omit<IngestRundown, 'segments'> = {
+			externalId: externalId,
+			name: 'MyMockRundownRenamed',
+			type: 'mock',
+		}
+		Meteor.call(PeripheralDeviceAPIMethods.dataRundownMetaDataUpdate, device._id, device.token, rundownData)
+
+		const rundownPlaylist = RundownPlaylists.findOne() as RundownPlaylist
+		const rundown = Rundowns.findOne() as Rundown
+		expect(rundownPlaylist).toMatchObject({
+			externalId: rundown._id,
+			name: rundownData.name,
+		})
+		expect(RundownPlaylists.find().count()).toBe(1)
+
+		expect(rundown).toMatchObject({
+			externalId: rundownData.externalId,
+			name: rundownData.name,
+			playlistId: rundownPlaylist._id,
+		})
+		expect(Rundowns.find().count()).toBe(1)
+
+		const segments = Segments.find({ rundownId: rundown._id }).fetch()
+		expect(segments).toHaveLength(2)
+
+		const parts0 = Parts.find({ rundownId: rundown._id, segmentId: segments[0]._id }).fetch()
+		expect(parts0).toHaveLength(1)
+
+		const parts1 = Parts.find({ rundownId: rundown._id, segmentId: segments[1]._id }).fetch()
+		expect(parts1).toHaveLength(1)
+	})
+
 	testInFiber('dataRundownDelete', () => {
 		expect(Rundowns.findOne()).toBeTruthy()
 		Meteor.call(PeripheralDeviceAPIMethods.dataRundownDelete, device._id, device.token, externalId)

--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -50,6 +50,35 @@ export function makeNewIngestSegment(ingestSegment: IngestSegment): LocalIngestS
 export function makeNewIngestPart(ingestPart: IngestPart): LocalIngestPart {
 	return { ...ingestPart, modified: getCurrentTime() }
 }
+export function getIngestDataForRundown(rundownId: RundownId): IngestRundown | undefined {
+	const cachedData = IngestDataCache.find({ rundownId }).fetch()
+	const ingestRundown = cachedData.find((d) => d.type === IngestCacheType.RUNDOWN) as
+		| IngestDataCacheObjRundown
+		| undefined
+	if (!ingestRundown) return
+
+	const ingestSegments: Array<IngestDataCacheObjSegment> = cachedData.filter(
+		(d) => d.type === IngestCacheType.SEGMENT
+	) as Array<IngestDataCacheObjSegment>
+	const ingestParts: { [segmentId: string]: Array<IngestDataCacheObjPart> } = _.groupBy(
+		cachedData.filter((d) => d.type === IngestCacheType.PART),
+		(p) => p.segmentId
+	) as { [segmentId: string]: Array<IngestDataCacheObjPart> }
+
+	const segments: Array<IngestSegment> = []
+	for (const ingestSegment of ingestSegments) {
+		const parts = ingestParts[unprotectString(ingestSegment._id)] ?? []
+		segments.push({
+			...ingestSegment.data,
+			parts: parts.map((p) => p.data),
+		})
+	}
+
+	return {
+		...ingestRundown.data,
+		segments,
+	}
+}
 
 export class RundownIngestDataCache {
 	private constructor(

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -5,14 +5,15 @@ import { DBRundown, Rundowns } from '../../../lib/collections/Rundowns'
 import { getCurrentTime, literal } from '../../../lib/lib'
 import { IngestRundown, IngestSegment, IngestPart, IngestPlaylist } from '@sofie-automation/blueprints-integration'
 import { logger } from '../../../lib/logging'
-import { Studio, StudioId } from '../../../lib/collections/Studios'
-import { SegmentId, Segments } from '../../../lib/collections/Segments'
+import { Studio, StudioId, Studios } from '../../../lib/collections/Studios'
+import { DBSegment, SegmentId, Segments } from '../../../lib/collections/Segments'
 import {
 	RundownIngestDataCache,
 	LocalIngestRundown,
 	makeNewIngestSegment,
 	makeNewIngestPart,
 	makeNewIngestRundown,
+	getIngestDataForRundown,
 } from './ingestCache'
 import {
 	getSegmentId,
@@ -21,13 +22,30 @@ import {
 	canSegmentBeUpdated,
 	checkAccessAndGetPeripheralDevice,
 	getRundown,
+	extendIngestRundownCore,
+	getRundownId,
 } from './lib'
 import { MethodContext } from '../../../lib/api/methods'
 import { CommitIngestData, runIngestOperationWithCache, UpdateIngestRundownAction } from './lockFunction'
 import { CacheForIngest } from './cache'
-import { updateRundownFromIngestData, updateSegmentFromIngestData } from './generation'
+import {
+	getRundownFromIngestData,
+	resolveSegmentChangesForUpdatedRundown,
+	saveChangesForRundown,
+	saveSegmentChangesToCache,
+	updateRundownFromIngestData,
+	updateSegmentFromIngestData,
+	UpdateSegmentsResult,
+} from './generation'
 import { removeRundownsFromDb } from '../rundownPlaylist'
 import { RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
+import { StudioUserContext } from '../blueprints/context'
+import { selectShowStyleVariant } from '../rundown'
+import { WatchedPackagesHelper } from '../blueprints/context/watchedPackages'
+import { loadShowStyleBlueprint } from '../blueprints/cache'
+import _ from 'underscore'
+import { profiler } from '../profiler'
+import { updateBaselineExpectedPackagesOnRundown } from './expectedPackages'
 
 export namespace RundownInput {
 	export async function dataPlaylistGet(
@@ -95,6 +113,17 @@ export namespace RundownInput {
 		logger.info('dataRundownUpdate', ingestRundown)
 		check(ingestRundown, Object)
 		await handleUpdatedRundown(undefined, peripheralDevice, ingestRundown, false)
+	}
+	export async function dataRundownMetaDataUpdate(
+		context: MethodContext,
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		ingestRundown: Omit<IngestRundown, 'segments'>
+	): Promise<void> {
+		const peripheralDevice = checkAccessAndGetPeripheralDevice(deviceId, deviceToken, context)
+		logger.info('dataRundownMetaDataUpdate', ingestRundown)
+		check(ingestRundown, Object)
+		await handleUpdatedRundownMetaData(undefined, peripheralDevice, ingestRundown)
 	}
 	export async function dataSegmentGet(
 		context: MethodContext,
@@ -378,6 +407,55 @@ export async function handleUpdatedRundown(
 		}
 	)
 }
+/** Handle updates to existing rundown properties */
+export async function handleUpdatedRundownMetaData(
+	studio0: Studio | undefined,
+	peripheralDevice: PeripheralDevice | undefined,
+	newIngestRundown: Omit<IngestRundown, 'segments'>
+): Promise<void> {
+	const studioId = peripheralDevice?.studioId ?? studio0?._id
+	if ((!peripheralDevice && !studio0) || !studioId) {
+		throw new Meteor.Error(500, `A PeripheralDevice or Studio is required to update a rundown`)
+	}
+
+	if (peripheralDevice && studio0 && peripheralDevice.studioId !== studio0._id) {
+		throw new Meteor.Error(
+			500,
+			`PeripheralDevice "${peripheralDevice._id}" does not belong to studio "${studio0._id}"`
+		)
+	}
+
+	const studio = Studios.findOne(studioId)
+	if (!studio) {
+		throw new Meteor.Error(
+			500,
+			`Cannot find studio "${studioId}" requested by peripheral device "${peripheralDevice!._id}"`
+		)
+	}
+
+	const rundownExternalId = newIngestRundown.externalId
+	return runIngestOperationWithCache(
+		'handleUpdatedRundownMetaData',
+		studioId,
+		rundownExternalId,
+		(ingestRundown) => {
+			if (ingestRundown) {
+				const segments = getIngestDataForRundown(getRundownId(studio, rundownExternalId))?.segments ?? []
+				return makeNewIngestRundown({
+					...newIngestRundown,
+					segments: segments.map((segment) => makeNewIngestSegment(segment)),
+				})
+			} else {
+				throw new Meteor.Error(404, `Rundown "${rundownExternalId}" not found`)
+			}
+		},
+		async (cache, ingestRundown) => {
+			if (!ingestRundown) throw new Meteor.Error(`Rundown "${rundownExternalId}" not found`)
+
+			return handleUpdatedRundownMetaDataInner(cache, ingestRundown, peripheralDevice)
+		}
+	)
+}
 export async function handleUpdatedRundownInner(
 	cache: CacheForIngest,
 	ingestRundown: LocalIngestRundown,
@@ -424,6 +502,86 @@ export async function regenerateRundown(
 			return updateRundownFromIngestData(cache, ingestRundown, peripheralDevice)
 		}
 	)
+}
+
+export async function handleUpdatedRundownMetaDataInner(
+	cache: CacheForIngest,
+	ingestRundown: LocalIngestRundown,
+	peripheralDevice?: PeripheralDevice // TODO - to cache?
+): Promise<CommitIngestData | null> {
+	if (!canRundownBeUpdated(cache.Rundown.doc, false)) return null
+	const existingRundown = cache.Rundown.doc
+	if (!existingRundown) {
+		throw new Meteor.Error(404, `Rundown "${ingestRundown.externalId}" does not exist`)
+	}
+
+	const span = profiler.startSpan('ingest.rundownInput.handleUpdatedRundownMetaDataInner')
+
+	logger.info(`Updating rundown ${cache.RundownId}`)
+
+	const extendedIngestRundown = extendIngestRundownCore(ingestRundown, cache.Rundown.doc)
+
+	const selectShowStyleContext = new StudioUserContext(
+		{
+			name: 'selectShowStyleVariant',
+			identifier: `studioId=${cache.Studio.doc._id},rundownId=${cache.RundownId},ingestRundownId=${cache.RundownExternalId}`,
+			tempSendUserNotesIntoBlackHole: true,
+		},
+		cache.Studio.doc
+	)
+	// TODO-CONTEXT save any user notes from selectShowStyleContext
+	const showStyle = await selectShowStyleVariant(selectShowStyleContext, extendedIngestRundown)
+	if (!showStyle) {
+		logger.debug('Blueprint rejected the rundown')
+		throw new Meteor.Error(501, 'Blueprint rejected the rundown')
+	}
+
+	const pAllRundownWatchedPackages = WatchedPackagesHelper.createForIngest(cache, undefined)
+
+	const showStyleBlueprint = await loadShowStyleBlueprint(showStyle.base)
+	const allRundownWatchedPackages = await pAllRundownWatchedPackages
+
+	// Call blueprints, get rundown
+	const { dbRundownData, rundownRes } = await getRundownFromIngestData(
+		cache,
+		ingestRundown,
+		peripheralDevice,
+		showStyle,
+		showStyleBlueprint,
+		allRundownWatchedPackages
+	)
+
+	// Save rundown and baseline
+	const dbRundown = await saveChangesForRundown(cache, dbRundownData, rundownRes, showStyle)
+
+	let segmentChanges: UpdateSegmentsResult | undefined
+	let removedSegments: DBSegment[] | undefined
+	if (!_.isEqual(existingRundown.metaData, dbRundown.metaData)) {
+		logger.info(`MetaData of rundown ${dbRundown.externalId} has been modified, regenerating segments`)
+		const changes = await resolveSegmentChangesForUpdatedRundown(cache, ingestRundown, allRundownWatchedPackages)
+		segmentChanges = changes.segmentChanges
+		removedSegments = changes.removedSegments
+	}
+
+	updateBaselineExpectedPackagesOnRundown(cache, rundownRes.baseline)
+
+	if (segmentChanges) {
+		saveSegmentChangesToCache(cache, segmentChanges, true)
+	}
+
+	logger.info(`Rundown ${dbRundown._id} update complete`)
+
+	span?.end()
+	return literal<CommitIngestData>({
+		changedSegmentIds: segmentChanges?.segments.map((s) => s._id) ?? [],
+		removedSegmentIds: removedSegments?.map((s) => s._id) ?? [],
+		renamedSegments: new Map(),
+
+		removeRundown: false,
+
+		showStyle: showStyle.compound,
+		blueprint: showStyleBlueprint,
+	})
 }
 
 export async function handleRemovedSegment(

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -878,6 +878,13 @@ class ServerPeripheralDeviceAPIClass extends MethodContextAPI implements NewPeri
 	async dataRundownUpdate(deviceId: PeripheralDeviceId, deviceToken: string, ingestRundown: IngestRundown) {
 		return RundownInput.dataRundownUpdate(this, deviceId, deviceToken, ingestRundown)
 	}
+	async dataRundownMetaDataUpdate(
+		deviceId: PeripheralDeviceId,
+		deviceToken: string,
+		ingestRundown: Omit<IngestRundown, 'segments'>
+	) {
+		return RundownInput.dataRundownMetaDataUpdate(this, deviceId, deviceToken, ingestRundown)
+	}
 	async dataSegmentGet(
 		deviceId: PeripheralDeviceId,
 		deviceToken: string,

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -51,10 +51,16 @@ import { getRundown } from './ingest/lib'
 import { createShowStyleCompound } from './showStyles'
 import { checkAccessToPlaylist } from './lib'
 
+export interface SelectedShowStyleVariant {
+	variant: ShowStyleVariant
+	base: ShowStyleBase
+	compound: ShowStyleCompound
+}
+
 export async function selectShowStyleVariant(
 	context: StudioUserContext,
 	ingestRundown: ExtendedIngestRundown
-): Promise<{ variant: ShowStyleVariant; base: ShowStyleBase; compound: ShowStyleCompound } | null> {
+): Promise<SelectedShowStyleVariant | null> {
 	const studio = context.studio
 	if (!studio.supportedShowStyleBase.length) {
 		logger.debug(`Studio "${studio._id}" does not have any supportedShowStyleBase`)

--- a/packages/blueprints-integration/src/context.ts
+++ b/packages/blueprints-integration/src/context.ts
@@ -6,10 +6,10 @@ import {
 	IBlueprintPiece,
 	IBlueprintPieceInstance,
 	IBlueprintResolvedPieceInstance,
-	IBlueprintRundownDB,
 	IBlueprintMutatablePart,
 	IBlueprintSegmentDB,
 	IBlueprintPieceDB,
+	IBlueprintSegmentRundown,
 } from './rundown'
 import { BlueprintMappings } from './studio'
 import { OnGenerateTimelineObj } from './timeline'
@@ -120,7 +120,7 @@ export interface IShowStyleUserContext extends IUserNotesContext, IShowStyleCont
 
 export interface IRundownContext extends IShowStyleContext {
 	readonly rundownId: string
-	readonly rundown: Readonly<IBlueprintRundownDB>
+	readonly rundown: Readonly<IBlueprintSegmentRundown>
 }
 
 export interface IRundownUserContext extends IUserNotesContext, IRundownContext {}

--- a/packages/blueprints-integration/src/rundown.ts
+++ b/packages/blueprints-integration/src/rundown.ts
@@ -114,6 +114,13 @@ export interface IBlueprintRundownDBData {
 	airStatus?: string
 }
 
+export interface IBlueprintSegmentRundown<TMetadata = unknown> {
+	externalId: string
+
+	/** Arbitrary data storage for plugins */
+	metaData?: TMetadata
+}
+
 /** The Segment generated from Blueprint */
 export interface IBlueprintSegment<TMetadata = unknown> {
 	/** User-presentable name (Slug) for the Title */

--- a/packages/server-core-integration/src/lib/corePeripherals.ts
+++ b/packages/server-core-integration/src/lib/corePeripherals.ts
@@ -131,6 +131,7 @@ export namespace PeripheralDeviceAPI {
 		'dataRundownDelete' = 'peripheralDevice.rundown.rundownDelete',
 		'dataRundownCreate' = 'peripheralDevice.rundown.rundownCreate',
 		'dataRundownUpdate' = 'peripheralDevice.rundown.rundownUpdate',
+		'dataRundownMetaDataUpdate' = 'peripheralDevice.rundown.rundownMetaDataUpdate',
 		'dataSegmentGet' = 'peripheralDevice.rundown.segmentGet',
 		'dataSegmentDelete' = 'peripheralDevice.rundown.segmentDelete',
 		'dataSegmentCreate' = 'peripheralDevice.rundown.segmentCreate',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Currently, the only way to update the timing of rundown playlists via the `dataRundown*` methods is to use either the `dataRundownUpdate` or `dataRundownCreate` methods. Both of these methods require passing all of the segments in the rundown to core and will re-run `getSegment` for each of these segments. In long rundowns this can have a measurable impact on performance.

* **What is the new behavior (if this is a feature change)?**

This PR adds the method `dataRundownMetaDataUpdate` which allows just the `IngestRundown` without any segments to be passed to core, to be evaluated in the `getRundown` function of blueprints.

When this method is called, the segment data for the rundown is fetched from the ingest data cache so that `getRundown` still has access to all of the segment data.

If the value of the `rundown.metaData` property returned from `getRundown` differs from what is currently the value on the rundown, then the segments are considered to have been invalidated and `getSegment` will be re-run for each segment. However, if the data in `rundown.metaData` is the same as previously seen, the existing segment data is considered to still be valid.

This way, the timing of rundowns along with the name and any other rundown-level properties can be changed without reevaluating all the segments, but we can still ensure that any changes to the rundown that may affect segments will still be picked up.

To this end, `getSegment` no longer has access to the full rundown information, but only to `rundown.metaData` and `rundown.externalId`. The typings of the data passed to `getSegment` have been updated to reflect this.

* **Other information**:

This solution was sketched out with the help of @Julusian 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [X] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
