### PR TITLE
fix: make pieceIds generate without relying on the segmentId, so that they are stable when parts are moved between segments

### DIFF
--- a/meteor/lib/hash.ts
+++ b/meteor/lib/hash.ts
@@ -1,0 +1,26 @@
+import * as crypto from 'crypto'
+
+export function getHash(str: string): string {
+	const hash = crypto.createHash('sha1')
+	return hash
+		.update(str)
+		.digest('base64')
+		.replace(/[\+\/\=]/g, '_') // remove +/= from strings, because they cause troubles
+}
+/** Creates a hash based on the object properties (excluding ordering of properties) */
+export function hashObj(obj: any): string {
+	if (typeof obj === 'object') {
+		const keys = Object.keys(obj).sort((a, b) => {
+			if (a > b) return 1
+			if (a < b) return -1
+			return 0
+		})
+
+		const strs: string[] = []
+		for (const key of keys) {
+			strs.push(hashObj(obj[key]))
+		}
+		return getHash(strs.join('|'))
+	}
+	return obj + ''
+}

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -7,10 +7,11 @@ import { Timecode } from 'timecode'
 import { Settings } from './Settings'
 import * as objectPath from 'object-path'
 import { iterateDeeply, iterateDeeplyEnum } from '@sofie-automation/blueprints-integration'
-import * as crypto from 'crypto'
 import { ReadonlyDeep, PartialDeep } from 'type-fest'
 import { ITranslatableMessage } from './api/TranslatableMessage'
 import { AsyncTransformedCollection } from './collections/lib'
+
+export * from './hash'
 
 const cloneOrg = require('fast-clone')
 
@@ -55,31 +56,6 @@ export function max<T>(vals: T[], iterator: _.ListIterator<T, any>): T | undefin
 	} else {
 		return _.max(vals, iterator)
 	}
-}
-
-export function getHash(str: string): string {
-	const hash = crypto.createHash('sha1')
-	return hash
-		.update(str)
-		.digest('base64')
-		.replace(/[\+\/\=]/g, '_') // remove +/= from strings, because they cause troubles
-}
-/** Creates a hash based on the object properties (excluding ordering of properties) */
-export function hashObj(obj: any): string {
-	if (typeof obj === 'object') {
-		const keys = Object.keys(obj).sort((a, b) => {
-			if (a > b) return 1
-			if (a < b) return -1
-			return 0
-		})
-
-		const strs: string[] = []
-		for (const key of keys) {
-			strs.push(hashObj(obj[key]))
-		}
-		return getHash(strs.join('|'))
-	}
-	return obj + ''
 }
 
 export function getRandomId<T>(numberOfChars?: number): ProtectedString<T> {

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -921,7 +921,6 @@ describe('Test blueprint api context', () => {
 					expect(newPieceInstanceId).toMatch(/randomId(\d+)_part0_0_instance_randomId(\d+)/)
 					expect(postProcessPiecesMock).toHaveBeenCalledTimes(1)
 					expect(postProcessPiecesMock).toHaveBeenCalledWith(
-						expect.anything(),
 						[{ externalId: 'input1' }],
 						'mockBlueprint1',
 						partInstance.rundownId,

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -252,7 +252,6 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		const trimmedPiece: IBlueprintPiece = _.pick(rawPiece, IBlueprintPieceSampleKeys)
 
 		const piece = postProcessPieces(
-			this,
 			[trimmedPiece],
 			this.showStyleCompound.blueprintId,
 			partInstance.rundownId,
@@ -305,7 +304,6 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 
 		if (piece.content && piece.content.timelineObjects) {
 			piece.content.timelineObjects = postProcessTimelineObjects(
-				this,
 				pieceInstance.piece._id,
 				this.showStyleCompound.blueprintId,
 				piece.content.timelineObjects,
@@ -384,7 +382,6 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		}
 
 		const pieces = postProcessPieces(
-			this,
 			rawPieces,
 			this.showStyleCompound.blueprintId,
 			currentPartInstance.rundownId,

--- a/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
+++ b/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
@@ -116,7 +116,6 @@ export class SyncIngestUpdateToPartInstanceContext
 		// filter the submission to the allowed ones
 		const piece = modifiedPiece
 			? postProcessPieces(
-					this,
 					[
 						{
 							...modifiedPiece,
@@ -147,7 +146,6 @@ export class SyncIngestUpdateToPartInstanceContext
 		const trimmedPiece: IBlueprintPiece = _.pick(piece0, IBlueprintPieceSampleKeys)
 
 		const piece = postProcessPieces(
-			this,
 			[trimmedPiece],
 			this.showStyleCompound.blueprintId,
 			this.partInstance.rundownId,
@@ -188,7 +186,6 @@ export class SyncIngestUpdateToPartInstanceContext
 
 		if (updatedPiece.content && updatedPiece.content.timelineObjects) {
 			updatedPiece.content.timelineObjects = postProcessTimelineObjects(
-				this,
 				pieceInstance.piece._id,
 				this.showStyleCompound.blueprintId,
 				updatedPiece.content.timelineObjects,

--- a/meteor/server/api/blueprints/postProcess.ts
+++ b/meteor/server/api/blueprints/postProcess.ts
@@ -1,6 +1,6 @@
 import { Piece, PieceId } from '../../../lib/collections/Pieces'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
-import { protectString, unprotectString, literal } from '../../../lib/lib'
+import { protectString, unprotectString, literal, getHash } from '../../../lib/lib'
 import { TimelineObjGeneric, TimelineObjRundown, TimelineObjType } from '../../../lib/collections/Timeline'
 import { Studio } from '../../../lib/collections/Studios'
 import { Meteor } from 'meteor/meteor'
@@ -10,8 +10,6 @@ import {
 	IBlueprintAdLibPiece,
 	TSR,
 	IBlueprintActionManifest,
-	ICommonContext,
-	IShowStyleContext,
 } from '@sofie-automation/blueprints-integration'
 import { RundownAPI } from '../../../lib/api/rundown'
 import { BucketAdLib } from '../../../lib/collections/BucketAdlibs'
@@ -26,7 +24,7 @@ import { prefixAllObjectIds } from '../playout/lib'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { profiler } from '../profiler'
 import { BucketAdLibAction } from '../../../lib/collections/BucketAdlibActions'
-import { CommonContext, ShowStyleContext } from './context'
+import { ShowStyleContext } from './context'
 import { ReadonlyDeep } from 'type-fest'
 import { processAdLibActionITranslatableMessages } from '../../../lib/api/TranslatableMessage'
 import { setDefaultIdOnExpectedPackages } from '../ingest/expectedPackages'
@@ -37,7 +35,6 @@ import { setDefaultIdOnExpectedPackages } from '../ingest/expectedPackages'
  * prefixAllTimelineObjects: Add a prefix to the timeline object ids, to ensure duplicate ids don't occur when inserting a copy of a piece
  */
 export function postProcessPieces(
-	innerContext: IShowStyleContext,
 	pieces: IBlueprintPiece[],
 	blueprintId: BlueprintId,
 	rundownId: RundownId,
@@ -55,9 +52,10 @@ export function postProcessPieces(
 	const processedPieces = pieces.map((orgPiece: IBlueprintPiece) => {
 		const i = externalIds.get(orgPiece.externalId) ?? 0
 		externalIds.set(orgPiece.externalId, i + 1)
+
 		const piece: Piece = {
 			...(orgPiece as Omit<IBlueprintPiece, 'continuesRefId'>),
-			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_piece_${orgPiece.externalId}_${i}`)),
+			_id: protectString(getHash(`${rundownId}_${blueprintId}_${partId}_piece_${orgPiece.externalId}_${i}`)),
 			continuesRefId: protectString(orgPiece.continuesRefId),
 			startRundownId: rundownId,
 			startSegmentId: segmentId,
@@ -69,21 +67,16 @@ export function postProcessPieces(
 		if (!piece.externalId && !piece.isTransition)
 			throw new Meteor.Error(
 				400,
-				`Error in blueprint "${blueprintId}" externalId not set for piece in ${partId}! ("${innerContext.unhashId(
-					unprotectString(piece._id)
-				)}")`
+				`Error in blueprint "${blueprintId}" externalId not set for piece in ${partId}! ("${piece.name}")`
 			)
 		if (!allowNowForPiece && piece.enable.start === 'now')
 			throw new Meteor.Error(
 				400,
-				`Error in blueprint "${blueprintId}" piece cannot have a start of 'now' in ${partId}! ("${innerContext.unhashId(
-					unprotectString(piece._id)
-				)}")`
+				`Error in blueprint "${blueprintId}" piece cannot have a start of 'now' in ${partId}! ("${piece.name}")`
 			)
 
 		if (piece.content?.timelineObjects) {
 			piece.content.timelineObjects = postProcessTimelineObjects(
-				innerContext,
 				piece._id,
 				blueprintId,
 				piece.content.timelineObjects,
@@ -110,7 +103,6 @@ function isNow(enable: TSR.TSRTimelineObjBase['enable']): boolean {
 }
 
 export function postProcessTimelineObjects(
-	innerContext: ICommonContext,
 	pieceId: PieceId,
 	blueprintId: BlueprintId,
 	timelineObjects: TSR.TSRTimelineObjBase[],
@@ -124,21 +116,17 @@ export function postProcessTimelineObjects(
 			objectType: TimelineObjType.RUNDOWN,
 		}
 
-		if (!obj.id) obj.id = innerContext.getHashId(pieceId + '_' + i++)
+		if (!obj.id) obj.id = getHash(pieceId + '_' + i++)
 		if (isNow(obj.enable))
 			throw new Meteor.Error(
 				400,
-				`Error in blueprint "${blueprintId}" timelineObjs cannot have a start of 'now'! ("${innerContext.unhashId(
-					unprotectString(pieceId)
-				)}")`
+				`Error in blueprint "${blueprintId}" timelineObjs cannot have a start of 'now'! ("${obj.id}")`
 			)
 
 		if (timelineUniqueIds.has(obj.id))
 			throw new Meteor.Error(
 				400,
-				`Error in blueprint "${blueprintId}": ids of timelineObjs must be unique! ("${innerContext.unhashId(
-					obj.id
-				)}")`
+				`Error in blueprint "${blueprintId}": ids of timelineObjs must be unique! ("${obj.id}")`
 			)
 		timelineUniqueIds.add(obj.id)
 
@@ -153,7 +141,6 @@ export function postProcessTimelineObjects(
 }
 
 export function postProcessAdLibPieces(
-	innerContext: ICommonContext,
 	blueprintId: BlueprintId,
 	rundownId: RundownId,
 	partId: PartId | undefined,
@@ -171,7 +158,7 @@ export function postProcessAdLibPieces(
 		const piece: AdLibPiece = {
 			...orgAdlib,
 			_id: protectString(
-				innerContext.getHashId(`${blueprintId}_${partId}_adlib_piece_${orgAdlib.externalId}_${i}`)
+				getHash(`${rundownId}_${blueprintId}_${partId}_adlib_piece_${orgAdlib.externalId}_${i}`)
 			),
 			rundownId: rundownId,
 			partId: partId,
@@ -181,14 +168,11 @@ export function postProcessAdLibPieces(
 		if (!piece.externalId)
 			throw new Meteor.Error(
 				400,
-				`Error in blueprint "${blueprintId}" externalId not set for piece in ' + partId + '! ("${innerContext.unhashId(
-					unprotectString(piece._id)
-				)}")`
+				`Error in blueprint "${blueprintId}" externalId not set for piece in ${partId}! ("${piece.name}")`
 			)
 
 		if (piece.content && piece.content.timelineObjects) {
 			piece.content.timelineObjects = postProcessTimelineObjects(
-				innerContext,
 				piece._id,
 				blueprintId,
 				piece.content.timelineObjects,
@@ -207,7 +191,6 @@ export function postProcessAdLibPieces(
 }
 
 export function postProcessGlobalAdLibActions(
-	innerContext: ICommonContext,
 	blueprintId: BlueprintId,
 	rundownId: RundownId,
 	adlibActions: IBlueprintActionManifest[]
@@ -219,7 +202,7 @@ export function postProcessGlobalAdLibActions(
 		return literal<RundownBaselineAdLibAction>({
 			...action,
 			actionId: action.actionId,
-			_id: protectString(innerContext.getHashId(`${blueprintId}_global_adlib_action_${i}`)),
+			_id: protectString(getHash(`${rundownId}_${blueprintId}_global_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: undefined,
 			...processAdLibActionITranslatableMessages(action, blueprintId),
@@ -228,7 +211,6 @@ export function postProcessGlobalAdLibActions(
 }
 
 export function postProcessAdLibActions(
-	innerContext: ICommonContext,
 	blueprintId: BlueprintId,
 	rundownId: RundownId,
 	partId: PartId,
@@ -241,7 +223,7 @@ export function postProcessAdLibActions(
 		return literal<AdLibAction>({
 			...action,
 			actionId: action.actionId,
-			_id: protectString(innerContext.getHashId(`${blueprintId}_${partId}_adlib_action_${i}`)),
+			_id: protectString(getHash(`${rundownId}_${blueprintId}_${partId}_adlib_action_${i}`)),
 			rundownId: rundownId,
 			partId: partId,
 			...processAdLibActionITranslatableMessages(action, blueprintId),
@@ -253,16 +235,14 @@ export function postProcessStudioBaselineObjects(
 	studio: ReadonlyDeep<Studio>,
 	objs: TSR.TSRTimelineObjBase[]
 ): TimelineObjRundown[] {
-	const context = new CommonContext({ identifier: 'studio', name: 'studio' })
-	return postProcessTimelineObjects(context, protectString('studio'), studio.blueprintId!, objs, false)
+	return postProcessTimelineObjects(protectString('studio'), studio.blueprintId!, objs, false)
 }
 
 export function postProcessRundownBaselineItems(
-	innerContext: ICommonContext,
 	blueprintId: BlueprintId,
 	baselineItems: TSR.TSRTimelineObjBase[]
 ): TimelineObjGeneric[] {
-	return postProcessTimelineObjects(innerContext, protectString('baseline'), blueprintId, baselineItems, false)
+	return postProcessTimelineObjects(protectString('baseline'), blueprintId, baselineItems, false)
 }
 
 export function postProcessBucketAdLib(
@@ -277,7 +257,7 @@ export function postProcessBucketAdLib(
 	const piece: BucketAdLib = {
 		...itemOrig,
 		_id: protectString(
-			innerContext.getHashId(
+			getHash(
 				`${innerContext.showStyleCompound.showStyleVariantId}_${innerContext.studioIdProtected}_${bucketId}_bucket_adlib_${externalId}`
 			)
 		),
@@ -293,7 +273,6 @@ export function postProcessBucketAdLib(
 
 	if (piece.content && piece.content.timelineObjects) {
 		piece.content.timelineObjects = postProcessTimelineObjects(
-			innerContext,
 			piece._id,
 			blueprintId,
 			piece.content.timelineObjects,
@@ -316,7 +295,7 @@ export function postProcessBucketAction(
 	const action: BucketAdLibAction = {
 		...itemOrig,
 		_id: protectString(
-			innerContext.getHashId(
+			getHash(
 				`${innerContext.showStyleCompound.showStyleVariantId}_${innerContext.studioIdProtected}_${bucketId}_bucket_adlib_${externalId}`
 			)
 		),

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -119,7 +119,9 @@ export async function calculateSegmentsFromIngestData(
 			const context = new SegmentUserContext(
 				{
 					name: `getSegment=${ingestSegment.name}`,
-					identifier: `rundownId=${rundown._id},segmentId=${segmentId}`, // Note - this needs to not include the segmentId, because we want PieceIds to be persistant when moving across segments
+					// Note: this intentionally does not include the segmentId, as parts may be moved between segemnts later on
+					// This isn't much entropy, blueprints may want to add more for each Part they generate
+					identifier: `rundownId=${rundown._id}`,
 				},
 				cache.Studio.doc,
 				showStyle,

--- a/meteor/server/api/ingest/mosDevice/diff.ts
+++ b/meteor/server/api/ingest/mosDevice/diff.ts
@@ -77,7 +77,7 @@ export async function diffAndApplyChanges(
 	// Remove/orphan old segments
 	const segmentIdsToRemove = new Set(Object.keys(segmentDiff.removed).map((id) => getSegmentId(rundown._id, id)))
 	// We orphan it and queue for deletion. the commit phase will complete if possible
-	cache.Segments.update((s) => segmentIdsToRemove.has(s._id), {
+	const orphanedSegmentIds = cache.Segments.update((s) => segmentIdsToRemove.has(s._id), {
 		$set: {
 			orphaned: 'deleted',
 		},
@@ -93,7 +93,7 @@ export async function diffAndApplyChanges(
 	span?.end()
 	return literal<CommitIngestData>({
 		changedSegmentIds: segmentChanges.segments.map((s) => s._id),
-		removedSegmentIds: Array.from(segmentIdsToRemove),
+		removedSegmentIds: orphanedSegmentIds, // Only inform about the ones that werent renamed
 		renamedSegments: renamedSegments,
 
 		removeRundown: false,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

PieceIds are derived from among many other strings, the SegmentId.
This means that when we move a Part between segment via mosRoStoryMove, all the pieces will be purged and recreated with different ids.

* **What is the new behavior (if this is a feature change)?**

The ids are no longer based on the SegmentId, better matching how PartIds.

* **Other information**:

This has risk of duplicate id errors cropping up, so might be better for r38? @nytamin 

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
