### PR TITLE
Fix: package info

### DIFF
--- a/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/meteor/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -308,15 +308,19 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 			const piece = this.props.piece
 			if (piece.contentPackageInfos) {
 				// TODO: support multiple packages:
-				if (piece.contentPackageInfos[0]?.deepScan?.scenes) {
-					return _.compact(
-						piece.contentPackageInfos[0].deepScan.scenes.map((i) => {
-							if (i < itemDuration) {
-								return i * 1000
+				const contentPackageInfos = Object.values(piece.contentPackageInfos)
+				if (contentPackageInfos[0]?.deepScan?.scenes) {
+					const scenes = _.compact(
+						contentPackageInfos[0].deepScan.scenes.map((i) => {
+							const sceneTime = i * 1000
+							if (sceneTime < itemDuration) {
+								return sceneTime
 							}
 							return undefined
 						})
 					) // convert into milliseconds
+
+					return scenes
 				}
 			} else {
 				// Fallback to media objects:
@@ -343,8 +347,9 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 				let items: Array<PackageInfo.Anomaly> = []
 				// add freezes
 				// TODO: support multiple packages:
-				if (piece.contentPackageInfos[0]?.deepScan?.freezes) {
-					items = piece.contentPackageInfos[0].deepScan.freezes
+				const contentPackageInfos = Object.values(piece.contentPackageInfos)
+				if (contentPackageInfos[0]?.deepScan?.freezes) {
+					items = contentPackageInfos[0].deepScan.freezes
 						.filter((i) => i.start < itemDuration)
 						.map((i): PackageInfo.Anomaly => {
 							return { start: i.start * 1000, end: i.end * 1000, duration: i.duration * 1000 }
@@ -376,10 +381,11 @@ export class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithT
 				let items: Array<PackageInfo.Anomaly> = []
 				// add blacks
 				// TODO: support multiple packages:
-				if (piece.contentPackageInfos[0]?.deepScan?.blacks) {
+				const contentPackageInfos = Object.values(piece.contentPackageInfos)
+				if (contentPackageInfos[0]?.deepScan?.blacks) {
 					items = [
 						...items,
-						...piece.contentPackageInfos[0].deepScan.blacks
+						...contentPackageInfos[0].deepScan.blacks
 							.filter((i) => i.start < itemDuration)
 							.map((i): PackageInfo.Anomaly => {
 								return { start: i.start * 1000, end: i.end * 1000, duration: i.duration * 1000 }

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -278,8 +278,8 @@ export function checkPieceContentStatus(
 							}
 							// ok:
 							PackageInfos.find({
-								studio: studio._id,
-								packageId: protectString(expectedPackage._id),
+								studioId: studio._id,
+								packageId: getExpectedPackageId(piece._id, expectedPackage._id),
 								type: {
 									$in: [PackageInfo.Type.SCAN, PackageInfo.Type.DEEPSCAN] as any,
 								},

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -229,16 +229,10 @@ export function checkPieceContentStatus(
 							expectedPackage.content.guid ||
 							expectedPackage._id
 
-						if (!packageOnPackageContainer) {
-							newStatus = RundownAPI.PieceStatusCode.SOURCE_MISSING
-							messages.push(
-								t(`Clip "{{fileName}}" has not been looked up by Sofie yet`, {
-									fileName: packageName,
-								})
-							)
-						} else if (
+						if (
+							!packageOnPackageContainer ||
 							packageOnPackageContainer.status.status ===
-							ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.NOT_FOUND
+								ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.NOT_FOUND
 						) {
 							newStatus = RundownAPI.PieceStatusCode.SOURCE_MISSING
 							messages.push(

--- a/meteor/lib/mediaObjects.ts
+++ b/meteor/lib/mediaObjects.ts
@@ -386,6 +386,7 @@ export function checkPieceContentStatus(
 								t: i18next.TFunction
 							) => {
 								if (anomalies.length === 1) {
+									/** Number of frames */
 									const frames = Math.ceil((anomalies[0].duration * 1000) / timebase)
 									if (anomalies[0].start === 0) {
 										messages.push(
@@ -404,7 +405,7 @@ export function checkPieceContentStatus(
 												count: freezeStartsAt,
 											})
 										)
-									} else {
+									} else if (frames > 0) {
 										messages.push(
 											t('{{frames}} {{type}} frame detected within the clip', {
 												frames,


### PR DESCRIPTION
This PR fixes a few issues related to Package Manager media statuses.

* A few bugs, causing them to never show up
* Don't display freeze/black frames with 0 duration
* explicit handling of the media situations "not checked yet by Package Manager" vs "checked and not found"


**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
