### PR TITLE
feat: show "set segment as next" in Part context as well

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentContextMenu.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentContextMenu.tsx
@@ -36,58 +36,63 @@ export const SegmentContextMenu = withTranslation()(
 			const isCurrentPart =
 				(part && this.props.playlist && part.instance._id === this.props.playlist.currentPartInstanceId) || undefined
 
+			const canSetAsNext = !!this.props.playlist?.activationId
+
 			return this.props.studioMode && this.props.playlist && this.props.playlist.activationId ? (
 				<Escape to="document">
 					<ContextMenu id="segment-timeline-context-menu">
-						{this.props.playlist.activationId && (
+						{part && (
 							<>
-								{part && !part.instance.part.invalid && timecode !== null && (
-									<>
-										{startsAt !== null && (
-											<MenuItem
-												onClick={(e) => this.props.onSetNext(part.instance.part, e)}
-												disabled={isCurrentPart || !!part.instance.orphaned}
-											>
-												<span dangerouslySetInnerHTML={{ __html: t('Set this part as <strong>Next</strong>') }}></span>{' '}
-												({RundownUtils.formatTimeToShortTime(Math.floor(startsAt / 1000) * 1000)})
-											</MenuItem>
-										)}
-										{startsAt !== null && part && this.props.enablePlayFromAnywhere ? (
-											<>
-												<MenuItem
-													onClick={(e) => this.onSetAsNextFromHere(part.instance.part, e)}
-													disabled={isCurrentPart || !!part.instance.orphaned}
-												>
-													<span dangerouslySetInnerHTML={{ __html: t('Set <strong>Next</strong> Here') }}></span> (
-													{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
-												</MenuItem>
-												<MenuItem
-													onClick={(e) => this.onPlayFromHere(part.instance.part, e)}
-													disabled={isCurrentPart || !!part.instance.orphaned}
-												>
-													<span dangerouslySetInnerHTML={{ __html: t('Play from Here') }}></span> (
-													{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
-												</MenuItem>
-											</>
-										) : null}
-									</>
+								<MenuItem
+									onClick={(e) => this.props.onSetNext(part.instance.part, e)}
+									disabled={isCurrentPart || !canSetAsNext}
+								>
+									<span dangerouslySetInnerHTML={{ __html: t('Set segment as <strong>Next</strong>') }}></span>
+								</MenuItem>
+								{part.instance.segmentId !== this.props.playlist.nextSegmentId ? (
+									<MenuItem
+										onClick={(e) => this.props.onSetNextSegment(part.instance.segmentId, e)}
+										disabled={!canSetAsNext}
+									>
+										<span>{t('Queue segment')}</span>
+									</MenuItem>
+								) : (
+									<MenuItem onClick={(e) => this.props.onSetNextSegment(null, e)} disabled={!canSetAsNext}>
+										<span>{t('Clear queued segment')}</span>
+									</MenuItem>
 								)}
-								{part && timecode === null && (
+								<hr />
+							</>
+						)}
+						{part && !part.instance.part.invalid && timecode !== null && (
+							<>
+								{startsAt !== null && (
+									<MenuItem
+										onClick={(e) => this.props.onSetNext(part.instance.part, e)}
+										disabled={isCurrentPart || !!part.instance.orphaned || !canSetAsNext}
+									>
+										<span dangerouslySetInnerHTML={{ __html: t('Set this part as <strong>Next</strong>') }}></span> (
+										{RundownUtils.formatTimeToShortTime(Math.floor(startsAt / 1000) * 1000)})
+									</MenuItem>
+								)}
+								{startsAt !== null && part && this.props.enablePlayFromAnywhere ? (
 									<>
-										<MenuItem onClick={(e) => this.props.onSetNext(part.instance.part, e)} disabled={isCurrentPart}>
-											<span dangerouslySetInnerHTML={{ __html: t('Set segment as <strong>Next</strong>') }}></span>
+										<MenuItem
+											onClick={(e) => this.onSetAsNextFromHere(part.instance.part, e)}
+											disabled={isCurrentPart || !!part.instance.orphaned || !canSetAsNext}
+										>
+											<span dangerouslySetInnerHTML={{ __html: t('Set <strong>Next</strong> Here') }}></span> (
+											{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
 										</MenuItem>
-										{part.instance.segmentId !== this.props.playlist.nextSegmentId ? (
-											<MenuItem onClick={(e) => this.props.onSetNextSegment(part.instance.segmentId, e)}>
-												<span>{t('Queue segment')}</span>
-											</MenuItem>
-										) : (
-											<MenuItem onClick={(e) => this.props.onSetNextSegment(null, e)}>
-												<span>{t('Clear queued segment')}</span>
-											</MenuItem>
-										)}
+										<MenuItem
+											onClick={(e) => this.onPlayFromHere(part.instance.part, e)}
+											disabled={isCurrentPart || !!part.instance.orphaned || !canSetAsNext}
+										>
+											<span dangerouslySetInnerHTML={{ __html: t('Play from Here') }}></span> (
+											{RundownUtils.formatTimeToShortTime(Math.floor((startsAt + timecode) / 1000) * 1000)})
+										</MenuItem>
 									</>
-								)}
+								) : null}
 							</>
 						)}
 					</ContextMenu>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

It's impossible to use the option of "Set Segment as Next" when context-clicking on a Part.

* **What is the new behavior (if this is a feature change)?**

All spots will show the option of "Set Segment as Next", with a separator and the "Set this Part as Next" option below a separator.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
