### PR TITLE
chore: fix pre-commit script to work on Linux and macOS

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,10 +4,10 @@
 # lint meteor
 cd meteor
 
-if [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "cygwin"* ]]; then
+if echo "$OSTYPE" | grep -E -q "msys|cygwin" ; then
 	# we're on a windows machine
 	meteor.bat npx --no-install lint-staged
-elif [[ "$OSTYPE" == "darwin"* ]] && [[ $(arch) == "arm64" ]]; then
+elif echo "$OSTYPE" | grep -q "darwin" && arch | grep -q "arm64" ; then
 	# we're on an arm64 mac
 	arch -x86_64 meteor npx --no-install lint-staged
 else

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,12 +4,12 @@
 # lint meteor
 cd meteor
 
-# check if we're on a windows machine
-DUMMY=$(command -v where)
-IS_WINDOWS=$?
-
-if [ "$IS_WINDOWS" = "0" ]; then
+if [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "cygwin"* ]]; then
+	# we're on a windows machine
 	meteor.bat npx --no-install lint-staged
+elif [[ "$OSTYPE" == "darwin"* ]] && [[ $(arch) == "arm64" ]]; then
+	# we're on an arm64 mac
+	arch -x86_64 meteor npx --no-install lint-staged
 else
 	meteor npx --no-install lint-staged
 fi;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Pre-commit script fix


* **What is the current behavior?** (You can also link to an open issue here)
Failing on Linux and macOS.


* **What is the new behavior (if this is a feature change)?**
Use $OSTYPE to detect the OS.
Force meteor to run in x86 on ARM Macs. (to be removed when upgrading to meteor that supports arm64) 


* **Other information**:
Tested only on Windows and macOS, not tested on Linux.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
