### PR TITLE
feat: Optimize timeline publication

### DIFF
--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -46,6 +46,7 @@ import { DbCacheWriteCollection } from '../cache/CacheCollection'
 import { CacheForStudio } from './studio/cache'
 import { PieceInstance, PieceInstances } from '../../lib/collections/PieceInstances'
 import { profiler } from './profiler'
+import { FastTrackObservers, triggerFastTrackObserver } from '../publications/fastTrack'
 
 // import {ServerPeripheralDeviceAPIMOS as MOS} from './peripheralDeviceMos'
 
@@ -355,17 +356,16 @@ export namespace ServerPeripheralDeviceAPI {
 			}
 		}
 		if (tlChanged) {
-			cache.Timeline.update(
-				cache.Studio.doc._id,
-				{
-					$set: {
-						timeline: timelineObjs,
-						timelineHash: getRandomId(),
-						generated: getCurrentTime(),
-					},
-				},
-				true
-			)
+			const newTimeline: TimelineComplete = {
+				_id: cache.Studio.doc._id,
+				timeline: timelineObjs,
+				timelineHash: getRandomId(),
+				generated: getCurrentTime(),
+			}
+
+			cache.Timeline.replace(newTimeline)
+			// Also do a fast-track for the timeline to be published faster:
+			triggerFastTrackObserver(FastTrackObservers.TIMELINE, [cache.Studio.doc._id], newTimeline)
 		}
 	}
 	export async function partPlaybackStarted(

--- a/meteor/server/lib/optimizedObserver.ts
+++ b/meteor/server/lib/optimizedObserver.ts
@@ -34,26 +34,20 @@ export function setUpOptimizedObserver<Data extends any[], Context extends Conte
 				if (newContext[key] !== undefined) context[key] = newContext[key]
 			}
 
-			const innerFcn = () => {
-				const o = optimizedObservers[identifier]
-				if (o) {
-					const result = manipulateData(context)
+			lazyIgnore(
+				`optimizedObserver_${identifier}`,
+				() => {
+					const o = optimizedObservers[identifier]
+					if (o) {
+						const result = manipulateData(context)
 
-					for (const dataReceiver of o.dataReceivers) {
-						dataReceiver(result)
+						for (const dataReceiver of o.dataReceivers) {
+							dataReceiver(result)
+						}
 					}
-				}
-			}
-
-			if (lazynessDuration) {
-				lazyIgnore(
-					`optimizedObserver_${identifier}`,
-					innerFcn,
-					lazynessDuration // ms
-				)
-			} else {
-				innerFcn()
-			}
+				},
+				lazynessDuration // ms
+			)
 		}
 		const context: any = {}
 		const observers = setupObservers(triggerUpdate)

--- a/meteor/server/lib/optimizedObserver.ts
+++ b/meteor/server/lib/optimizedObserver.ts
@@ -34,20 +34,26 @@ export function setUpOptimizedObserver<Data extends any[], Context extends Conte
 				if (newContext[key] !== undefined) context[key] = newContext[key]
 			}
 
-			lazyIgnore(
-				`optimizedObserver_${identifier}`,
-				() => {
-					const o = optimizedObservers[identifier]
-					if (o) {
-						const result = manipulateData(context)
+			const innerFcn = () => {
+				const o = optimizedObservers[identifier]
+				if (o) {
+					const result = manipulateData(context)
 
-						for (const dataReceiver of o.dataReceivers) {
-							dataReceiver(result)
-						}
+					for (const dataReceiver of o.dataReceivers) {
+						dataReceiver(result)
 					}
-				},
-				lazynessDuration // ms
-			)
+				}
+			}
+
+			if (lazynessDuration) {
+				lazyIgnore(
+					`optimizedObserver_${identifier}`,
+					innerFcn,
+					lazynessDuration // ms
+				)
+			} else {
+				innerFcn()
+			}
 		}
 		const context: any = {}
 		const observers = setupObservers(triggerUpdate)

--- a/meteor/server/publications/fastTrack.ts
+++ b/meteor/server/publications/fastTrack.ts
@@ -1,0 +1,52 @@
+import { Meteor } from 'meteor/meteor'
+import { logger } from '../logging'
+
+export enum FastTrackObservers {
+	TIMELINE = 'timeline',
+}
+
+const fastTrackObserver: {
+	[key: string]: {
+		useCount: number
+		onData: (data: any) => void
+	}
+} = {}
+
+function getKey(key: string, args: any[]): string {
+	return key + args.join(',')
+}
+
+export function setupFastTrackObserver<T>(
+	key: string,
+	keyArgs: any[],
+	onData: (data: T) => void
+): Meteor.LiveQueryHandle {
+	const fullKey = getKey(key, keyArgs)
+
+	if (!fastTrackObserver[fullKey]) {
+		fastTrackObserver[fullKey] = {
+			useCount: 1,
+			onData: onData,
+		}
+	} else {
+		fastTrackObserver[fullKey].useCount++
+	}
+	return {
+		stop: () => {
+			fastTrackObserver[fullKey].useCount--
+			if (!fastTrackObserver[fullKey].useCount) {
+				delete fastTrackObserver[fullKey]
+			}
+		},
+	}
+}
+
+export function triggerFastTrackObserver(key: string, keyArgs: any[], data: any) {
+	const fullKey = getKey(key, keyArgs)
+
+	try {
+		fastTrackObserver[fullKey]?.onData(data)
+	} catch (e) {
+		logger.error(e)
+	}
+}

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -15,6 +15,7 @@ import { PeripheralDeviceId, PeripheralDevices } from '../../lib/collections/Per
 import { Studios, getActiveRoutes, StudioId, DBStudio, ResultingMappingRoutes } from '../../lib/collections/Studios'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { StudioReadAccess } from '../security/studio'
+import { FastTrackObservers, setupFastTrackObserver } from './fastTrack'
 
 meteorPublish(PubSub.timeline, function (selector, token) {
 	if (!selector) throw new Meteor.Error(400, 'selector argument missing')
@@ -64,6 +65,15 @@ meteorCustomPublishArray(
 							changed: (timeline) => triggerUpdate({ timeline: timeline }),
 							removed: () => triggerUpdate({ timeline: null }),
 						}),
+						setupFastTrackObserver(
+							FastTrackObservers.TIMELINE,
+							[studioId],
+							(timeline: TimelineComplete) => {
+								triggerUpdate({
+									timeline: timeline,
+								})
+							}
+						),
 					]
 				},
 				() => {

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -1,12 +1,18 @@
 import { Meteor } from 'meteor/meteor'
-import { Timeline, getRoutedTimeline, TimelineComplete } from '../../lib/collections/Timeline'
+import {
+	Timeline,
+	getRoutedTimeline,
+	TimelineComplete,
+	TimelineObjGeneric,
+	TimelineHash,
+} from '../../lib/collections/Timeline'
 import { meteorPublish } from './lib'
 import { PubSub } from '../../lib/api/pubsub'
 import { FindOptions } from '../../lib/typings/meteor'
 import { meteorCustomPublishArray } from '../lib/customPublication'
 import { setUpOptimizedObserver } from '../lib/optimizedObserver'
 import { PeripheralDeviceId, PeripheralDevices } from '../../lib/collections/PeripheralDevices'
-import { Studios, getActiveRoutes, StudioId } from '../../lib/collections/Studios'
+import { Studios, getActiveRoutes, StudioId, DBStudio, ResultingMappingRoutes } from '../../lib/collections/Studios'
 import { PeripheralDeviceReadAccess } from '../security/peripheralDevice'
 import { StudioReadAccess } from '../security/studio'
 
@@ -47,9 +53,9 @@ meteorCustomPublishArray(
 								mappingsHash: 1,
 							},
 						}).observe({
-							added: () => triggerUpdate({ studioId: studioId }),
-							changed: () => triggerUpdate({ studioId: studioId }),
-							removed: () => triggerUpdate({ studioId: null }),
+							added: () => triggerUpdate({ invalidateStudio: true, studioId: studioId }),
+							changed: () => triggerUpdate({ invalidateStudio: true, studioId: studioId }),
+							removed: () => triggerUpdate({ invalidateStudio: true, studioId: null }),
 						}),
 						Timeline.find({
 							_id: studioId,
@@ -63,37 +69,90 @@ meteorCustomPublishArray(
 				() => {
 					// Initial data fetch
 					return {
+						studioId: studioId,
 						timeline: Timeline.findOne({
 							_id: studioId,
 						}),
-						studioId: studioId,
+
+						invalidateStudio: true,
+						studio: undefined,
+						routes: undefined,
+
+						timelineHash: undefined,
+						routedTimeline: [],
 					}
 				},
-				(newData: { studioId: StudioId | undefined; timeline: TimelineComplete | undefined }) => {
+				(context: {
+					studioId: StudioId | undefined
+					timeline: TimelineComplete | undefined
+
+					invalidateStudio: boolean
+					studio: DBStudio | undefined
+					routes: ResultingMappingRoutes | undefined
+
+					// re-calc of timeline using timelineHash:
+					timelineHash: TimelineHash | undefined
+					routedTimeline: TimelineObjGeneric[]
+				}) => {
 					// Prepare data for publication:
 
-					if (!newData.studioId || !newData.timeline) {
+					if (!context.studioId || !context.timeline) {
 						return []
-					} else {
-						const studio = Studios.findOne(newData.studioId)
-						if (!studio) return []
-
-						const routes = getActiveRoutes(studio)
-						const routedTimeline = getRoutedTimeline(newData.timeline.timeline, routes)
-
-						return [
-							{
-								_id: newData.timeline._id,
-								mappingsHash: studio.mappingsHash,
-								timelineHash: newData.timeline.timelineHash,
-								timeline: routedTimeline,
-							},
-						]
 					}
+
+					let changedData = false
+					let invalidateTimeline = false
+
+					if (context.invalidateStudio) {
+						context.invalidateStudio = false
+						context.studio = Studios.findOne(context.studioId)
+						context.routes = context.studio ? getActiveRoutes(context.studio) : undefined
+
+						invalidateTimeline = true
+					}
+					if (!context.studio) return []
+					if (!context.routes) return []
+
+					if (context.timelineHash !== context.timeline.timelineHash) {
+						invalidateTimeline = true
+					}
+
+					if (invalidateTimeline) {
+						context.timelineHash = context.timeline.timelineHash
+						context.routedTimeline = getRoutedTimeline(context.timeline.timeline, context.routes)
+						changedData = true
+					}
+
+					return [
+						{
+							_id: context.timeline._id,
+							mappingsHash: context.studio.mappingsHash,
+							timelineHash: context.timeline.timelineHash,
+							timeline: context.routedTimeline,
+
+							changedData,
+						},
+					]
 				},
 				(newData) => {
-					pub.updatedDocs(newData)
-				}
+					if (newData.length) {
+						// Only update the publication if any data has changed:
+						let changedData = false
+						for (const data of newData) {
+							if (data.changedData) {
+								changedData = true
+								break
+							}
+						}
+						if (changedData) {
+							pub.updatedDocs(newData)
+						} else {
+						}
+					} else {
+						pub.updatedDocs(newData)
+					}
+				},
+				0 // ms
 			)
 			pub.onStop(() => {
 				observer.stop()

--- a/meteor/server/publications/timeline.ts
+++ b/meteor/server/publications/timeline.ts
@@ -156,7 +156,6 @@ meteorCustomPublishArray(
 						}
 						if (changedData) {
 							pub.updatedDocs(newData)
-						} else {
 						}
 					} else {
 						pub.updatedDocs(newData)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Performance improvement


**What is the current behavior?** (You can also link to an open issue here)
When a new timeline is generated:

1. The timeline is generated and is put into the in-memory Cache
2. The timeline is saved into MongoDB
3. MongoDB emits the change back to Core
4. The publication picks up the change and starts recalculating (routing) the timeline.
5. The publication sends the new timeline to Playout-gateway

In my local tests, the time from 1 to 4 is about **20-30 ms**.

**What is the new behavior (if this is a feature change)?**
When a new timeline is generated:

1. The timeline is generated and is put into the in-memory Cache
2. The timeline is also fast-tracked and sent directly to the publication
3. The publication picks up the change and starts recalculating (routing) the timeline.
4. The publication sends the new timeline to Playout-gateway
5. The timeline is saved into MongoDB (from step 1)
6. MongoDB emits the change back to Core
7. The publication picks up the change, but does nothing, since the `timelineHash` is the same.

In my local tests, the time from 1 to 3 is basically zero.

**Other information**:
This PR is targetting release38, but is based on release37

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
