### PR TITLE
feat: wheel detach follow on air

### DIFF
--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -163,7 +163,7 @@ export const App = translateWithTracker(() => {
 				document.querySelector('.rundown.active') === null
 			) {
 				// forceReload is marked as deprecated, but it's still usable
-				// tslint:disable-next-line
+				// @ts-ignore
 				setTimeout(() => window.location.reload(true))
 			}
 		}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2010,12 +2010,12 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				const liveSegmentComponent = document.querySelector('.segment-timeline.live')
 				if (liveSegmentComponent) {
 					const offsetPosition = liveSegmentComponent.getBoundingClientRect()
-					if (
-						// if it's closer to the top edge than the headerHeight
-						offsetPosition.top < getHeaderHeight() ||
-						// of if it's closer to the bottom edge than very close to the top
+					// if it's closer to the top edge than the headerHeight
+					const segmentComponentTooHigh = offsetPosition.top < getHeaderHeight()
+					// or if it's closer to the bottom edge than very close to the top
+					const segmentComponentTooLow =
 						offsetPosition.bottom < window.innerHeight - getHeaderHeight() - 20 - (offsetPosition.height * 3) / 2
-					) {
+					if (segmentComponentTooHigh || segmentComponentTooLow) {
 						this.setState({
 							followLiveSegments: false,
 						})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The Follow OnAir state is disabled only when the segment leaves the viewport.

* **What is the new behavior (if this is a feature change)?**

This changes the behavior so that the Follow OnAir state is disabled when mouse wheel interactions happen and the segment leaves the top area of the Rundown View.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
