### PR TITLE
fix: Hash triggers for core migrations

### DIFF
--- a/meteor/server/migration/1_37_0.ts
+++ b/meteor/server/migration/1_37_0.ts
@@ -3,7 +3,7 @@ import { addMigrationSteps } from './databaseMigration'
 import { ensureCollectionProperty } from './lib'
 import { CustomizableRegions } from '../../lib/collections/RundownLayouts'
 import { RundownPlaylist, RundownPlaylists } from '../../lib/collections/RundownPlaylists'
-import { generateTranslation as t, objectPathGet, protectString } from '../../lib/lib'
+import { generateTranslation as t, getHash, objectPathGet, protectString } from '../../lib/lib'
 import {
 	ClientActions,
 	IBlueprintTriggeredActions,
@@ -493,7 +493,7 @@ export const addSteps = addMigrationSteps('1.37.0', [
 			DEFAULT_CORE_TRIGGERS.forEach((triggeredAction) => {
 				TriggeredActions.insert({
 					...triggeredAction,
-					_id: protectString(triggeredAction._id),
+					_id: protectString(getHash(triggeredAction._id)),
 					showStyleBaseId: null,
 					_rundownVersionHash: '',
 				})

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -1,5 +1,7 @@
 import { addMigrationSteps } from './databaseMigration'
 import { CURRENT_SYSTEM_VERSION } from './currentSystemVersion'
+import { TriggeredActions } from '../../lib/collections/TriggeredActions'
+import { getHash, protectString, unprotectString } from '../../lib/lib'
 
 /*
  * **************************************************************************************
@@ -13,4 +15,25 @@ import { CURRENT_SYSTEM_VERSION } from './currentSystemVersion'
 // Release X
 export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 	// Add some migrations!
+	{
+		id: `TriggeredActions.core.fixIds`,
+		canBeRunAutomatically: true,
+		validate: () => {
+			const existingActions = TriggeredActions.find({ showStyleBaseId: null }).fetch()
+			return existingActions.some((action) => !!unprotectString(action._id).match(/^core_/))
+		},
+		migrate: () => {
+			const existingActions = TriggeredActions.find({ showStyleBaseId: null }).fetch()
+			for (const action of existingActions) {
+				let actionId = unprotectString(action._id)
+				if (!!actionId.match(/^core_/)) {
+					TriggeredActions.remove(action._id)
+					TriggeredActions.insert({
+						...action,
+						_id: protectString(getHash(actionId)),
+					})
+				}
+			}
+		},
+	},
 ])


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)

It's currently not possible for System migrations to change / remove the default keyboard shortcuts created by core migrations.

* **What is the new behavior (if this is a feature change)?**

The Id values of the default migrations are now hashed when they are created, making them match up with the Ids that the migration context will be searching for. A migration has also been added to migrate the existing actions to the new Id values, so that this change will take effect when R38 is deployed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
