### PR TITLE
feat: Action Triggers tag filter suggestions

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -796,18 +796,16 @@ const EditAttributeDropdownText = wrapEditAttribute(
 					/>
 
 					<datalist id={this._id}>
-						{this.getOptions(true).map((o, j) =>
+						{this.getOptions(false).map((o, j) =>
 							Array.isArray(o.value) ? (
 								<optgroup key={j} label={o.name}>
 									{o.value.map((v, i) => (
-										<option key={i} value={v + ''}>
-											{v}
-										</option>
+										<option key={i} value={v + ''}></option>
 									))}
 								</optgroup>
 							) : (
 								<option key={o.i} value={o.value + ''}>
-									{o.name}
+									{o.value !== o.name ? o.name : null}
 								</option>
 							)
 						)}

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -5,8 +5,8 @@ import { PlayoutActions, SourceLayerType, TriggerType } from '@sofie-automation/
 import classNames from 'classnames'
 import {
 	DBBlueprintTrigger,
+	TriggeredActionId,
 	TriggeredActions,
-	TriggeredActionsObj,
 } from '../../../../../lib/collections/TriggeredActions'
 import { useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { ActionEditor } from './actionEditors/ActionEditor'
@@ -25,7 +25,7 @@ import { useDrag, useDrop } from 'react-dnd'
 
 interface IProps {
 	showStyleBase: ShowStyleBase | undefined
-	triggeredAction: TriggeredActionsObj
+	triggeredActionId: TriggeredActionId
 	selected?: boolean
 	previewContext: PreviewContext | null
 	locked?: boolean
@@ -42,14 +42,16 @@ export const TRIGGERED_ACTION_ENTRY_DRAG_TYPE = 'TriggeredActionEntry'
 export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEntry(
 	props: IProps
 ): React.ReactElement | null {
-	const { showStyleBase, triggeredAction, selected, locked, previewContext, onEdit, onRemove, onDuplicate } = props
+	const { showStyleBase, triggeredActionId, selected, locked, previewContext, onEdit, onRemove, onDuplicate } = props
+
+	const triggeredAction = useTracker(() => TriggeredActions.findOne(triggeredActionId), [triggeredActionId])
 
 	const { t } = useTranslation()
 	const [selectedTrigger, setSelectedTrigger] = useState(-1)
 	const [selectedAction, setSelectedAction] = useState(-1)
 
 	const [{ isDragging }, drag, dragPreview] = useDrag({
-		item: { id: triggeredAction._id, type: TRIGGERED_ACTION_ENTRY_DRAG_TYPE },
+		item: { id: triggeredActionId, type: TRIGGERED_ACTION_ENTRY_DRAG_TYPE },
 		// The collect function utilizes a "monitor" instance (see the Overview for what this is)
 		// to pull important pieces of state from the DnD system.
 		collect: (monitor) => ({
@@ -72,7 +74,7 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 								},
 							}
 						)?._rank ?? -1000
-					if (pairRank === triggeredAction._rank) {
+					if (pairRank === triggeredAction?._rank) {
 						pairRank =
 							TriggeredActions.findOne(
 								{
@@ -88,7 +90,7 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 							)?._rank ?? dropResult.overRank + 1000
 					}
 					const newRank = (pairRank + dropResult.overRank) / 2
-					TriggeredActions.update(triggeredAction._id, {
+					TriggeredActions.update(triggeredActionId, {
 						$set: {
 							_rank: newRank,
 							showStyleBaseId: dropResult.overShowStyleBaseId,
@@ -110,9 +112,9 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 		drop: (item) => {
 			if (item.type === TRIGGERED_ACTION_ENTRY_DRAG_TYPE) {
 				return {
-					overId: triggeredAction._id,
-					overRank: triggeredAction._rank,
-					overShowStyleBaseId: triggeredAction.showStyleBaseId,
+					overId: triggeredActionId,
+					overRank: triggeredAction?._rank,
+					overShowStyleBaseId: triggeredAction?.showStyleBaseId,
 				}
 			}
 		},
@@ -121,7 +123,7 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 	const previewItems = useTracker(
 		() => {
 			try {
-				if (selected && showStyleBase) {
+				if (triggeredAction && selected && showStyleBase) {
 					const executableActions = triggeredAction.actions.map((value) => createAction(value, showStyleBase))
 					const ctx = previewContext
 					if (ctx && ctx.rundownPlaylist) {
@@ -152,84 +154,99 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 	}
 
 	function removeTrigger(index: number) {
-		triggeredAction.triggers.splice(index, 1)
+		if (triggeredAction) {
+			triggeredAction.triggers.splice(index, 1)
 
-		TriggeredActions.update(triggeredAction._id, {
-			$set: {
-				triggers: triggeredAction.triggers,
-			},
-		})
+			TriggeredActions.update(triggeredActionId, {
+				$set: {
+					triggers: triggeredAction.triggers,
+				},
+			})
 
-		setSelectedTrigger(-1)
+			setSelectedTrigger(-1)
+		}
 	}
 
 	function changeTrigger(index: number, newVal: DBBlueprintTrigger) {
-		triggeredAction.triggers.splice(index, 1, newVal)
+		if (triggeredAction) {
+			triggeredAction.triggers.splice(index, 1, newVal)
 
-		LAST_UP_SETTING = !!newVal.up
+			LAST_UP_SETTING = !!newVal.up
 
-		TriggeredActions.update(triggeredAction._id, {
-			$set: {
-				triggers: triggeredAction.triggers,
-			},
-		})
+			TriggeredActions.update(triggeredActionId, {
+				$set: {
+					triggers: triggeredAction.triggers,
+				},
+			})
 
-		setSelectedTrigger(-1)
+			setSelectedTrigger(-1)
+		}
 	}
 
 	function addTrigger() {
-		const index =
-			triggeredAction.triggers.push({
-				type: TriggerType.hotkey,
-				keys: '',
-				up: LAST_UP_SETTING,
-			}) - 1
+		if (triggeredAction) {
+			const index =
+				triggeredAction.triggers.push({
+					type: TriggerType.hotkey,
+					keys: '',
+					up: LAST_UP_SETTING,
+				}) - 1
 
-		TriggeredActions.update(triggeredAction._id, {
-			$set: {
-				triggers: triggeredAction.triggers,
-			},
-		})
+			TriggeredActions.update(triggeredActionId, {
+				$set: {
+					triggers: triggeredAction.triggers,
+				},
+			})
 
-		setSelectedTrigger(index)
-		setSelectedAction(-1)
+			setSelectedTrigger(index)
+			setSelectedAction(-1)
+		}
 	}
 
 	function addAction() {
-		const index =
-			triggeredAction.actions.push({
-				action: PlayoutActions.adlib,
-				filterChain: [],
-			}) - 1
+		if (triggeredAction) {
+			const index =
+				triggeredAction.actions.push({
+					action: PlayoutActions.adlib,
+					filterChain: [],
+				}) - 1
 
-		TriggeredActions.update(triggeredAction._id, {
-			$set: {
-				actions: triggeredAction.actions,
-			},
-		})
+			TriggeredActions.update(triggeredActionId, {
+				$set: {
+					actions: triggeredAction.actions,
+				},
+			})
 
-		setSelectedTrigger(-1)
-		setSelectedAction(index)
+			setSelectedTrigger(-1)
+			setSelectedAction(index)
+		}
 	}
 
 	function removeAction(index: number) {
-		triggeredAction.actions.splice(index, 1)
+		if (triggeredAction) {
+			triggeredAction.actions.splice(index, 1)
 
-		TriggeredActions.update(triggeredAction._id, {
-			$set: {
-				actions: triggeredAction.actions,
-			},
-		})
+			TriggeredActions.update(triggeredActionId, {
+				$set: {
+					actions: triggeredAction.actions,
+				},
+			})
 
-		setSelectedAction(-1)
+			setSelectedAction(-1)
+		}
 	}
 
 	useEffect(() => {
-		LAST_UP_SETTING =
-			selectedTrigger >= 0
-				? !!triggeredAction.triggers[selectedTrigger]?.up
-				: triggeredAction.triggers[triggeredAction.triggers.length - 1]?.up ?? LAST_UP_SETTING
-	}, [triggeredAction.triggers[triggeredAction.triggers.length - 1]?.up, selectedTrigger])
+		if (triggeredAction) {
+			LAST_UP_SETTING =
+				selectedTrigger >= 0
+					? !!triggeredAction.triggers[selectedTrigger]?.up
+					: triggeredAction.triggers[triggeredAction.triggers.length - 1]?.up ?? LAST_UP_SETTING
+		}
+	}, [triggeredAction, triggeredAction?.triggers[triggeredAction.triggers.length - 1]?.up, selectedTrigger])
+
+	// do not render anything until we get the triggered action from the collection
+	if (!triggeredAction) return null
 
 	return (
 		<div

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionEntry.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../../lib/collections/TriggeredActions'
 import { useTracker } from '../../../../lib/ReactMeteorData/ReactMeteorData'
 import { ActionEditor } from './actionEditors/ActionEditor'
-import { ShowStyleBase } from '../../../../../lib/collections/ShowStyleBases'
+import { ShowStyleBase, ShowStyleBaseId } from '../../../../../lib/collections/ShowStyleBases'
 import { flatten, normalizeArray } from '../../../../../lib/lib'
 import { createAction, isPreviewableAction } from '../../../../../lib/api/triggers/actionFactory'
 import { PreviewContext } from './TriggeredActionsEditor'
@@ -59,8 +59,14 @@ export const TriggeredActionEntry: React.FC<IProps> = function TriggeredActionEn
 		}),
 		end: (_, monitor) => {
 			if (monitor.didDrop()) {
-				const dropResult = monitor.getDropResult()
-				if (dropResult) {
+				const dropResult = monitor.getDropResult() as
+					| {
+							overId: TriggeredActionId
+							overRank?: number
+							overShowStyleBaseId?: ShowStyleBaseId
+					  }
+					| undefined
+				if (dropResult && dropResult.overRank !== undefined && dropResult.overShowStyleBaseId) {
 					let pairRank =
 						TriggeredActions.findOne(
 							{

--- a/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/TriggeredActionsEditor.tsx
@@ -105,7 +105,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 		}
 	}, [triggerFilter])
 
-	const systemTriggeredActions = useTracker(
+	const systemTriggeredActionIds = useTracker(
 		() =>
 			TriggeredActions.find(
 				Object.assign(
@@ -127,11 +127,14 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 					sort: {
 						_rank: 1,
 					},
+					fields: {
+						_id: 1,
+					},
 				}
-			).fetch(),
+			).map((triggeredAction) => triggeredAction._id),
 		[parsedTriggerFilter]
 	)
-	const showTriggeredActions = useTracker(
+	const showTriggeredActionIds = useTracker(
 		() =>
 			TriggeredActions.find(
 				Object.assign(
@@ -153,8 +156,11 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 					sort: {
 						_rank: 1,
 					},
+					fields: {
+						_id: 1,
+					},
 				}
-			).fetch(),
+			).map((triggeredAction) => triggeredAction._id),
 		[showStyleBaseId, parsedTriggerFilter]
 	)
 
@@ -426,7 +432,7 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 					onChange={(e) => setTriggerFilter(e.target.value)}
 				/>
 			</div>
-			{showTriggeredActions?.length === 0 && systemTriggeredActions?.length === 0 ? (
+			{showTriggeredActionIds?.length === 0 && systemTriggeredActionIds?.length === 0 ? (
 				parsedTriggerFilter ? (
 					<p className="mod mhn subtle">{t('No matching Action Trigger.')}</p>
 				) : (
@@ -434,25 +440,25 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 				)
 			) : null}
 			<div className={classNames('mod mhn', parsedTriggerFilter ? 'mbn' : undefined)}>
-				{showTriggeredActions?.map((triggeredAction) => (
+				{showTriggeredActionIds?.map((triggeredActionId) => (
 					<TriggeredActionEntry
-						key={unprotectString(triggeredAction._id)}
-						triggeredAction={triggeredAction}
-						selected={selectedTriggeredActionId === triggeredAction._id}
+						key={unprotectString(triggeredActionId)}
+						triggeredActionId={triggeredActionId}
+						selected={selectedTriggeredActionId === triggeredActionId}
 						locked={!!parsedTriggerFilter}
-						onEdit={() => onEditEntry(triggeredAction._id)}
-						onRemove={() => onRemoveTriggeredAction(triggeredAction._id)}
-						onDuplicate={() => onDuplicateEntry(triggeredAction._id)}
+						onEdit={() => onEditEntry(triggeredActionId)}
+						onRemove={() => onRemoveTriggeredAction(triggeredActionId)}
+						onDuplicate={() => onDuplicateEntry(triggeredActionId)}
 						showStyleBase={showStyleBase}
 						previewContext={rundownPlaylist ? previewContext : null}
-						onFocus={() => setSelectedTriggeredActionId(triggeredAction._id)}
+						onFocus={() => setSelectedTriggeredActionId(triggeredActionId)}
 					/>
 				))}
 			</div>
 			{showStyleBaseId !== null ? (
 				<>
 					<div className={classNames('mod mhn', parsedTriggerFilter ? 'mtn' : undefined)}>
-						{(systemTriggeredActions?.length ?? 0) > 0 && !parsedTriggerFilter ? (
+						{(systemTriggeredActionIds?.length ?? 0) > 0 && !parsedTriggerFilter ? (
 							<h3
 								className="mhn mvs clickable disable-select"
 								onClick={() => setSystemWideCollapsed(!systemWideCollapsed)}
@@ -467,18 +473,18 @@ export const TriggeredActionsEditor: React.FC<IProps> = function TriggeredAction
 							</h3>
 						) : null}
 						{!systemWideCollapsed || parsedTriggerFilter
-							? systemTriggeredActions?.map((triggeredAction) => (
+							? systemTriggeredActionIds?.map((triggeredActionId) => (
 									<TriggeredActionEntry
-										key={unprotectString(triggeredAction._id)}
-										triggeredAction={triggeredAction}
-										selected={selectedTriggeredActionId === triggeredAction._id}
+										key={unprotectString(triggeredActionId)}
+										triggeredActionId={triggeredActionId}
+										selected={selectedTriggeredActionId === triggeredActionId}
 										locked={!!parsedTriggerFilter}
-										onEdit={() => onEditEntry(triggeredAction._id)}
-										onRemove={() => onRemoveTriggeredAction(triggeredAction._id)}
-										onDuplicate={() => onDuplicateEntry(triggeredAction._id)}
+										onEdit={() => onEditEntry(triggeredActionId)}
+										onRemove={() => onRemoveTriggeredAction(triggeredActionId)}
+										onDuplicate={() => onDuplicateEntry(triggeredActionId)}
 										showStyleBase={showStyleBase}
 										previewContext={rundownPlaylist ? previewContext : null}
-										onFocus={() => setSelectedTriggeredActionId(triggeredAction._id)}
+										onFocus={() => setSelectedTriggeredActionId(triggeredActionId)}
 									/>
 							  ))
 							: null}

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
@@ -205,7 +205,7 @@ function fieldValueMutate(link: IAdLibFilterLink, newValue: any) {
 			return Boolean(newValue)
 		case 'label':
 		case 'tag':
-			return String(newValue).split(',')
+			return String(newValue).split(/\,\s*/)
 		case 'limit':
 			return Number(newValue)
 		case 'pick':

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
@@ -303,7 +303,7 @@ export const AdLibFilter: React.FC<IProps> = function AdLibFilter({
 			// tags are a special case because we need to search the database for available options
 			// we should have the data subscribed already
 			if (link.field === 'tag') {
-				const availableTags = _.chain(
+				return _.chain(
 					RundownBaselineAdLibActions.find()
 						.map((action) => action.display.tags)
 						.concat(AdLibActions.find().map((action) => action.display.tags))
@@ -314,7 +314,6 @@ export const AdLibFilter: React.FC<IProps> = function AdLibFilter({
 					.compact()
 					.uniq()
 					.value() as string[]
-				return availableTags
 			} else {
 				return fieldToOptions(t, showStyleBase, link.field)
 			}

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/AdLibFilter.tsx
@@ -303,13 +303,12 @@ export const AdLibFilter: React.FC<IProps> = function AdLibFilter({
 			// tags are a special case because we need to search the database for available options
 			// we should have the data subscribed already
 			if (link.field === 'tag') {
-				return _.chain(
-					RundownBaselineAdLibActions.find()
-						.map((action) => action.display.tags)
-						.concat(AdLibActions.find().map((action) => action.display.tags))
-						.concat(RundownBaselineAdLibPieces.find().map((piece) => piece.tags))
-						.concat(AdLibPieces.find().map((piece) => piece.tags))
-				)
+				return _.chain([
+					...RundownBaselineAdLibActions.find().map((action) => action.display.tags),
+					...AdLibActions.find().map((action) => action.display.tags),
+					...RundownBaselineAdLibPieces.find().map((piece) => piece.tags),
+					...AdLibPieces.find().map((piece) => piece.tags),
+				])
 					.flatten()
 					.compact()
 					.uniq()

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/filterPreviews/FilterEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect } from 'react'
 import classNames from 'classnames'
 import { usePopper } from 'react-popper'
-import { EditAttribute } from '../../../../../../lib/EditAttribute'
+import { EditAttribute, EditAttributeType } from '../../../../../../lib/EditAttribute'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleRight, faCheck, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { sameWidth } from '../../../../../../lib/popperUtils'
@@ -16,7 +16,7 @@ interface IProps {
 	value: any
 	final?: boolean
 	readonly?: boolean
-	type: 'toggle' | 'text' | 'int' | 'dropdown' | 'multiselect'
+	type: EditAttributeType
 	values?: Record<string, any>
 	onChangeField: (newField: any) => void
 	onChange: (newValue: any) => void


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature & Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When editing the tags field in the Action Triggers, the field is a free text field, with no information on the tags available

* **What is the new behavior (if this is a feature change)?**

When editing the tags filter, a list of available tag suggestions will be displayed, based on the selected "sample" rundown. Since this list may not be exhaustive, the field is still non-validated (you can still input multiple comma separated tags), but it should give a bit more help during manual setup.

This PR also fixes an issue with the performance of that view, because all of the components were reactive whenever any of the Action Triggers objects changed. Only the modified Action Trigger component should rerender now.

* **Other information**:
