### PR TITLE
Fix: supress not saved cache

### DIFF
--- a/meteor/server/api/playout/lockFunction.ts
+++ b/meteor/server/api/playout/lockFunction.ts
@@ -242,11 +242,16 @@ async function playoutLockFunctionInner<T>(
 
 		const fullCache = await CacheForPlayout.fromInit(initCache)
 
-		const res = await fcn(fullCache)
+		try {
+			const res = await fcn(fullCache)
 
-		await fullCache.saveAllToDatabase()
+			await fullCache.saveAllToDatabase()
 
-		return res
+			return res
+		} catch (err) {
+			fullCache.discardChanges()
+			throw err
+		}
 	}
 
 	if (options?.skipPlaylistLock) {

--- a/meteor/server/api/studio/lockFunction.ts
+++ b/meteor/server/api/studio/lockFunction.ts
@@ -47,11 +47,14 @@ export async function runStudioOperationWithCache<T>(
 	return runStudioOperationWithLock(context, studioId, priority, async () => {
 		const cache = await CacheForStudio.create(studioId)
 
-		const res = await fcn(cache)
-
-		await cache.saveAllToDatabase()
-
-		return res
+		try {
+			const res = await fcn(cache)
+			await cache.saveAllToDatabase()
+			return res
+		} catch (err) {
+			cache.discardChanges()
+			throw err
+		}
 	})
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
minor fix


* **What is the current behavior?** (You can also link to an open issue here)
"saveAllToDatabase never called" is logged (a few seconds later) every time an error is thrown in the lockFunctions.


* **What is the new behavior (if this is a feature change)?**
Upon error, "saveAllToDatabase never called" is not logged.


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
