### PR TITLE
feat: remove transformed collections

### DIFF
--- a/meteor/__mocks__/helpers/lib.ts
+++ b/meteor/__mocks__/helpers/lib.ts
@@ -1,6 +1,6 @@
 import * as _ from 'underscore'
 import { LogLevel, ProtectedString } from '../../lib/lib'
-import { AsyncTransformedCollection } from '../../lib/collections/lib'
+import { AsyncMongoCollection } from '../../lib/collections/lib'
 import { getLogLevel, setLogLevel } from '../../server/logging'
 
 /*
@@ -41,10 +41,10 @@ const METHOD_NAMES = [
  * Make mocks of all methods of a collection.
  * Important: This Remember to run resetMockupCollection() after the test
  */
-export function mockupCollection<A extends B, B extends { _id: ProtectedString<any> }>(
-	collection0: AsyncTransformedCollection<A, B>
-): AsyncTransformedCollection<A, B> & MockedCollection {
-	const collection = collection0 as AsyncTransformedCollection<A, B> & MockedCollection
+export function mockupCollection<DBInterface extends { _id: ProtectedString<any> }>(
+	collection0: AsyncMongoCollection<DBInterface>
+): AsyncMongoCollection<DBInterface> & MockedCollection {
+	const collection = collection0 as AsyncMongoCollection<DBInterface> & MockedCollection
 
 	_.each(METHOD_NAMES, (methodName) => {
 		collection['__original' + methodName] = collection[methodName]
@@ -60,8 +60,8 @@ export function mockupCollection<A extends B, B extends { _id: ProtectedString<a
 
 	return collection
 }
-export function resetMockupCollection<A extends B, B extends { _id: ProtectedString<any> }>(
-	collection: AsyncTransformedCollection<A, B>
+export function resetMockupCollection<DBInterface extends { _id: ProtectedString<any> }>(
+	collection: AsyncMongoCollection<DBInterface>
 ): void {
 	_.each(METHOD_NAMES, (methodName) => {
 		collection[methodName] = collection['__original' + methodName]

--- a/meteor/client/lib/__tests__/__snapshots__/rundown.test.ts.snap
+++ b/meteor/client/lib/__tests__/__snapshots__/rundown.test.ts.snap
@@ -12,10 +12,10 @@ Object {
   "isNextSegment": false,
   "parts": Array [
     Object {
-      "instance": PartInstance {
+      "instance": Object {
         "_id": "randomId9002_part0_0_tmp_instance",
         "isTemporary": true,
-        "part": Part {
+        "part": Object {
           "_id": "randomId9002_part0_0",
           "_rank": 0,
           "externalId": "MOCK_PART_0_0",
@@ -143,10 +143,10 @@ Object {
       "willProbablyAutoNext": false,
     },
     Object {
-      "instance": PartInstance {
+      "instance": Object {
         "_id": "randomId9002_part0_1_tmp_instance",
         "isTemporary": true,
-        "part": Part {
+        "part": Object {
           "_id": "randomId9002_part0_1",
           "_rank": 1,
           "externalId": "MOCK_PART_0_1",

--- a/meteor/client/lib/__tests__/rundown.test.ts
+++ b/meteor/client/lib/__tests__/rundown.test.ts
@@ -5,7 +5,11 @@ import {
 	setupDefaultRundownPlaylist,
 } from '../../../__mocks__/helpers/database'
 import { RundownUtils } from '../rundown'
-import { RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 
 describe('client/lib/rundown', () => {
 	let env: DefaultEnvironment
@@ -19,11 +23,11 @@ describe('client/lib/rundown', () => {
 		const playlist = RundownPlaylists.findOne(playlistId)
 		if (!playlist) throw new Error('Rundown not found')
 
-		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
+		const { currentPartInstance, nextPartInstance } =
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
-		const rundowns = playlist.getRundowns()
-		const segments = playlist.getSegments()
-		const parts = playlist.getAllOrderedParts()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
+		const { parts, segments } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
 		const rundown = rundowns[0]
 		const segment = segments[0]
 

--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -21,7 +21,7 @@ import {
 	getSegmentsWithPartInstances,
 } from '../../lib/Rundown'
 import { PartInstance } from '../../lib/collections/PartInstances'
-import { DBSegment, Segment, SegmentId, Segments } from '../../lib/collections/Segments'
+import { Segment, SegmentId, Segments } from '../../lib/collections/Segments'
 import { RundownPlaylist } from '../../lib/collections/RundownPlaylists'
 import { ShowStyleBase, ShowStyleBaseId } from '../../lib/collections/ShowStyleBases'
 import { literal, normalizeArray, getCurrentTime, applyToArray } from '../../lib/lib'

--- a/meteor/client/lib/rundown.ts
+++ b/meteor/client/lib/rundown.ts
@@ -249,8 +249,8 @@ export namespace RundownUtils {
 	export function getResolvedSegment(
 		showStyleBase: ShowStyleBase,
 		playlist: RundownPlaylist,
-		rundown: Rundown,
-		segment: DBSegment,
+		rundown: Pick<Rundown, '_id' | 'showStyleBaseId'>,
+		segment: Segment,
 		segmentsBeforeThisInRundownSet: Set<SegmentId>,
 		rundownsBeforeThisInPlaylist: RundownId[],
 		rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,

--- a/meteor/client/lib/triggers/TriggersHandler.tsx
+++ b/meteor/client/lib/triggers/TriggersHandler.tsx
@@ -7,7 +7,12 @@ import { PubSub } from '../../../lib/api/pubsub'
 import { ShowStyleBase, ShowStyleBaseId, ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { TriggeredActionId, TriggeredActions } from '../../../lib/collections/TriggeredActions'
 import { useSubscription, useTracker } from '../ReactMeteorData/ReactMeteorData'
-import { RundownPlaylist, RundownPlaylistId, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylistId,
+	RundownPlaylists,
+} from '../../../lib/collections/RundownPlaylists'
 import { ISourceLayer, SomeAction, TriggerType } from '@sofie-automation/blueprints-integration'
 import { RundownId } from '../../../lib/collections/Rundowns'
 import {
@@ -368,7 +373,7 @@ export const TriggersHandler: React.FC<IProps> = function TriggersHandler(
 				},
 			})
 			if (playlist) {
-				return playlist.getRundownUnorderedIDs()
+				return RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
 			}
 			return []
 		}, [props.rundownPlaylistId]) || []

--- a/meteor/client/ui/ClockView/PresenterScreen.tsx
+++ b/meteor/client/ui/ClockView/PresenterScreen.tsx
@@ -2,7 +2,12 @@ import * as React from 'react'
 import ClassNames from 'classnames'
 import { DBSegment, Segment } from '../../../lib/collections/Segments'
 import { PartUi } from '../SegmentTimeline/SegmentTimelineContainer'
-import { RundownPlaylistId, RundownPlaylist, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylistId,
+	RundownPlaylist,
+	RundownPlaylists,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 import { ShowStyleBase, ShowStyleBaseId, ShowStyleBases } from '../../../lib/collections/ShowStyleBases'
 import { Rundown, RundownId, Rundowns } from '../../../lib/collections/Rundowns'
 import { withTranslation, WithTranslation } from 'react-i18next'
@@ -110,7 +115,7 @@ function getShowStyleBaseIdSegmentPartUi(
 
 	const segmentIndex = orderedSegmentsAndParts.segments.findIndex((s) => s._id === partInstance.segmentId)
 	if (currentRundown && segmentIndex >= 0) {
-		const rundownOrder = playlist.getRundownIDs()
+		const rundownOrder = RundownPlaylistCollectionUtil.getRundownIDs(playlist)
 		const rundownIndex = rundownOrder.indexOf(partInstance.rundownId)
 		showStyleBase = ShowStyleBases.findOne(showStyleBaseId)
 		showStyleVariant = ShowStyleVariants.findOne(showStyleVariantId)
@@ -188,15 +193,15 @@ export const getPresenterScreenReactive = (props: RundownOverviewProps): Rundown
 	const presenterLayoutId = protectString((params['presenterLayout'] as string) || '')
 
 	if (playlist) {
-		rundowns = playlist.getRundowns()
-		const orderedSegmentsAndParts = playlist.getSegmentsAndPartsSync()
+		rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
+		const orderedSegmentsAndParts = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
 		rundownIds = rundowns.map((rundown) => rundown._id)
 		const rundownsToShowstyles: Map<RundownId, ShowStyleBaseId> = new Map()
 		for (const rundown of rundowns) {
 			rundownsToShowstyles.set(rundown._id, rundown.showStyleBaseId)
 		}
 		showStyleBaseIds = rundowns.map((rundown) => rundown.showStyleBaseId)
-		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
+		const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 		const partInstance = currentPartInstance || nextPartInstance
 		if (partInstance) {
 			// This is to register a reactive dependency on Rundown-spanning PieceInstances, that we may miss otherwise.
@@ -297,35 +302,23 @@ export class PresenterScreenBase extends MeteorReactComponent<
 				fields: {
 					_id: 1,
 				},
-			}) as Pick<RundownPlaylist, '_id' | 'getRundownIDs' | 'getRundowns'> | undefined
+			}) as Pick<RundownPlaylist, '_id'> | undefined
 			if (playlist) {
 				this.subscribe(PubSub.rundowns, {
 					playlistId: playlist._id,
 				})
-				const rundowns = playlist.getRundowns(undefined, {
-					fields: {
-						_id: 1,
-						showStyleBaseId: 1,
-						showStyleVariantId: 1,
-					},
-				}) as Pick<Rundown, '_id' | 'showStyleBaseId' | 'showStyleVariantId'>[]
 
 				this.autorun(() => {
-					const rundownIds = playlist.getRundownIDs()
-					const showStyleBaseIds = (
-						playlist.getRundowns(undefined, {
-							fields: {
-								showStyleBaseId: 1,
-							},
-						}) as Pick<Rundown, 'showStyleBaseId'>[]
-					).map((r) => r.showStyleBaseId)
-					const showStyleVariantIds = (
-						playlist!.getRundowns(undefined, {
-							fields: {
-								showStyleVariantId: 1,
-							},
-						}) as Pick<Rundown, 'showStyleVariantId'>[]
-					).map((r) => r.showStyleVariantId)
+					const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist, undefined, {
+						fields: {
+							_id: 1,
+							showStyleBaseId: 1,
+							showStyleVariantId: 1,
+						},
+					}) as Array<Pick<Rundown, '_id' | 'showStyleBaseId' | 'showStyleVariantId'>>
+					const rundownIds = rundowns.map((r) => r._id)
+					const showStyleBaseIds = rundowns.map((r) => r.showStyleBaseId)
+					const showStyleVariantIds = rundowns.map((r) => r.showStyleVariantId)
 
 					this.subscribe(PubSub.segments, {
 						rundownId: { $in: rundownIds },
@@ -349,7 +342,7 @@ export class PresenterScreenBase extends MeteorReactComponent<
 					})
 					this.subscribe(PubSub.rundownLayouts, {
 						showStyleBaseId: {
-							$in: rundowns.map((i) => i.showStyleBaseId),
+							$in: showStyleBaseIds,
 						},
 					})
 
@@ -362,17 +355,11 @@ export class PresenterScreenBase extends MeteorReactComponent<
 								previousPartInstanceId: 1,
 							},
 						}) as
-							| Pick<
-									RundownPlaylist,
-									| '_id'
-									| 'currentPartInstanceId'
-									| 'nextPartInstanceId'
-									| 'previousPartInstanceId'
-									| 'getSelectedPartInstances'
-							  >
+							| Pick<RundownPlaylist, '_id' | 'currentPartInstanceId' | 'nextPartInstanceId' | 'previousPartInstanceId'>
 							| undefined
 						if (playlistR) {
-							const { nextPartInstance, currentPartInstance } = playlistR.getSelectedPartInstances()
+							const { nextPartInstance, currentPartInstance } =
+								RundownPlaylistCollectionUtil.getSelectedPartInstances(playlistR)
 							if (currentPartInstance) {
 								this.subscribe(PubSub.pieceInstances, {
 									rundownId: currentPartInstance.rundownId,

--- a/meteor/client/ui/Prompter/PrompterView.tsx
+++ b/meteor/client/ui/Prompter/PrompterView.tsx
@@ -5,7 +5,12 @@ import ClassNames from 'classnames'
 import { Meteor } from 'meteor/meteor'
 import { Route } from 'react-router-dom'
 import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylists,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 import { Studios, Studio, StudioId } from '../../../lib/collections/Studios'
 import { parse as queryStringParse } from 'query-string'
 
@@ -596,7 +601,7 @@ export const Prompter = translateWithTracker<IPrompterProps, {}, IPrompterTracke
 			this.autorun(() => {
 				const playlist = RundownPlaylists.findOne(this.props.rundownPlaylistId)
 				if (playlist) {
-					const rundownIDs = playlist.getRundownIDs()
+					const rundownIDs = RundownPlaylistCollectionUtil.getRundownIDs(playlist)
 					this.subscribe(PubSub.segments, {
 						rundownId: { $in: rundownIDs },
 					})

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -13,7 +13,11 @@ import { PubSub } from '../../lib/api/pubsub'
 import { StatusResponse } from '../../lib/api/systemStatus'
 import { GENESIS_SYSTEM_VERSION, getCoreSystem, ICoreSystem } from '../../lib/collections/CoreSystem'
 import { RundownLayoutBase, RundownLayouts } from '../../lib/collections/RundownLayouts'
-import { RundownPlaylist, RundownPlaylists } from '../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylists,
+} from '../../lib/collections/RundownPlaylists'
 import { Rundown, RundownId, Rundowns } from '../../lib/collections/Rundowns'
 import { getAllowConfigure, getHelpMode } from '../lib/localStorage'
 import { NotificationCenter, Notification, NoticeLevel } from '../lib/notifications/notifications'
@@ -106,7 +110,7 @@ export const RundownList = translateWithTracker((): IRundownsListProps => {
 		rundownPlaylists: RundownPlaylists.find({}, { sort: { created: -1 } })
 			.fetch()
 			.map((playlist: RundownPlaylist) => {
-				const rundowns = playlist.getRundowns()
+				const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 
 				const airStatuses: string[] = []
 				const statuses: string[] = []

--- a/meteor/client/ui/RundownList/RundownListItem.tsx
+++ b/meteor/client/ui/RundownList/RundownListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Rundown, RundownId } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownCollectionUtil, RundownId } from '../../../lib/collections/Rundowns'
 import { ShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 import { Studio, Studios } from '../../../lib/collections/Studios'
 import { getAllowConfigure, getAllowService, getAllowStudio } from '../../lib/localStorage'
@@ -159,12 +159,12 @@ export const RundownListItem = translateWithTracker<IRundownListItemProps, {}, I
 			// this is fine, we'll probably have it eventually and the component can render without it
 		}
 		try {
-			showStyle = props.rundown.getShowStyleBase()
+			showStyle = RundownCollectionUtil.getShowStyleBase(props.rundown)
 		} catch (e) {
 			// this is fine, we'll probably have it eventually and the component can render without it
 		}
 		try {
-			showStyleVariant = props.rundown.getShowStyleVariant()
+			showStyleVariant = RundownCollectionUtil.getShowStyleVariant(props.rundown)
 		} catch (e) {
 			// this is fine, we'll probably have it eventually and the component can render without it
 		}

--- a/meteor/client/ui/RundownList/RundownListItemView.tsx
+++ b/meteor/client/ui/RundownList/RundownListItemView.tsx
@@ -2,7 +2,7 @@ import Tooltip from 'rc-tooltip'
 import React, { ReactElement } from 'react'
 import { withTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { Rundown } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownCollectionUtil } from '../../../lib/collections/Rundowns'
 import { getAllowStudio } from '../../lib/localStorage'
 import { Translated } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { RundownUtils } from '../../lib/rundown'
@@ -50,7 +50,7 @@ export default withTranslation()(function RundownListItemView(props: Translated<
 		isOnlyRundownInPlaylist,
 	} = props
 
-	const playlist = rundown.getRundownPlaylist()
+	const playlist = RundownCollectionUtil.getRundownPlaylist(rundown)
 
 	const classNames = props.classNames.slice()
 	classNames.push('rundown-list-item')

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -14,7 +14,12 @@ import Escape from 'react-escape'
 import * as i18next from 'i18next'
 import Tooltip from 'rc-tooltip'
 import { NavLink, Route, Prompt } from 'react-router-dom'
-import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylists,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../lib/collections/RundownPlaylists'
 import { Rundown, Rundowns, RundownHoldState, RundownId } from '../../lib/collections/Rundowns'
 import { Segment, SegmentId } from '../../lib/collections/Segments'
 import { Studio, Studios, StudioRouteSet } from '../../lib/collections/Studios'
@@ -1118,7 +1123,7 @@ interface IState {
 }
 
 type MatchedSegment = {
-	rundown: Rundown
+	rundown: Pick<Rundown, '_id' | 'name' | 'timing' | 'showStyleBaseId' | 'endOfRundownIsShowBreak'>
 	segments: Segment[]
 	segmentIdsBeforeEachSegment: Set<SegmentId>[]
 }
@@ -1168,8 +1173,12 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 	if (playlist) {
 		studio = Studios.findOne({ _id: playlist.studioId })
-		rundowns = memoizedIsolatedAutorun((_playlistId) => playlist.getRundowns(), 'playlist.getRundowns', playlistId)
-		;({ currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances())
+		rundowns = memoizedIsolatedAutorun(
+			(_playlistId) => RundownPlaylistCollectionUtil.getRundowns(playlist),
+			'playlist.getRundowns',
+			playlistId
+		)
+		;({ currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist))
 		const somePartInstance = currentPartInstance || nextPartInstance
 		if (somePartInstance) {
 			currentRundown = rundowns.find((rundown) => rundown._id === somePartInstance?.rundownId)
@@ -1196,24 +1205,22 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		rundowns,
 		currentRundown,
 		matchedSegments: playlist
-			? playlist
-					.getRundownsAndSegments({
-						isHidden: {
-							$ne: true,
-						},
-					})
-					.map((input, rundownIndex, rundownArray) => ({
-						...input,
-						segmentIdsBeforeEachSegment: input.segments.map(
-							(segment, segmentIndex, segmentArray) =>
-								new Set([
-									...(_.flatten(
-										rundownArray.slice(0, rundownIndex).map((match) => match.segments.map((segment) => segment._id))
-									) as SegmentId[]),
-									...segmentArray.slice(0, segmentIndex).map((segment) => segment._id),
-								])
-						),
-					}))
+			? RundownPlaylistCollectionUtil.getRundownsAndSegments(playlist, {
+					isHidden: {
+						$ne: true,
+					},
+			  }).map((input, rundownIndex, rundownArray) => ({
+					...input,
+					segmentIdsBeforeEachSegment: input.segments.map(
+						(segment, segmentIndex, segmentArray) =>
+							new Set([
+								...(_.flatten(
+									rundownArray.slice(0, rundownIndex).map((match) => match.segments.map((segment) => segment._id))
+								) as SegmentId[]),
+								...segmentArray.slice(0, segmentIndex).map((segment) => segment._id),
+							])
+					),
+			  }))
 			: [],
 		rundownsToShowstyles,
 		playlist,
@@ -1478,9 +1485,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 					fields: {
 						_id: 1,
 					},
-				}) as Pick<RundownPlaylist, '_id' | 'getRundowns'> | undefined
+				}) as Pick<RundownPlaylist, '_id'> | undefined
 				if (playlist) {
-					const rundowns = playlist.getRundowns(undefined, {
+					const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist, undefined, {
 						fields: {
 							_id: 1,
 							showStyleBaseId: 1,
@@ -1551,17 +1558,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						previousPartInstanceId: 1,
 					},
 				}) as
-					| Pick<
-							RundownPlaylist,
-							| '_id'
-							| 'currentPartInstanceId'
-							| 'nextPartInstanceId'
-							| 'previousPartInstanceId'
-							| 'getRundownUnorderedIDs'
-					  >
+					| Pick<RundownPlaylist, '_id' | 'currentPartInstanceId' | 'nextPartInstanceId' | 'previousPartInstanceId'>
 					| undefined
 				if (playlist) {
-					const rundownIds = playlist.getRundownUnorderedIDs()
+					const rundownIds = RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist)
 					// Use Meteor.subscribe so that this subscription doesn't mess with this.subscriptionsReady()
 					// it's run in this.autorun, so the subscription will be stopped along with the autorun,
 					// so we don't have to manually clean up after ourselves.
@@ -2665,7 +2665,7 @@ function handleRundownPlaylistReloadResponse(t: i18next.TFunction, result: Reloa
 	if (firstRundownId) {
 		const firstRundown = Rundowns.findOne(firstRundownId)
 		const playlist = RundownPlaylists.findOne(firstRundown?.playlistId)
-		const allRundownIds = playlist?.getRundownUnorderedIDs() || []
+		const allRundownIds = playlist ? RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist) : []
 		if (
 			allRundownIds.length > 0 &&
 			_.difference(

--- a/meteor/client/ui/RundownView/RundownDividerHeader.tsx
+++ b/meteor/client/ui/RundownView/RundownDividerHeader.tsx
@@ -9,7 +9,7 @@ import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
 
 interface IProps {
-	rundown: Rundown
+	rundown: Pick<Rundown, '_id' | 'name' | 'timing'>
 	playlist: RundownPlaylist
 }
 

--- a/meteor/client/ui/RundownView/RundownNotifier.tsx
+++ b/meteor/client/ui/RundownView/RundownNotifier.tsx
@@ -32,7 +32,11 @@ import { TrackedNote } from '../../../lib/api/notes'
 import { PieceId, Piece } from '../../../lib/collections/Pieces'
 import { PeripheralDevicesAPI } from '../../lib/clientAPI'
 import { handleRundownReloadResponse } from '../RundownView'
-import { RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
 import { getSegmentPartNotes } from '../../../lib/rundownNotifications'
 import { RankedNote, IMediaObjectIssue, MEDIASTATUS_POLL_INTERVAL } from '../../../lib/api/rundownNotifications'
@@ -707,7 +711,7 @@ class RundownViewNotifier extends WithManagedTracker {
 				let newNotification: Notification | undefined = undefined
 				if (versionMismatch && versionMismatch.length) {
 					const playlist = RundownPlaylists.findOne(playlistId)
-					const firstRundown = playlist ? _.first(playlist.getRundowns()) : undefined
+					const firstRundown = playlist ? _.first(RundownPlaylistCollectionUtil.getRundowns(playlist)) : undefined
 
 					newNotification = new Notification(
 						'rundown_importVersions',

--- a/meteor/client/ui/RundownView/RundownOverview.tsx
+++ b/meteor/client/ui/RundownView/RundownOverview.tsx
@@ -10,7 +10,12 @@ import { withTiming, WithTiming } from './RundownTiming/withTiming'
 import { ErrorBoundary } from '../../lib/ErrorBoundary'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
-import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylist,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 import { findPartInstanceOrWrapToTemporary } from '../../../lib/collections/PartInstances'
 import { PlaylistTiming } from '../../../lib/rundown/rundownTiming'
 
@@ -39,60 +44,58 @@ export const RundownOverview = withTracker<RundownOverviewProps, RundownOverview
 		let segments: Array<SegmentUi> = []
 		if (playlist) {
 			const segmentMap = new Map<SegmentId, SegmentUi>()
-			segments = playlist
-				.getSegments(
-					{
-						isHidden: {
-							$ne: true,
-						},
+			segments = RundownPlaylistCollectionUtil.getSegments(
+				playlist,
+				{
+					isHidden: {
+						$ne: true,
 					},
-					{
-						fields: {
-							rundownId: 1,
-							name: 1,
-						},
-					}
-				)
-				.map((segment) => {
-					const segmentUi = literal<SegmentUi>({
-						...segment,
-						items: [],
-					})
-					segmentMap.set(segment._id, segmentUi)
-					return segmentUi
+				},
+				{
+					fields: {
+						rundownId: 1,
+						name: 1,
+					},
+				}
+			).map((segment) => {
+				const segmentUi = literal<SegmentUi>({
+					...segment,
+					items: [],
 				})
+				segmentMap.set(segment._id, segmentUi)
+				return segmentUi
+			})
 
-			const partInstancesMap = playlist.getActivePartInstancesMap()
-			playlist
-				.getUnorderedParts(
-					{
-						segmentId: {
-							$in: Array.from(segmentMap.keys()),
-						},
+			const partInstancesMap = RundownPlaylistCollectionUtil.getActivePartInstancesMap(playlist)
+			RundownPlaylistCollectionUtil.getUnorderedParts(
+				playlist,
+				{
+					segmentId: {
+						$in: Array.from(segmentMap.keys()),
 					},
-					{
-						fields: {
-							_rank: 1,
-							title: 1,
-							rundownId: 1,
-							segmentId: 1,
-							expectedDuration: 1,
-						},
-					}
-				)
-				.forEach((part) => {
-					const instance = findPartInstanceOrWrapToTemporary(partInstancesMap, part)
-					const partUi = literal<PartUi>({
-						partId: part._id,
-						instance,
-						pieces: [],
-						renderedDuration: 0,
-						startsAt: 0,
-						willProbablyAutoNext: false,
-					})
-					const segment = segmentMap.get(part.segmentId)
-					if (segment) segment.items.push(partUi)
+				},
+				{
+					fields: {
+						_rank: 1,
+						title: 1,
+						rundownId: 1,
+						segmentId: 1,
+						expectedDuration: 1,
+					},
+				}
+			).forEach((part) => {
+				const instance = findPartInstanceOrWrapToTemporary(partInstancesMap, part)
+				const partUi = literal<PartUi>({
+					partId: part._id,
+					instance,
+					pieces: [],
+					renderedDuration: 0,
+					startsAt: 0,
+					willProbablyAutoNext: false,
 				})
+				const segment = segmentMap.get(part.segmentId)
+				if (segment) segment.items.push(partUi)
+			})
 
 			segmentMap.forEach((segment) => {
 				// Sort parts by rank

--- a/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/RundownTimingProvider.tsx
@@ -5,7 +5,7 @@ import { withTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { Part, PartId } from '../../../../lib/collections/Parts'
 import { getCurrentTime } from '../../../../lib/lib'
 import { MeteorReactComponent } from '../../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../../lib/collections/RundownPlaylists'
 import { PartInstance } from '../../../../lib/collections/PartInstances'
 import { RundownTiming, TimeEventArgs } from './RundownTiming'
 import { RundownTimingCalculator, RundownTimingContext } from '../../../../lib/rundown/rundownTiming'
@@ -59,10 +59,10 @@ export const RundownTimingProvider = withTracker<
 	const partInstancesMap = new Map<PartId, PartInstance>()
 	let currentRundown: Rundown | undefined
 	if (props.playlist) {
-		rundowns = props.playlist.getRundowns()
-		const { parts: incomingParts } = props.playlist.getSegmentsAndPartsSync()
+		rundowns = RundownPlaylistCollectionUtil.getRundowns(props.playlist)
+		const { parts: incomingParts } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(props.playlist)
 		parts = incomingParts
-		const partInstances = props.playlist.getActivePartInstances()
+		const partInstances = RundownPlaylistCollectionUtil.getActivePartInstances(props.playlist)
 
 		const currentPartInstance = partInstances.find((p) => p._id === props.playlist!.currentPartInstanceId)
 		currentRundown = currentPartInstance ? rundowns.find((r) => r._id === currentPartInstance.rundownId) : rundowns[0]

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -29,7 +29,7 @@ import { Settings } from '../../../lib/Settings'
 import { IContextMenuContext } from '../RundownView'
 import { literal, protectString, unprotectString } from '../../../lib/lib'
 import { SegmentId } from '../../../lib/collections/Segments'
-import { PartId } from '../../../lib/collections/Parts'
+import { isPartPlayable, PartId } from '../../../lib/collections/Parts'
 import { contextMenuHoldToDisplayTime } from '../../lib/lib'
 import { WarningIconSmall, CriticalIconSmall } from '../../lib/ui/icons/notifications'
 import RundownViewEventBus, { RundownViewEvents, HighlightEvent } from '../RundownView/RundownViewEventBus'
@@ -665,7 +665,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 	getSegmentContext = (_props) => {
 		const ctx = literal<IContextMenuContext>({
 			segment: this.props.segment,
-			part: this.props.parts.find((p) => p.instance.part.isPlayable()) || null,
+			part: this.props.parts.find((p) => isPartPlayable(p.instance.part)) || null,
 		})
 
 		if (this.props.onContextMenu && typeof this.props.onContextMenu === 'function') {

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -71,8 +71,8 @@ function filterLayerMappings(
 	return result
 }
 
-function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, DocClass extends DBInterface>(
-	collection: TransformedCollection<DocClass, DBInterface>,
+function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }>(
+	collection: TransformedCollection<DBInterface, DBInterface>,
 	object: DBInterface,
 	item: BasicConfigManifestEntry,
 	attribute: string,
@@ -214,9 +214,8 @@ function getEditAttribute<DBInterface extends { _id: ProtectedString<any> }, Doc
 }
 
 interface IConfigManifestSettingsProps<
-	TCol extends TransformedCollection<DocClass, DBInterface>,
-	DBInterface extends { _id: ProtectedString<any> },
-	DocClass extends DBInterface
+	TCol extends TransformedCollection<DBInterface, DBInterface>,
+	DBInterface extends { _id: ProtectedString<any> }
 > {
 	manifest: ConfigManifestEntry[]
 
@@ -239,9 +238,8 @@ interface IConfigManifestSettingsState {
 }
 
 interface IConfigManifestTableProps<
-	TCol extends TransformedCollection<DocClass, DBInterface>,
-	DBInterface extends { _id: ProtectedString<any> },
-	DocClass extends DBInterface
+	TCol extends TransformedCollection<DBInterface, DBInterface>,
+	DBInterface extends { _id: ProtectedString<any> }
 > {
 	item: ConfigManifestEntryTable
 	baseAttribute: string
@@ -261,14 +259,10 @@ interface IConfigManifestTableState {
 }
 
 export class ConfigManifestTable<
-	TCol extends TransformedCollection<DocClass, DBInterface>,
-	DBInterface extends DBObj,
-	DocClass extends DBInterface
-> extends React.Component<
-	Translated<IConfigManifestTableProps<TCol, DBInterface, DocClass>>,
-	IConfigManifestTableState
-> {
-	constructor(props: Translated<IConfigManifestTableProps<TCol, DBInterface, DocClass>>) {
+	TCol extends TransformedCollection<DBInterface, DBInterface>,
+	DBInterface extends DBObj
+> extends React.Component<Translated<IConfigManifestTableProps<TCol, DBInterface>>, IConfigManifestTableState> {
+	constructor(props: Translated<IConfigManifestTableProps<TCol, DBInterface>>) {
 		super(props)
 
 		this.state = {
@@ -534,14 +528,10 @@ export class ConfigManifestTable<
 }
 
 export class ConfigManifestSettings<
-	TCol extends TransformedCollection<DocClass, DBInterface>,
-	DBInterface extends DBObj,
-	DocClass extends DBInterface
-> extends React.Component<
-	Translated<IConfigManifestSettingsProps<TCol, DBInterface, DocClass>>,
-	IConfigManifestSettingsState
-> {
-	constructor(props: Translated<IConfigManifestSettingsProps<TCol, DBInterface, DocClass>>) {
+	TCol extends TransformedCollection<DBInterface, DBInterface>,
+	DBInterface extends DBObj
+> extends React.Component<Translated<IConfigManifestSettingsProps<TCol, DBInterface>>, IConfigManifestSettingsState> {
+	constructor(props: Translated<IConfigManifestSettingsProps<TCol, DBInterface>>) {
 		super(props)
 
 		this.state = {

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -22,6 +22,7 @@ import { translateWithTracker, Translated } from '../../lib/ReactMeteorData/Reac
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications'
 import { MeteorCall } from '../../../lib/api/methods'
+import { RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 
 interface IState {}
 
@@ -179,7 +180,7 @@ export const AdLibRegionPanel = translateWithTracker<
 	AdLibFetchAndFilterProps & IAdLibRegionPanelTrackedProps
 >(
 	(props: Translated<IAdLibPanelProps & IAdLibRegionPanelProps>) => {
-		const studio = props.playlist.getStudio()
+		const studio = RundownPlaylistCollectionUtil.getStudio(props.playlist)
 		const { unfinishedAdLibIds, unfinishedTags } = getUnfinishedPieceInstancesGrouped(
 			props.playlist,
 			props.showStyleBase

--- a/meteor/client/ui/Shelf/BucketPanel.tsx
+++ b/meteor/client/ui/Shelf/BucketPanel.tsx
@@ -45,7 +45,7 @@ import {
 import { BucketAdLib, BucketAdLibs } from '../../../lib/collections/BucketAdlibs'
 import { Bucket, BucketId } from '../../../lib/collections/Buckets'
 import { Events as MOSEvents } from '../../lib/data/mos/plugin-support'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../lib/api/methods'
 import { DragDropItemTypes } from '../DragDropItemTypes'
 import { PieceId } from '../../../lib/collections/Pieces'
@@ -271,7 +271,8 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 			}
 		}
 		if (showStyleVariantId === undefined) {
-			const rundown = props.playlist.getRundowns(
+			const rundown = RundownPlaylistCollectionUtil.getRundowns(
+				props.playlist,
 				{},
 				{
 					fields: {
@@ -317,7 +318,7 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 			.sort((a, b) => a._rank - b._rank || a.name.localeCompare(b.name))
 		return literal<IBucketPanelTrackedProps>({
 			adLibPieces: allBucketItems,
-			studio: props.playlist.getStudio(),
+			studio: RundownPlaylistCollectionUtil.getStudio(props.playlist),
 			unfinishedAdLibIds,
 			unfinishedTags,
 			showStyleVariantId,
@@ -367,9 +368,10 @@ export const BucketPanel = translateWithTracker<Translated<IBucketPanelProps>, I
 						_id: this.props.playlist.studioId,
 					})
 					this.autorun(() => {
-						const showStyles = this.props.playlist
-							.getRundowns()
-							.map((rundown) => [rundown.showStyleBaseId, rundown.showStyleVariantId])
+						const showStyles = RundownPlaylistCollectionUtil.getRundowns(this.props.playlist).map((rundown) => [
+							rundown.showStyleBaseId,
+							rundown.showStyleVariantId,
+						])
 						const showStyleBases = showStyles.map((showStyle) => showStyle[0])
 						const showStyleVariants = showStyles.map((showStyle) => showStyle[1])
 						this.subscribe(PubSub.bucketAdLibPieces, {

--- a/meteor/client/ui/Shelf/DashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/DashboardPanel.tsx
@@ -35,7 +35,7 @@ import { ContextMenuTrigger } from '@jstarpl/react-contextmenu'
 import { setShelfContextMenuContext, ContextType } from './ShelfContextMenu'
 import { RundownUtils } from '../../lib/rundown'
 import { getUnfinishedPieceInstancesReactive } from '../../lib/rundownLayouts'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { DBShowStyleBase } from '../../../lib/collections/ShowStyleBases'
 
 interface IState {
@@ -154,7 +154,7 @@ export class DashboardPanelInner extends MeteorReactComponent<
 
 	componentDidMount() {
 		this.autorun(() => {
-			const rundownIds = this.props.playlist.getRundownIDs()
+			const rundownIds = RundownPlaylistCollectionUtil.getRundownIDs(this.props.playlist)
 			if (rundownIds.length > 0) {
 				this.subscribe(PubSub.pieceInstances, {
 					rundownId: {
@@ -723,7 +723,7 @@ export const DashboardPanel = translateWithTracker<
 		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist)
 		return {
 			...fetchAndFilter(props),
-			studio: props.playlist.getStudio(),
+			studio: RundownPlaylistCollectionUtil.getStudio(props.playlist),
 			unfinishedAdLibIds,
 			unfinishedTags,
 			nextAdLibIds,

--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -11,7 +11,11 @@ import {
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { dashboardElementStyle } from './DashboardPanel'
 import { literal, protectString } from '../../../lib/lib'
-import { RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylistId,
+} from '../../../lib/collections/RundownPlaylists'
 import { PartInstanceId, PartInstances, PartInstance } from '../../../lib/collections/PartInstances'
 import { parseMosPluginMessageXml, MosPluginMessage, fixMosData } from '../../lib/parsers/mos/mosXml2Js'
 import {
@@ -211,7 +215,7 @@ export const ExternalFramePanel = withTranslation()(
 
 				targetRundown = Rundowns.findOne(currentPart.rundownId)
 			} else {
-				targetRundown = playlist.getRundowns()[0]
+				targetRundown = RundownPlaylistCollectionUtil.getRundowns(playlist)[0]
 			}
 
 			if (!targetRundown) {

--- a/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
+++ b/meteor/client/ui/Shelf/GlobalAdLibPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Meteor } from 'meteor/meteor'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/react-meteor-data'
 import { withTranslation } from 'react-i18next'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { Rundown } from '../../../lib/collections/Rundowns'
 import { RundownBaselineAdLibPieces } from '../../../lib/collections/RundownBaselineAdLibPieces'
 import { AdLibListItem, IAdLibListItem } from './AdLibListItem'
@@ -260,7 +260,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 	let currentRundown: Rundown | undefined = undefined
 
 	if (props.playlist) {
-		const rundowns = props.playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(props.playlist)
 		const rMap = normalizeArray(rundowns, '_id')
 		currentRundown = rundowns[0]
 		const partInstanceId = props.playlist.currentPartInstanceId || props.playlist.nextPartInstanceId
@@ -361,7 +361,7 @@ export const GlobalAdLibPanel = translateWithTracker<IProps, IState, ITrackedPro
 		sourceLayerLookup,
 		rundownAdLibs,
 		currentRundown,
-		studio: props.playlist.getStudio(),
+		studio: RundownPlaylistCollectionUtil.getStudio(props.playlist),
 	}
 })(
 	class GlobalAdLibPanel extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {

--- a/meteor/client/ui/Shelf/PartNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PartNamePanel.tsx
@@ -7,7 +7,7 @@ import {
 	RundownLayoutPartName,
 } from '../../../lib/collections/RundownLayouts'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
@@ -77,7 +77,9 @@ export const PartNamePanel = translateWithTracker<IPartNamePanelProps, IState, I
 		let instanceToShow: IFoundPieceInstance | undefined
 
 		if (selectedPartInstanceId) {
-			const selectedPartInstance = props.playlist.getActivePartInstances({ _id: selectedPartInstanceId })[0]
+			const selectedPartInstance = RundownPlaylistCollectionUtil.getActivePartInstances(props.playlist, {
+				_id: selectedPartInstanceId,
+			})[0]
 			name = selectedPartInstance.part?.title
 
 			if (selectedPartInstance && props.panel.showPieceIconColor) {

--- a/meteor/client/ui/Shelf/PartTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/PartTimingPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { PartInstance } from '../../../lib/collections/PartInstances'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
@@ -75,7 +75,9 @@ class PartTimingPanelInner extends MeteorReactComponent<
 export const PartTimingPanel = translateWithTracker<IPartTimingPanelProps, IState, IPartTimingPanelTrackedProps>(
 	(props: IPartTimingPanelProps) => {
 		if (props.playlist.currentPartInstanceId) {
-			const livePart = props.playlist.getActivePartInstances({ _id: props.playlist.currentPartInstanceId })[0]
+			const livePart = RundownPlaylistCollectionUtil.getActivePartInstances(props.playlist, {
+				_id: props.playlist.currentPartInstanceId,
+			})[0]
 			const { active } = getIsFilterActive(props.playlist, props.showStyleBase, props.panel)
 
 			return { active, livePart }

--- a/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
+++ b/meteor/client/ui/Shelf/PlaylistNamePanel.tsx
@@ -6,11 +6,11 @@ import {
 	RundownLayoutPlaylistName,
 } from '../../../lib/collections/RundownLayouts'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
-import { Rundown } from '../../../lib/collections/Rundowns'
+import { Rundown, Rundowns } from '../../../lib/collections/Rundowns'
 
 interface IPlaylistNamePanelProps {
 	visible?: boolean
@@ -59,8 +59,10 @@ class PlaylistNamePanelInner extends MeteorReactComponent<
 export const PlaylistNamePanel = withTracker<IPlaylistNamePanelProps, IState, IPlaylistNamePanelTrackedProps>(
 	(props: IPlaylistNamePanelProps) => {
 		if (props.playlist.currentPartInstanceId) {
-			const livePart = props.playlist.getActivePartInstances({ _id: props.playlist.currentPartInstanceId })[0]
-			const currentRundown = props.playlist.getRundowns({ _id: livePart.rundownId })[0]
+			const livePart = RundownPlaylistCollectionUtil.getActivePartInstances(props.playlist, {
+				_id: props.playlist.currentPartInstanceId,
+			})[0]
+			const currentRundown = Rundowns.findOne({ _id: livePart.rundownId, playlistId: props.playlist._id })
 
 			return {
 				currentRundown,

--- a/meteor/client/ui/Shelf/SegmentNamePanel.tsx
+++ b/meteor/client/ui/Shelf/SegmentNamePanel.tsx
@@ -6,7 +6,7 @@ import {
 	RundownLayoutSegmentName,
 } from '../../../lib/collections/RundownLayouts'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
@@ -59,30 +59,36 @@ class SegmentNamePanelInner extends MeteorReactComponent<
 
 function getSegmentName(selectedSegment: 'current' | 'next', playlist: RundownPlaylist): string | undefined {
 	const currentPartInstance = playlist.currentPartInstanceId
-		? (playlist.getActivePartInstances({ _id: playlist.currentPartInstanceId })[0] as PartInstance | undefined)
+		? (RundownPlaylistCollectionUtil.getActivePartInstances(playlist, { _id: playlist.currentPartInstanceId })[0] as
+				| PartInstance
+				| undefined)
 		: undefined
 
 	if (!currentPartInstance) return
 
 	if (selectedSegment === 'current') {
 		if (currentPartInstance) {
-			const segment = playlist.getSegments({ _id: currentPartInstance.segmentId })[0] as Segment | undefined
+			const segment = RundownPlaylistCollectionUtil.getSegments(playlist, { _id: currentPartInstance.segmentId })[0] as
+				| Segment
+				| undefined
 			return segment?.name
 		}
 	} else {
 		if (playlist.nextPartInstanceId) {
-			const nextPartInstance = playlist.getActivePartInstances({
+			const nextPartInstance = RundownPlaylistCollectionUtil.getActivePartInstances(playlist, {
 				_id: playlist.nextPartInstanceId,
 			})[0] as PartInstance | undefined
 			if (nextPartInstance && nextPartInstance.segmentId !== currentPartInstance.segmentId) {
-				const segment = playlist.getSegments({ _id: nextPartInstance.segmentId })[0] as Segment | undefined
+				const segment = RundownPlaylistCollectionUtil.getSegments(playlist, { _id: nextPartInstance.segmentId })[0] as
+					| Segment
+					| undefined
 				return segment?.name
 			}
 		}
 
 		// Current and next part are same segment, or next is not set
 		// Find next segment in order
-		const orderedSegmentsAndParts = playlist.getSegmentsAndPartsSync()
+		const orderedSegmentsAndParts = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
 		const segmentIndex = orderedSegmentsAndParts.segments.findIndex((s) => s._id === currentPartInstance.segmentId)
 		if (segmentIndex === -1) return
 

--- a/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
+++ b/meteor/client/ui/Shelf/SegmentTimingPanel.tsx
@@ -9,7 +9,11 @@ import {
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
 import { RundownUtils } from '../../lib/rundown'
-import { RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylistId,
+} from '../../../lib/collections/RundownPlaylists'
 import { Segment } from '../../../lib/collections/Segments'
 import { SegmentDuration } from '../RundownView/RundownTiming/SegmentDuration'
 import { PartExtended } from '../../../lib/Rundown'
@@ -84,8 +88,12 @@ export const SegmentTimingPanel = translateWithTracker<
 >(
 	(props: ISegmentTimingPanelProps) => {
 		if (props.playlist.currentPartInstanceId) {
-			const livePart = props.playlist.getActivePartInstances({ _id: props.playlist.currentPartInstanceId })[0]
-			const liveSegment = livePart ? props.playlist.getSegments({ _id: livePart.segmentId })[0] : undefined
+			const livePart = RundownPlaylistCollectionUtil.getActivePartInstances(props.playlist, {
+				_id: props.playlist.currentPartInstanceId,
+			})[0]
+			const liveSegment = livePart
+				? RundownPlaylistCollectionUtil.getSegments(props.playlist, { _id: livePart.segmentId })[0]
+				: undefined
 
 			const { active } = getIsFilterActive(props.playlist, props.showStyleBase, props.panel)
 
@@ -97,19 +105,22 @@ export const SegmentTimingPanel = translateWithTracker<
 						memoizedIsolatedAutorun(
 							(_playlistId: RundownPlaylistId) =>
 								(
-									props.playlist.getAllOrderedParts(undefined, {
-										fields: {
-											segmentId: 1,
-											_rank: 1,
-										},
-									}) as Pick<Part, '_id' | 'segmentId' | '_rank'>[]
+									RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(
+										props.playlist,
+										undefined,
+										undefined,
+										undefined,
+										{
+											fields: { _id: 1 },
+										}
+									).parts as Pick<Part, '_id'>[]
 								).map((part) => part._id),
 							'playlist.getAllOrderedParts',
 							props.playlist._id
 						),
 						memoizedIsolatedAutorun(
 							(_playlistId: RundownPlaylistId, _currentPartInstanceId, _nextPartInstanceId) =>
-								props.playlist.getSelectedPartInstances(),
+								RundownPlaylistCollectionUtil.getSelectedPartInstances(props.playlist),
 							'playlist.getSelectedPartInstances',
 							props.playlist._id,
 							props.playlist.currentPartInstanceId,
@@ -125,10 +136,10 @@ export const SegmentTimingPanel = translateWithTracker<
 				props.playlist.activationId === undefined ? 0 : Math.random() * 2000 + 500
 			)
 
-			const orderedSegmentsAndParts = props.playlist.getSegmentsAndPartsSync()
-			const rundownOrder = props.playlist.getRundownIDs()
+			const orderedSegmentsAndParts = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(props.playlist)
+			const rundownOrder = RundownPlaylistCollectionUtil.getRundownIDs(props.playlist)
 			const rundownIndex = rundownOrder.indexOf(liveSegment.rundownId)
-			const rundowns = props.playlist.getRundowns()
+			const rundowns = RundownPlaylistCollectionUtil.getRundowns(props.playlist)
 			const rundown = rundowns.find((r) => r._id === liveSegment!.rundownId)
 			const segmentIndex = orderedSegmentsAndParts.segments.findIndex((s) => s._id === liveSegment!._id)
 

--- a/meteor/client/ui/Shelf/SystemStatusPanel.tsx
+++ b/meteor/client/ui/Shelf/SystemStatusPanel.tsx
@@ -7,12 +7,12 @@ import {
 } from '../../../lib/collections/RundownLayouts'
 import { Translated, translateWithTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
 import { MeteorReactComponent } from '../../lib/MeteorReactComponent'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 import { dashboardElementStyle } from './DashboardPanel'
 import { RundownLayoutsAPI } from '../../../lib/api/rundownLayouts'
 import { RundownSystemStatus } from '../RundownView/RundownSystemStatus'
 import { DBStudio } from '../../../lib/collections/Studios'
-import { Rundown, RundownId } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownId, Rundowns } from '../../../lib/collections/Rundowns'
 
 interface ISystemStatusPanelProps {
 	studio: DBStudio
@@ -65,8 +65,10 @@ class SystemStatusPanelInner extends MeteorReactComponent<
 
 export const SystemStatusPanel = translateWithTracker<ISystemStatusPanelProps, IState, ISystemStatusPanelTrackedProps>(
 	(props: ISystemStatusPanelProps) => {
-		const rundownIds = props.playlist.getRundownIDs() ?? []
-		const firstRundown = rundownIds.length ? props.playlist.getRundowns({ _id: rundownIds[0] })[0] : undefined
+		const rundownIds = RundownPlaylistCollectionUtil.getRundownIDs(props.playlist)
+		const firstRundown = rundownIds.length
+			? Rundowns.findOne({ playlistId: props.playlist._id, _id: rundownIds[0] })
+			: undefined
 		return {
 			rundownIds,
 			firstRundown,

--- a/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
+++ b/meteor/client/ui/Shelf/TimelineDashboardPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from './DashboardPanel'
 import { unprotectString } from '../../../lib/lib'
 import { RundownUtils } from '../../lib/rundown'
+import { RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
 
 export const TimelineDashboardPanel = translateWithTracker<
 	Translated<IAdLibPanelProps & IDashboardPanelProps>,
@@ -39,7 +40,7 @@ export const TimelineDashboardPanel = translateWithTracker<
 		const { nextAdLibIds, nextTags } = getNextPieceInstancesGrouped(props.playlist)
 		return {
 			...fetchAndFilter(props),
-			studio: props.playlist.getStudio(),
+			studio: RundownPlaylistCollectionUtil.getStudio(props.playlist),
 			unfinishedAdLibIds,
 			unfinishedTags,
 			nextAdLibIds,

--- a/meteor/lib/Rundown.ts
+++ b/meteor/lib/Rundown.ts
@@ -15,7 +15,11 @@ import {
 import { FindOptions } from './typings/meteor'
 import { invalidateAfter } from '../client/lib/invalidatingTime'
 import { getCurrentTime, protectString, unprotectString } from './lib'
-import { RundownPlaylist, RundownPlaylistActivationId } from './collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistActivationId,
+	RundownPlaylistCollectionUtil,
+} from './collections/RundownPlaylists'
 import { Rundown, RundownId } from './collections/Rundowns'
 import { ShowStyleBaseId } from './collections/ShowStyleBases'
 
@@ -120,7 +124,7 @@ const SIMULATION_INVALIDATION = 3000
  */
 export function getPieceInstancesForPartInstance(
 	playlistActivationId: RundownPlaylistActivationId | undefined,
-	rundown: Rundown,
+	rundown: Pick<Rundown, '_id' | 'showStyleBaseId'>,
 	partInstance: PartInstanceLimited,
 	partsBeforeThisInSegmentSet: Set<PartId>,
 	segmentsBeforeThisInRundownSet: Set<SegmentId>,
@@ -228,13 +232,18 @@ export function getSegmentsWithPartInstances(
 	partsOptions?: FindOptions<DBPart>,
 	partInstancesOptions?: FindOptions<PartInstance>
 ): Array<{ segment: Segment; partInstances: PartInstance[] }> {
-	const { segments, parts: rawParts } = playlist.getSegmentsAndPartsSync(
+	const { segments, parts: rawParts } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(
+		playlist,
 		segmentsQuery,
 		partsQuery,
 		segmentsOptions,
 		partsOptions
 	)
-	const rawPartInstances = playlist.getActivePartInstances(partInstancesQuery, partInstancesOptions)
+	const rawPartInstances = RundownPlaylistCollectionUtil.getActivePartInstances(
+		playlist,
+		partInstancesQuery,
+		partInstancesOptions
+	)
 	const playlistActivationId = playlist.activationId ?? protectString('')
 
 	const partsBySegment = _.groupBy(rawParts, (p) => p.segmentId)

--- a/meteor/lib/__tests__/lib.test.ts
+++ b/meteor/lib/__tests__/lib.test.ts
@@ -9,7 +9,6 @@ import {
 	getCurrentTime,
 	systemTime,
 	literal,
-	applyClassToDocument,
 	formatDateAsTimecode,
 	formatDurationAsTimecode,
 	formatDateTime,
@@ -90,29 +89,6 @@ describe('lib/lib', () => {
 		})
 		const layer: string | number = obj.layer // just to check typings
 		expect(layer).toBeTruthy()
-	})
-	testInFiber('applyClassToDocument', () => {
-		class MyClass {
-			public publ: string
-			private priv: string
-			constructor(from) {
-				Object.keys(from).forEach((key) => {
-					this[key] = from[key]
-				})
-			}
-			getPriv() {
-				return this.priv
-			}
-			getPubl() {
-				return this.publ
-			}
-		}
-		const doc = applyClassToDocument(MyClass, {
-			priv: 'aaa',
-			publ: 'bbb',
-		})
-		expect(doc.getPriv()).toEqual('aaa')
-		expect(doc.getPubl()).toEqual('bbb')
 	})
 	testInFiber('formatDateAsTimecode', () => {
 		const d = new Date('2019-01-01 13:04:15.145')

--- a/meteor/lib/api/prompter.ts
+++ b/meteor/lib/api/prompter.ts
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor'
 import { check } from '../../lib/check'
 import * as _ from 'underscore'
 import { ISourceLayer, ScriptContent, SourceLayerType } from '@sofie-automation/blueprints-integration'
-import { RundownPlaylists, RundownPlaylistId } from '../collections/RundownPlaylists'
+import { RundownPlaylists, RundownPlaylistId, RundownPlaylistCollectionUtil } from '../collections/RundownPlaylists'
 import { getRandomId, normalizeArray, normalizeArrayToMap } from '../lib'
 import { SegmentId } from '../collections/Segments'
 import { PieceId } from '../collections/Pieces'
@@ -50,7 +50,7 @@ export namespace PrompterAPI {
 
 		const playlist = RundownPlaylists.findOne(playlistId)
 		if (!playlist) throw new Meteor.Error(404, `RundownPlaylist "${playlistId}" not found!`)
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		const rundownIdsToShowStyleBaseIds: Map<RundownId, ShowStyleBaseId> = new Map()
 		const rundownIdsToShowStyleBase: Map<RundownId, [ShowStyleBase, Record<string, ISourceLayer>] | undefined> =
 			new Map()
@@ -64,7 +64,8 @@ export namespace PrompterAPI {
 		}
 		const rundownMap = normalizeArrayToMap(rundowns, '_id')
 
-		const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
+		const { currentPartInstance, nextPartInstance } =
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
 		const groupedParts = getSegmentsWithPartInstances(
 			playlist,

--- a/meteor/lib/collections/AdLibActions.ts
+++ b/meteor/lib/collections/AdLibActions.ts
@@ -32,7 +32,7 @@ export interface AdLibAction extends AdLibActionCommon {
 	partId: PartId
 }
 
-export const AdLibActions = createMongoCollection<AdLibAction, AdLibAction>('adLibActions')
+export const AdLibActions = createMongoCollection<AdLibAction>('adLibActions')
 registerCollection('AdLibActions', AdLibActions)
 registerIndex(AdLibActions, {
 	rundownId: 1,

--- a/meteor/lib/collections/AdLibPieces.ts
+++ b/meteor/lib/collections/AdLibPieces.ts
@@ -14,7 +14,7 @@ export interface AdLibPiece extends PieceGeneric, IBlueprintAdLibPiece {
 	partId?: PartId
 }
 
-export const AdLibPieces = createMongoCollection<AdLibPiece, AdLibPiece>('adLibPieces')
+export const AdLibPieces = createMongoCollection<AdLibPiece>('adLibPieces')
 registerCollection('AdLibPieces', AdLibPieces)
 
 registerIndex(AdLibPieces, {

--- a/meteor/lib/collections/Blueprints.ts
+++ b/meteor/lib/collections/Blueprints.ts
@@ -44,7 +44,7 @@ export interface Blueprint {
 	disableVersionChecks?: boolean
 }
 
-export const Blueprints = createMongoCollection<Blueprint, Blueprint>('blueprints')
+export const Blueprints = createMongoCollection<Blueprint>('blueprints')
 registerCollection('Blueprints', Blueprints)
 
 registerIndex(Blueprints, {

--- a/meteor/lib/collections/BucketAdlibActions.ts
+++ b/meteor/lib/collections/BucketAdlibActions.ts
@@ -43,7 +43,7 @@ export interface BucketAdLibAction extends Omit<IBlueprintActionManifest, 'partI
 	})[]
 }
 
-export const BucketAdLibActions = createMongoCollection<BucketAdLibAction, BucketAdLibAction>('bucketAdlibActions')
+export const BucketAdLibActions = createMongoCollection<BucketAdLibAction>('bucketAdlibActions')
 registerCollection('BucketAdLibActions', BucketAdLibActions)
 
 registerIndex(BucketAdLibActions, {

--- a/meteor/lib/collections/BucketAdlibs.ts
+++ b/meteor/lib/collections/BucketAdlibs.ts
@@ -22,7 +22,7 @@ export interface BucketAdLib extends IBlueprintAdLibPiece {
 	importVersions: RundownImportVersions // TODO - is this good?
 }
 
-export const BucketAdLibs = createMongoCollection<BucketAdLib, BucketAdLib>('bucketAdlibs')
+export const BucketAdLibs = createMongoCollection<BucketAdLib>('bucketAdlibs')
 registerCollection('BucketAdLibs', BucketAdLibs)
 
 registerIndex(BucketAdLibs, {

--- a/meteor/lib/collections/Buckets.ts
+++ b/meteor/lib/collections/Buckets.ts
@@ -28,7 +28,7 @@ export interface Bucket {
 	buttonWidthScale: number
 	buttonHeightScale: number
 }
-export const Buckets = createMongoCollection<Bucket, Bucket>('buckets')
+export const Buckets = createMongoCollection<Bucket>('buckets')
 registerCollection('Buckets', Buckets)
 
 registerIndex(Buckets, {

--- a/meteor/lib/collections/CoreSystem.ts
+++ b/meteor/lib/collections/CoreSystem.ts
@@ -110,7 +110,7 @@ export const GENESIS_SYSTEM_VERSION = '0.0.0'
 // The CoreSystem collection will contain one (exactly 1) object.
 // This represents the "system"
 
-export const CoreSystem = createMongoCollection<ICoreSystem, ICoreSystem>('coreSystem')
+export const CoreSystem = createMongoCollection<ICoreSystem>('coreSystem')
 registerCollection('CoreSystem', CoreSystem)
 
 export function getCoreSystem(): ICoreSystem | undefined {

--- a/meteor/lib/collections/Evaluations.ts
+++ b/meteor/lib/collections/Evaluations.ts
@@ -25,7 +25,7 @@ export interface EvaluationBase {
 	snapshots?: Array<SnapshotId>
 }
 
-export const Evaluations = createMongoCollection<Evaluation, Evaluation>('evaluations')
+export const Evaluations = createMongoCollection<Evaluation>('evaluations')
 registerCollection('Evaluations', Evaluations)
 
 registerIndex(Evaluations, {

--- a/meteor/lib/collections/ExpectedMediaItems.ts
+++ b/meteor/lib/collections/ExpectedMediaItems.ts
@@ -68,7 +68,7 @@ export interface ExpectedMediaItemBucketAction extends ExpectedMediaItemBase {
 /** @deprecated */
 export type ExpectedMediaItem = ExpectedMediaItemRundown | ExpectedMediaItemBucketPiece | ExpectedMediaItemBucketAction
 /** @deprecated */
-export const ExpectedMediaItems = createMongoCollection<ExpectedMediaItem, ExpectedMediaItem>('expectedMediaItems')
+export const ExpectedMediaItems = createMongoCollection<ExpectedMediaItem>('expectedMediaItems')
 registerCollection('ExpectedMediaItems', ExpectedMediaItems)
 
 registerIndex(ExpectedMediaItems, {

--- a/meteor/lib/collections/ExpectedPackageWorkStatuses.ts
+++ b/meteor/lib/collections/ExpectedPackageWorkStatuses.ts
@@ -28,9 +28,8 @@ export interface ExpectedPackageWorkStatusFromPackage
 	id: ExpectedPackageDBBase['_id']
 }
 
-export const ExpectedPackageWorkStatuses = createMongoCollection<ExpectedPackageWorkStatus, ExpectedPackageWorkStatus>(
-	'expectedPackageWorkStatuses'
-)
+export const ExpectedPackageWorkStatuses =
+	createMongoCollection<ExpectedPackageWorkStatus>('expectedPackageWorkStatuses')
 registerCollection('ExpectedPackageWorkStatuses', ExpectedPackageWorkStatuses)
 
 registerIndex(ExpectedPackageWorkStatuses, {

--- a/meteor/lib/collections/ExpectedPackages.ts
+++ b/meteor/lib/collections/ExpectedPackages.ts
@@ -122,7 +122,7 @@ export interface ExpectedPackageDBFromBucketAdLibAction extends ExpectedPackageD
 	/** The Bucket adlib-action this package belongs to */
 	pieceId: BucketAdLibActionId
 }
-export const ExpectedPackages = createMongoCollection<ExpectedPackageDB, ExpectedPackageDB>('expectedPackages')
+export const ExpectedPackages = createMongoCollection<ExpectedPackageDB>('expectedPackages')
 registerCollection('ExpectedPackages', ExpectedPackages)
 
 registerIndex(ExpectedPackages, {

--- a/meteor/lib/collections/ExpectedPlayoutItems.ts
+++ b/meteor/lib/collections/ExpectedPlayoutItems.ts
@@ -37,9 +37,7 @@ export interface ExpectedPlayoutItemStudio extends ExpectedPlayoutItemBase {
 export type ExpectedPlayoutItem = ExpectedPlayoutItemStudio | ExpectedPlayoutItemRundown
 
 /** @deprecated */
-export const ExpectedPlayoutItems = createMongoCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>(
-	'expectedPlayoutItems'
-)
+export const ExpectedPlayoutItems = createMongoCollection<ExpectedPlayoutItem>('expectedPlayoutItems')
 registerCollection('ExpectedPlayoutItems', ExpectedPlayoutItems)
 
 registerIndex(ExpectedPlayoutItems, {

--- a/meteor/lib/collections/ExternalMessageQueue.ts
+++ b/meteor/lib/collections/ExternalMessageQueue.ts
@@ -55,9 +55,7 @@ export interface ExternalMessageQueueObj extends ProtectedStringProperties<IBlue
 	manualRetry?: boolean
 }
 
-export const ExternalMessageQueue = createMongoCollection<ExternalMessageQueueObj, ExternalMessageQueueObj>(
-	'externalMessageQueue'
-)
+export const ExternalMessageQueue = createMongoCollection<ExternalMessageQueueObj>('externalMessageQueue')
 registerCollection('ExternalMessageQueue', ExternalMessageQueue)
 
 registerIndex(ExternalMessageQueue, {

--- a/meteor/lib/collections/IngestDataCache.ts
+++ b/meteor/lib/collections/IngestDataCache.ts
@@ -50,7 +50,7 @@ export interface IngestDataCacheObjPart extends IngestDataCacheObjBase {
 }
 export type IngestDataCacheObj = IngestDataCacheObjRundown | IngestDataCacheObjSegment | IngestDataCacheObjPart
 
-export const IngestDataCache = createMongoCollection<IngestDataCacheObj, IngestDataCacheObj>('ingestDataCache')
+export const IngestDataCache = createMongoCollection<IngestDataCacheObj>('ingestDataCache')
 registerCollection('IngestDataCache', IngestDataCache)
 
 registerIndex(IngestDataCache, {

--- a/meteor/lib/collections/MediaObjects.ts
+++ b/meteor/lib/collections/MediaObjects.ts
@@ -122,7 +122,7 @@ export interface MediaStreamCodec {
 	is_avc?: string
 }
 
-export const MediaObjects = createMongoCollection<MediaObject, MediaObject>('mediaObjects')
+export const MediaObjects = createMongoCollection<MediaObject>('mediaObjects')
 registerCollection('MediaObjects', MediaObjects)
 registerIndex(MediaObjects, {
 	studioId: 1,

--- a/meteor/lib/collections/MediaWorkFlowSteps.ts
+++ b/meteor/lib/collections/MediaWorkFlowSteps.ts
@@ -30,7 +30,7 @@ export abstract class MediaWorkFlowStep {
 	expectedLeft?: number
 }
 
-export const MediaWorkFlowSteps = createMongoCollection<MediaWorkFlowStep, MediaWorkFlowStep>('mediaWorkFlowSteps')
+export const MediaWorkFlowSteps = createMongoCollection<MediaWorkFlowStep>('mediaWorkFlowSteps')
 registerCollection('MediaWorkFlowSteps', MediaWorkFlowSteps)
 
 registerIndex(MediaWorkFlowSteps, {

--- a/meteor/lib/collections/MediaWorkFlows.ts
+++ b/meteor/lib/collections/MediaWorkFlows.ts
@@ -31,7 +31,7 @@ export interface MediaWorkFlow {
 	success: boolean
 }
 
-export const MediaWorkFlows = createMongoCollection<MediaWorkFlow, MediaWorkFlow>('mediaWorkFlows')
+export const MediaWorkFlows = createMongoCollection<MediaWorkFlow>('mediaWorkFlows')
 registerCollection('MediaWorkFlows', MediaWorkFlows)
 registerIndex(MediaWorkFlows, {
 	// TODO: add deviceId: 1,

--- a/meteor/lib/collections/Organization.ts
+++ b/meteor/lib/collections/Organization.ts
@@ -37,7 +37,8 @@ export interface UserRoles {
 	admin?: boolean
 }
 
+/** @deprecated TODO: TransformedCollection */
 export type Organization = DBOrganization // to be replaced by a class some time later?
 
-export const Organizations = createMongoCollection<Organization, DBOrganization>('organizations')
+export const Organizations = createMongoCollection<DBOrganization>('organizations')
 registerCollection('Organizations', Organizations)

--- a/meteor/lib/collections/PackageContainerPackageStatus.ts
+++ b/meteor/lib/collections/PackageContainerPackageStatus.ts
@@ -39,10 +39,9 @@ export interface PackageContainerPackageStatusDB {
 	modified: Time
 }
 
-export const PackageContainerPackageStatuses = createMongoCollection<
-	PackageContainerPackageStatusDB,
-	PackageContainerPackageStatusDB
->('packageContainerPackageStatuses')
+export const PackageContainerPackageStatuses = createMongoCollection<PackageContainerPackageStatusDB>(
+	'packageContainerPackageStatuses'
+)
 registerCollection('PackageContainerPackageStatuses', PackageContainerPackageStatuses)
 
 registerIndex(PackageContainerPackageStatuses, {

--- a/meteor/lib/collections/PackageContainerStatus.ts
+++ b/meteor/lib/collections/PackageContainerStatus.ts
@@ -35,9 +35,7 @@ export interface PackageContainerStatusDB {
 	modified: Time
 }
 
-export const PackageContainerStatuses = createMongoCollection<PackageContainerStatusDB, PackageContainerStatusDB>(
-	'packageContainerStatuses'
-)
+export const PackageContainerStatuses = createMongoCollection<PackageContainerStatusDB>('packageContainerStatuses')
 registerCollection('PackageContainerStatuses', PackageContainerStatuses)
 
 registerIndex(PackageContainerStatuses, {

--- a/meteor/lib/collections/PackageInfos.ts
+++ b/meteor/lib/collections/PackageInfos.ts
@@ -33,7 +33,7 @@ export interface PackageInfoDB extends PackageInfo.Base {
 	payload: any
 }
 
-export const PackageInfos = createMongoCollection<PackageInfoDB, PackageInfoDB>('packageInfos')
+export const PackageInfos = createMongoCollection<PackageInfoDB>('packageInfos')
 registerCollection('PackageInfos', PackageInfos)
 
 registerIndex(PackageInfos, {

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -115,7 +115,7 @@ export class PartInstance implements DBPartInstance {
 			this[key] = document[key]
 		})
 		this.isTemporary = isTemporary === true
-		this.part = new Part(document.part)
+		this.part = document.part
 	}
 }
 
@@ -132,7 +132,7 @@ export function wrapPartToTemporaryInstance(
 			segmentPlayoutId: protectString(''), // Only needed when stored in the db, and filled in nearer the time
 			takeCount: -1,
 			rehearsal: false,
-			part: new Part(part),
+			part: part,
 		},
 		true
 	)

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -1,20 +1,7 @@
-import * as _ from 'underscore'
-import {
-	applyClassToDocument,
-	registerCollection,
-	ProtectedString,
-	ProtectedStringProperties,
-	protectString,
-	unprotectString,
-} from '../lib'
-import {
-	IBlueprintPartInstance,
-	PartEndState,
-	Time,
-	IBlueprintPartInstanceTimings,
-} from '@sofie-automation/blueprints-integration'
-import { createMongoCollectionOLD } from './lib'
-import { DBPart, Part, PartId } from './Parts'
+import { registerCollection, ProtectedString, ProtectedStringProperties, protectString, unprotectString } from '../lib'
+import { IBlueprintPartInstance, Time, IBlueprintPartInstanceTimings } from '@sofie-automation/blueprints-integration'
+import { createMongoCollection } from './lib'
+import { DBPart, PartId } from './Parts'
 import { RundownId } from './Rundowns'
 import { SegmentId } from './Segments'
 import { registerIndex } from '../database'
@@ -42,6 +29,10 @@ export function protectPartInstance(partInstance: IBlueprintPartInstance): Parti
 }
 
 export interface DBPartInstance extends InternalIBlueprintPartInstance {
+	// Temporary properties (never stored in DB):
+	/** Whether this PartInstance is a temprorary wrapping of a Part */
+	readonly isTemporary?: boolean
+
 	_id: PartInstanceId
 	rundownId: RundownId
 	segmentId: SegmentId
@@ -82,60 +73,23 @@ export interface PartInstanceTimings extends IBlueprintPartInstanceTimings {
 	duration?: Time
 }
 
-export class PartInstance implements DBPartInstance {
-	// Temporary properties (never stored in DB):
-	/** Whether this PartInstance is a temprorary wrapping of a Part */
-	public readonly isTemporary: boolean
-
-	public playlistActivationId: RundownPlaylistActivationId
-	public segmentPlayoutId: SegmentPlayoutId
-	/** Whether this instance has been finished with and reset (to restore the original part as the primary version) */
-	public reset?: boolean
-	public takeCount: number
-	public consumesNextSegmentId?: boolean
-	public previousPartEndState?: PartEndState
-
-	public timings?: PartInstanceTimings
-	/** Temporarily track whether this PartInstance has been taken, so we can easily find and prune those which are only nexted */
-	public isTaken?: boolean
-	public rehearsal: boolean
-
-	// From IBlueprintPartInstance:
-	public part: Part
-	public _id: PartInstanceId
-	public segmentId: SegmentId
-	public rundownId: RundownId
-
-	public allowedToUseTransition?: boolean
-
-	public orphaned?: 'adlib-part' | 'deleted'
-
-	constructor(document: DBPartInstance, isTemporary?: boolean) {
-		_.each(_.keys(document), (key) => {
-			this[key] = document[key]
-		})
-		this.isTemporary = isTemporary === true
-		this.part = document.part
-	}
-}
+export type PartInstance = DBPartInstance
 
 export function wrapPartToTemporaryInstance(
 	playlistActivationId: RundownPlaylistActivationId,
 	part: DBPart
 ): PartInstance {
-	return new PartInstance(
-		{
-			_id: protectString(`${part._id}_tmp_instance`),
-			rundownId: part.rundownId,
-			segmentId: part.segmentId,
-			playlistActivationId,
-			segmentPlayoutId: protectString(''), // Only needed when stored in the db, and filled in nearer the time
-			takeCount: -1,
-			rehearsal: false,
-			part: part,
-		},
-		true
-	)
+	return {
+		isTemporary: true,
+		_id: protectString(`${part._id}_tmp_instance`),
+		rundownId: part.rundownId,
+		segmentId: part.segmentId,
+		playlistActivationId,
+		segmentPlayoutId: protectString(''), // Only needed when stored in the db, and filled in nearer the time
+		takeCount: -1,
+		rehearsal: false,
+		part: part,
+	}
 }
 
 export function findPartInstanceInMapOrWrapToTemporary<T extends Partial<PartInstance>>(
@@ -152,9 +106,7 @@ export function findPartInstanceOrWrapToTemporary<T extends Partial<PartInstance
 	return partInstances[unprotectString(part._id)] || (wrapPartToTemporaryInstance(protectString(''), part) as T)
 }
 
-export const PartInstances = createMongoCollectionOLD<PartInstance, DBPartInstance>('partInstances', {
-	transform: (doc) => applyClassToDocument(PartInstance, doc),
-})
+export const PartInstances = createMongoCollection<PartInstance>('partInstances')
 registerCollection('PartInstances', PartInstances)
 registerIndex(PartInstances, {
 	rundownId: 1,

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -13,7 +13,7 @@ import {
 	Time,
 	IBlueprintPartInstanceTimings,
 } from '@sofie-automation/blueprints-integration'
-import { createMongoCollection } from './lib'
+import { createMongoCollectionOLD } from './lib'
 import { DBPart, Part, PartId } from './Parts'
 import { RundownId } from './Rundowns'
 import { SegmentId } from './Segments'
@@ -152,7 +152,7 @@ export function findPartInstanceOrWrapToTemporary<T extends Partial<PartInstance
 	return partInstances[unprotectString(part._id)] || (wrapPartToTemporaryInstance(protectString(''), part) as T)
 }
 
-export const PartInstances = createMongoCollection<PartInstance, DBPartInstance>('partInstances', {
+export const PartInstances = createMongoCollectionOLD<PartInstance, DBPartInstance>('partInstances', {
 	transform: (doc) => applyClassToDocument(PartInstance, doc),
 })
 registerCollection('PartInstances', PartInstances)

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -28,7 +28,7 @@ export function protectPartInstance(partInstance: IBlueprintPartInstance): Parti
 	return partInstance as any
 }
 
-export interface DBPartInstance extends InternalIBlueprintPartInstance {
+export interface PartInstance extends InternalIBlueprintPartInstance {
 	// Temporary properties (never stored in DB):
 	/** Whether this PartInstance is a temprorary wrapping of a Part */
 	readonly isTemporary?: boolean
@@ -73,7 +73,8 @@ export interface PartInstanceTimings extends IBlueprintPartInstanceTimings {
 	duration?: Time
 }
 
-export type PartInstance = DBPartInstance
+/** Note: Use PartInstance instead */
+export type DBPartInstance = PartInstance
 
 export function wrapPartToTemporaryInstance(
 	playlistActivationId: RundownPlaylistActivationId,

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -17,7 +17,7 @@ export interface PartInvalidReason {
 	severity?: NoteSeverity
 	color?: string
 }
-export interface DBPart extends ProtectedStringProperties<IBlueprintPartDB, '_id' | 'segmentId'> {
+export interface Part extends ProtectedStringProperties<IBlueprintPartDB, '_id' | 'segmentId'> {
 	_id: PartId
 	/** Position inside the segment */
 	_rank: number
@@ -38,7 +38,8 @@ export interface DBPart extends ProtectedStringProperties<IBlueprintPartDB, '_id
 	identifier?: string
 }
 
-export type Part = DBPart
+/** Note: Use Part instead */
+export type DBPart = Part
 
 export function isPartPlayable(part: DBPart) {
 	return !part.invalid && !part.floated

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -80,10 +80,6 @@ export class Part implements DBPart {
 			this[key] = value
 		}
 	}
-
-	isPlayable() {
-		return isPartPlayable(this)
-	}
 }
 
 export function isPartPlayable(part: DBPart) {

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -1,9 +1,9 @@
 import { RundownId } from './Rundowns'
 import { SegmentId } from './Segments'
-import { applyClassToDocument, registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
-import { IBlueprintPartDB, NoteSeverity, PartHoldMode } from '@sofie-automation/blueprints-integration'
+import { registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
+import { IBlueprintPartDB, NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { PartNote } from '../api/notes'
-import { createMongoCollectionOLD } from './lib'
+import { createMongoCollection } from './lib'
 import { registerIndex } from '../database'
 import { ITranslatableMessage } from '../api/TranslatableMessage'
 
@@ -38,57 +38,13 @@ export interface DBPart extends ProtectedStringProperties<IBlueprintPartDB, '_id
 	identifier?: string
 }
 
-export class Part implements DBPart {
-	// From IBlueprintPart:
-	public externalId: string
-	public title: string
-	public metaData?: {
-		[key: string]: any
-	}
-	public autoNext?: boolean
-	public autoNextOverlap?: number
-	public prerollDuration?: number
-	public transitionPrerollDuration?: number | null
-	public transitionKeepaliveDuration?: number | null
-	public transitionDuration?: number | null
-	public disableOutTransition?: boolean
-	public expectedDuration?: number
-	public budgetDuration?: number
-	public holdMode?: PartHoldMode
-	public shouldNotifyCurrentPlayingPart?: boolean
-	public classes?: string[]
-	public classesForNext?: string[]
-	public displayDurationGroup?: string
-	public displayDuration?: number
-	public invalid?: boolean
-	public invalidReason?: PartInvalidReason
-	public untimed?: boolean
-	public floated?: boolean
-	public gap?: boolean
-	// From IBlueprintPartDB:
-	public _id: PartId
-	public segmentId: SegmentId
-	// From DBPart:
-	public _rank: number
-	public rundownId: RundownId
-	public status?: string
-	public notes?: Array<PartNote>
-	public identifier?: string
-
-	constructor(document: DBPart) {
-		for (const [key, value] of Object.entries(document)) {
-			this[key] = value
-		}
-	}
-}
+export type Part = DBPart
 
 export function isPartPlayable(part: DBPart) {
 	return !part.invalid && !part.floated
 }
 
-export const Parts = createMongoCollectionOLD<Part, DBPart>('parts', {
-	transform: (doc) => applyClassToDocument(Part, doc),
-})
+export const Parts = createMongoCollection<Part>('parts')
 registerCollection('Parts', Parts)
 
 registerIndex(Parts, {

--- a/meteor/lib/collections/Parts.ts
+++ b/meteor/lib/collections/Parts.ts
@@ -3,7 +3,7 @@ import { SegmentId } from './Segments'
 import { applyClassToDocument, registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
 import { IBlueprintPartDB, NoteSeverity, PartHoldMode } from '@sofie-automation/blueprints-integration'
 import { PartNote } from '../api/notes'
-import { createMongoCollection } from './lib'
+import { createMongoCollectionOLD } from './lib'
 import { registerIndex } from '../database'
 import { ITranslatableMessage } from '../api/TranslatableMessage'
 
@@ -90,7 +90,7 @@ export function isPartPlayable(part: DBPart) {
 	return !part.invalid && !part.floated
 }
 
-export const Parts = createMongoCollection<Part, DBPart>('parts', {
+export const Parts = createMongoCollectionOLD<Part, DBPart>('parts', {
 	transform: (doc) => applyClassToDocument(Part, doc),
 })
 registerCollection('Parts', Parts)

--- a/meteor/lib/collections/PeripheralDeviceCommands.ts
+++ b/meteor/lib/collections/PeripheralDeviceCommands.ts
@@ -21,9 +21,7 @@ export interface PeripheralDeviceCommand {
 
 	time: Time // time
 }
-export const PeripheralDeviceCommands = createMongoCollection<PeripheralDeviceCommand, PeripheralDeviceCommand>(
-	'peripheralDeviceCommands'
-)
+export const PeripheralDeviceCommands = createMongoCollection<PeripheralDeviceCommand>('peripheralDeviceCommands')
 registerCollection('PeripheralDeviceCommands', PeripheralDeviceCommands)
 
 // Monitor and remove old, lingering commands:

--- a/meteor/lib/collections/PeripheralDevices.ts
+++ b/meteor/lib/collections/PeripheralDevices.ts
@@ -67,7 +67,7 @@ export interface PeripheralDevice {
 	accessTokenUrl?: string
 }
 
-export const PeripheralDevices = createMongoCollection<PeripheralDevice, PeripheralDevice>('peripheralDevices')
+export const PeripheralDevices = createMongoCollection<PeripheralDevice>('peripheralDevices')
 registerCollection('PeripheralDevices', PeripheralDevices)
 
 registerIndex(PeripheralDevices, {

--- a/meteor/lib/collections/PieceInstances.ts
+++ b/meteor/lib/collections/PieceInstances.ts
@@ -113,7 +113,7 @@ export function wrapPieceToInstance(
 	)
 }
 
-export const PieceInstances = createMongoCollection<PieceInstance, PieceInstance>('pieceInstances')
+export const PieceInstances = createMongoCollection<PieceInstance>('pieceInstances')
 registerCollection('PieceInstances', PieceInstances)
 
 registerIndex(PieceInstances, {

--- a/meteor/lib/collections/Pieces.ts
+++ b/meteor/lib/collections/Pieces.ts
@@ -43,7 +43,7 @@ export interface Piece extends PieceGeneric, Omit<IBlueprintPieceDB, '_id' | 'co
 	invalid: boolean
 }
 
-export const Pieces = createMongoCollection<Piece, Piece>('pieces')
+export const Pieces = createMongoCollection<Piece>('pieces')
 registerCollection('Pieces', Pieces)
 
 registerIndex(Pieces, {

--- a/meteor/lib/collections/RundownBaselineAdLibActions.ts
+++ b/meteor/lib/collections/RundownBaselineAdLibActions.ts
@@ -10,10 +10,8 @@ export interface RundownBaselineAdLibAction extends AdLibActionCommon {
 	_id: RundownBaselineAdLibActionId
 }
 
-export const RundownBaselineAdLibActions = createMongoCollection<
-	RundownBaselineAdLibAction,
-	RundownBaselineAdLibAction
->('rundownBaselineAdLibActions')
+export const RundownBaselineAdLibActions =
+	createMongoCollection<RundownBaselineAdLibAction>('rundownBaselineAdLibActions')
 registerCollection('RundownBaselineAdLibActions', RundownBaselineAdLibActions)
 registerIndex(RundownBaselineAdLibActions, {
 	rundownId: 1,

--- a/meteor/lib/collections/RundownBaselineAdLibPieces.ts
+++ b/meteor/lib/collections/RundownBaselineAdLibPieces.ts
@@ -5,9 +5,7 @@ import { registerIndex } from '../database'
 
 export type RundownBaselineAdLibItem = AdLibPiece
 
-export const RundownBaselineAdLibPieces = createMongoCollection<RundownBaselineAdLibItem, RundownBaselineAdLibItem>(
-	'rundownBaselineAdLibPieces'
-)
+export const RundownBaselineAdLibPieces = createMongoCollection<RundownBaselineAdLibItem>('rundownBaselineAdLibPieces')
 registerCollection('RundownBaselineAdLibPieces', RundownBaselineAdLibPieces)
 registerIndex(RundownBaselineAdLibPieces, {
 	rundownId: 1,

--- a/meteor/lib/collections/RundownBaselineObjs.ts
+++ b/meteor/lib/collections/RundownBaselineObjs.ts
@@ -15,7 +15,7 @@ export interface RundownBaselineObj {
 	objects: TimelineObjGeneric[]
 }
 
-export const RundownBaselineObjs = createMongoCollection<RundownBaselineObj, RundownBaselineObj>('rundownBaselineObjs')
+export const RundownBaselineObjs = createMongoCollection<RundownBaselineObj>('rundownBaselineObjs')
 registerCollection('RundownBaselineObjs', RundownBaselineObjs)
 registerIndex(RundownBaselineObjs, {
 	rundownId: 1,

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -372,7 +372,7 @@ export interface DashboardLayout extends RundownLayoutShelfBase {
 	actionButtons?: DashboardLayoutActionButton[]
 }
 
-export const RundownLayouts = createMongoCollection<RundownLayoutBase, RundownLayoutBase>('rundownLayouts')
+export const RundownLayouts = createMongoCollection<RundownLayoutBase>('rundownLayouts')
 registerCollection('RundownLayouts', RundownLayouts)
 
 // addIndex(RundownLayouts, {

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -2,16 +2,8 @@ import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
 import { MongoQuery, FindOptions } from '../typings/meteor'
 import * as _ from 'underscore'
-import {
-	Time,
-	applyClassToDocument,
-	registerCollection,
-	normalizeArray,
-	normalizeArrayFunc,
-	ProtectedString,
-	unprotectString,
-} from '../lib'
-import { RundownHoldState, Rundowns, Rundown, DBRundown, RundownId } from './Rundowns'
+import { Time, registerCollection, normalizeArray, normalizeArrayFunc, ProtectedString, unprotectString } from '../lib'
+import { RundownHoldState, Rundowns, Rundown, RundownId, DBRundown } from './Rundowns'
 import { Studio, Studios, StudioId } from './Studios'
 import { Segments, Segment, DBSegment, SegmentId } from './Segments'
 import { Parts, Part, DBPart, PartId } from './Parts'
@@ -481,7 +473,7 @@ export class RundownPlaylist implements DBRundownPlaylist {
 }
 
 export const RundownPlaylists = createMongoCollectionOLD<RundownPlaylist, DBRundownPlaylist>('rundownPlaylists', {
-	transform: (doc) => applyClassToDocument(RundownPlaylist, doc),
+	transform: (doc) => new RundownPlaylist(doc),
 })
 registerCollection('RundownPlaylists', RundownPlaylists)
 

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -17,7 +17,7 @@ import { Segments, Segment, DBSegment, SegmentId } from './Segments'
 import { Parts, Part, DBPart, PartId } from './Parts'
 import { RundownPlaylistTiming, TimelinePersistentState } from '@sofie-automation/blueprints-integration'
 import { PartInstance, PartInstances, PartInstanceId } from './PartInstances'
-import { createMongoCollection } from './lib'
+import { createMongoCollectionOLD } from './lib'
 import { OrganizationId } from './Organization'
 import { registerIndex } from '../database'
 import { PieceInstanceInfiniteId } from './PieceInstances'
@@ -473,7 +473,7 @@ export class RundownPlaylist implements DBRundownPlaylist {
 	}
 }
 
-export const RundownPlaylists = createMongoCollection<RundownPlaylist, DBRundownPlaylist>('rundownPlaylists', {
+export const RundownPlaylists = createMongoCollectionOLD<RundownPlaylist, DBRundownPlaylist>('rundownPlaylists', {
 	transform: (doc) => applyClassToDocument(RundownPlaylist, doc),
 })
 registerCollection('RundownPlaylists', RundownPlaylists)

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -9,7 +9,7 @@ import { Segments, Segment, DBSegment, SegmentId } from './Segments'
 import { Parts, Part, DBPart, PartId } from './Parts'
 import { RundownPlaylistTiming, TimelinePersistentState } from '@sofie-automation/blueprints-integration'
 import { PartInstance, PartInstances, PartInstanceId } from './PartInstances'
-import { createMongoCollectionOLD } from './lib'
+import { createMongoCollection } from './lib'
 import { OrganizationId } from './Organization'
 import { registerIndex } from '../database'
 import { PieceInstanceInfiniteId } from './PieceInstances'
@@ -39,7 +39,7 @@ export interface ABSessionInfo {
 export interface DBRundownPlaylist {
 	_id: RundownPlaylistId
 	/** External ID (source) of the playlist */
-	externalId: string | null
+	externalId: string
 	/** ID of the organization that owns the playlist */
 	organizationId?: OrganizationId | null
 	/** Studio that this playlist is assigned to */
@@ -98,42 +98,7 @@ export interface DBRundownPlaylist {
 	trackedAbSessions?: ABSessionInfo[]
 }
 
-export class RundownPlaylist implements DBRundownPlaylist {
-	public _id: RundownPlaylistId
-	public externalId: string
-	public organizationId: OrganizationId
-	public studioId: StudioId
-	public restoredFromSnapshotId?: RundownPlaylistId
-	public name: string
-	public created: Time
-	public modified: Time
-	public startedPlayback?: Time
-	public lastIncorrectPartPlaybackReported?: Time
-	public rundownsStartedPlayback?: Record<string, Time>
-	public timing: RundownPlaylistTiming
-	public rehearsal?: boolean
-	public holdState?: RundownHoldState
-	public activationId?: RundownPlaylistActivationId
-	public currentPartInstanceId: PartInstanceId | null
-	public nextPartInstanceId: PartInstanceId | null
-	public nextSegmentId?: SegmentId
-	public nextTimeOffset?: number | null
-	public nextPartManual?: boolean
-	public previousPartInstanceId: PartInstanceId | null
-	public loop?: boolean
-	public outOfOrderTiming?: boolean
-	public timeOfDayCountdowns?: boolean
-	public rundownRanksAreSetInSofie?: boolean
-
-	public previousPersistentState?: TimelinePersistentState
-	public trackedAbSessions?: ABSessionInfo[]
-
-	constructor(document: DBRundownPlaylist) {
-		for (const [key, value] of Object.entries(document)) {
-			this[key] = value
-		}
-	}
-}
+export type RundownPlaylist = DBRundownPlaylist
 
 /**
  * Direct database accessors for the RundownPlaylist
@@ -493,9 +458,7 @@ export class RundownPlaylistCollectionUtil {
 	}
 }
 
-export const RundownPlaylists = createMongoCollectionOLD<RundownPlaylist, DBRundownPlaylist>('rundownPlaylists', {
-	transform: (doc) => new RundownPlaylist(doc),
-})
+export const RundownPlaylists = createMongoCollection<RundownPlaylist>('rundownPlaylists')
 registerCollection('RundownPlaylists', RundownPlaylists)
 
 registerIndex(RundownPlaylists, {

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -36,7 +36,7 @@ export interface ABSessionInfo {
 	partInstanceIds?: Array<PartInstanceId>
 }
 
-export interface DBRundownPlaylist {
+export interface RundownPlaylist {
 	_id: RundownPlaylistId
 	/** External ID (source) of the playlist */
 	externalId: string
@@ -98,7 +98,8 @@ export interface DBRundownPlaylist {
 	trackedAbSessions?: ABSessionInfo[]
 }
 
-export type RundownPlaylist = DBRundownPlaylist
+/** Note: Use RundownPlaylist instead */
+export type DBRundownPlaylist = RundownPlaylist
 
 /**
  * Direct database accessors for the RundownPlaylist

--- a/meteor/lib/collections/RundownPlaylists.ts
+++ b/meteor/lib/collections/RundownPlaylists.ts
@@ -423,7 +423,10 @@ export class RundownPlaylist implements DBRundownPlaylist {
 		const instances = this.getActivePartInstances(selector, options)
 		return normalizeArrayFunc(instances, (i) => unprotectString(i.part._id))
 	}
-	static _sortSegments(segments: Segment[], rundowns: Array<ReadonlyDeep<DBRundown>>) {
+	static _sortSegments<TSegment extends Pick<Segment, '_id' | 'rundownId' | '_rank'>>(
+		segments: Array<TSegment>,
+		rundowns: Array<ReadonlyDeep<DBRundown>>
+	) {
 		const rundownsMap = normalizeArray(rundowns, '_id')
 		return segments.sort((a, b) => {
 			if (a.rundownId === b.rundownId) {
@@ -454,10 +457,14 @@ export class RundownPlaylist implements DBRundownPlaylist {
 		})
 		return Array.from(rundownsMap.values())
 	}
-	static _sortParts(parts: Part[], rundowns: DBRundown[], segments: Segment[]) {
+	static _sortParts(
+		parts: Part[],
+		rundowns: DBRundown[],
+		segments: Array<Pick<Segment, '_id' | 'rundownId' | '_rank'>>
+	) {
 		return RundownPlaylist._sortPartsInner(parts, RundownPlaylist._sortSegments(segments, rundowns))
 	}
-	static _sortPartsInner<P extends DBPart>(parts: P[], sortedSegments: DBSegment[]): P[] {
+	static _sortPartsInner<P extends DBPart>(parts: P[], sortedSegments: Array<Pick<Segment, '_id'>>): P[] {
 		const segmentRanks: { [segmentId: string]: number } = {}
 		_.each(sortedSegments, (segment, i) => (segmentRanks[unprotectString(segment._id)] = i))
 

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -32,7 +32,7 @@ export interface RundownImportVersions {
 /** A string, identifying a Rundown */
 export type RundownId = ProtectedString<'RundownId'>
 /** This is a very uncomplete mock-up of the Rundown object */
-export interface DBRundown
+export interface Rundown
 	extends ProtectedStringProperties<IBlueprintRundownDB, '_id' | 'playlistId' | 'showStyleVariantId'> {
 	_id: RundownId
 	/** ID of the organization that owns the rundown */
@@ -78,7 +78,9 @@ export interface DBRundown
 	/** Whenever the baseline (RundownBaselineObjs, RundownBaselineAdLibItems, RundownBaselineAdLibActions) changes, this is changed too */
 	baselineModifyHash?: string
 }
-export type Rundown = DBRundown
+
+/** Note: Use Rundown instead */
+export type DBRundown = Rundown
 
 /**
  * Direct database accessors for the Rundown

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -1,15 +1,15 @@
-import { Time, applyClassToDocument, registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
+import { Time, registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
 import { Segments, Segment } from './Segments'
 import { Parts, Part, DBPart } from './Parts'
 import { FindOptions, MongoQuery } from '../typings/meteor'
 import { StudioId } from './Studios'
 import { Meteor } from 'meteor/meteor'
-import { IBlueprintRundownDB, RundownPlaylistTiming } from '@sofie-automation/blueprints-integration'
-import { ShowStyleVariantId, ShowStyleVariant, ShowStyleVariants } from './ShowStyleVariants'
+import { IBlueprintRundownDB } from '@sofie-automation/blueprints-integration'
+import { ShowStyleVariant, ShowStyleVariants } from './ShowStyleVariants'
 import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from './ShowStyleBases'
 import { RundownNote } from '../api/notes'
 import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from './RundownPlaylists'
-import { createMongoCollectionOLD } from './lib'
+import { createMongoCollection } from './lib'
 import { PeripheralDeviceId } from './PeripheralDevices'
 import { OrganizationId } from './Organization'
 import { registerIndex } from '../database'
@@ -78,44 +78,7 @@ export interface DBRundown
 	/** Whenever the baseline (RundownBaselineObjs, RundownBaselineAdLibItems, RundownBaselineAdLibActions) changes, this is changed too */
 	baselineModifyHash?: string
 }
-export class Rundown implements DBRundown {
-	// From IBlueprintRundown:
-	public externalId: string
-	public organizationId: OrganizationId
-	public name: string
-	public description?: string
-	public timing: RundownPlaylistTiming
-	public metaData?: unknown
-	// From IBlueprintRundownDB:
-	public _id: RundownId
-	public showStyleVariantId: ShowStyleVariantId
-	// From DBRundown:
-	public studioId: StudioId
-	public showStyleBaseId: ShowStyleBaseId
-	public peripheralDeviceId?: PeripheralDeviceId
-	public restoredFromSnapshotId?: RundownId
-	public created: Time
-	public modified: Time
-	public importVersions: RundownImportVersions
-	public status?: string
-	public airStatus?: string
-	public orphaned?: 'deleted'
-	public notifiedCurrentPlayingPartExternalId?: string
-	public notes?: Array<RundownNote>
-	public playlistExternalId?: string
-	public endOfRundownIsShowBreak?: boolean
-	public externalNRCSName: string
-	public playlistId: RundownPlaylistId
-	public playlistIdIsSetInSofie?: boolean
-	public _rank: number
-	public baselineModifyHash?: string
-
-	constructor(document: DBRundown) {
-		for (const [key, value] of Object.entries(document)) {
-			this[key] = value
-		}
-	}
-}
+export type Rundown = DBRundown
 
 /**
  * Direct database accessors for the Rundown
@@ -207,9 +170,7 @@ export class RundownCollectionUtil {
 	}
 }
 
-export const Rundowns = createMongoCollectionOLD<Rundown, DBRundown>('rundowns', {
-	transform: (doc) => applyClassToDocument(Rundown, doc),
-})
+export const Rundowns = createMongoCollection<Rundown>('rundowns')
 registerCollection('Rundowns', Rundowns)
 
 registerIndex(Rundowns, {

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -1,6 +1,5 @@
-import * as _ from 'underscore'
 import { Time, applyClassToDocument, registerCollection, ProtectedString, ProtectedStringProperties } from '../lib'
-import { Segments, DBSegment, Segment } from './Segments'
+import { Segments, Segment } from './Segments'
 import { Parts, Part, DBPart } from './Parts'
 import { FindOptions, MongoQuery } from '../typings/meteor'
 import { StudioId } from './Studios'
@@ -11,7 +10,6 @@ import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from './ShowStyleBases
 import { RundownNote } from '../api/notes'
 import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from './RundownPlaylists'
 import { createMongoCollectionOLD } from './lib'
-import { PartInstances, PartInstance, DBPartInstance } from './PartInstances'
 import { PeripheralDeviceId } from './PeripheralDevices'
 import { OrganizationId } from './Organization'
 import { registerIndex } from '../database'
@@ -117,76 +115,87 @@ export class Rundown implements DBRundown {
 			this[key] = value
 		}
 	}
-	getRundownPlaylist(): RundownPlaylist {
-		if (!this.playlistId) throw new Meteor.Error(500, 'Rundown is not a part of a rundown playlist!')
-		const pls = RundownPlaylists.findOne(this.playlistId)
+}
+
+/**
+ * Direct database accessors for the Rundown
+ * These used to reside on the Rundown class
+ */
+export class RundownCollectionUtil {
+	static getRundownPlaylist(rundown: Pick<DBRundown, 'playlistId'>): RundownPlaylist {
+		if (!rundown.playlistId) throw new Meteor.Error(500, 'Rundown is not a part of a rundown playlist!')
+		const pls = RundownPlaylists.findOne(rundown.playlistId)
 		if (pls) {
 			return pls
-		} else throw new Meteor.Error(404, `Rundown Playlist "${this.playlistId}" not found!`)
+		} else throw new Meteor.Error(404, `Rundown Playlist "${rundown.playlistId}" not found!`)
 	}
-	getShowStyleVariant(): ShowStyleVariant {
-		const showStyleVariant = ShowStyleVariants.findOne(this.showStyleVariantId)
-		if (!showStyleVariant) throw new Meteor.Error(404, `ShowStyleVariant "${this.showStyleVariantId}" not found!`)
+	static getShowStyleVariant(rundown: Pick<DBRundown, 'showStyleVariantId'>): ShowStyleVariant {
+		const showStyleVariant = ShowStyleVariants.findOne(rundown.showStyleVariantId)
+		if (!showStyleVariant)
+			throw new Meteor.Error(404, `ShowStyleVariant "${rundown.showStyleVariantId}" not found!`)
 		return showStyleVariant
 	}
-	getShowStyleBase(): ShowStyleBase {
-		const showStyleBase = ShowStyleBases.findOne(this.showStyleBaseId)
-		if (!showStyleBase) throw new Meteor.Error(404, `ShowStyleBase "${this.showStyleBaseId}" not found!`)
+	static getShowStyleBase(rundown: Pick<DBRundown, 'showStyleBaseId'>): ShowStyleBase {
+		const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId)
+		if (!showStyleBase) throw new Meteor.Error(404, `ShowStyleBase "${rundown.showStyleBaseId}" not found!`)
 		return showStyleBase
 	}
-	getSegments(selector?: MongoQuery<DBSegment>, options?: FindOptions<DBSegment>): Segment[] {
-		selector = selector || {}
-		options = options || {}
+	static getSegments(
+		rundown: Pick<DBRundown, '_id'>,
+		selector?: MongoQuery<Segment>,
+		options?: FindOptions<Segment>
+	): Segment[] {
 		return Segments.find(
-			_.extend(
-				{
-					rundownId: this._id,
-				},
-				selector
-			),
-			_.extend(
-				{
-					sort: { _rank: 1 },
-				},
-				options
-			)
+			{
+				rundownId: rundown._id,
+				...selector,
+			},
+			{
+				sort: { _rank: 1 },
+				...options,
+			}
 		).fetch()
 	}
-	getParts(selector?: MongoQuery<Part>, options?: FindOptions<DBPart>, segmentsInOrder?: Segment[]): Part[] {
-		selector = selector || {}
-		options = options || {}
-
-		let parts = Parts.find(
-			_.extend(
-				{
-					rundownId: this._id,
-				},
-				selector
-			),
-			_.extend(
-				{
-					sort: { _rank: 1 },
-				},
-				options
-			)
+	static getParts(
+		rundown: Pick<DBRundown, '_id'>,
+		selector?: MongoQuery<Part>,
+		options?: FindOptions<DBPart>,
+		segmentsInOrder?: Array<Pick<Segment, '_id'>>
+	): Part[] {
+		const parts = Parts.find(
+			{
+				rundownId: rundown._id,
+				...selector,
+			},
+			{
+				sort: { _rank: 1 },
+				...options,
+			}
 		).fetch()
-		if (!options.sort) {
-			parts = RundownPlaylist._sortPartsInner(parts, segmentsInOrder || this.getSegments())
+
+		if (options?.sort) {
+			// User explicitly sorted the parts
+			return parts
+		} else {
+			// Default to sorting within the rundown
+			return RundownPlaylist._sortPartsInner(
+				parts,
+				segmentsInOrder || RundownCollectionUtil.getSegments(rundown, undefined, { fields: { _id: 1 } })
+			)
 		}
-		return parts
 	}
 	/** Synchronous version of getSegmentsAndParts, to be used client-side */
-	getSegmentsAndPartsSync(): { segments: Segment[]; parts: Part[] } {
+	static getSegmentsAndPartsSync(rundown: Pick<DBRundown, '_id'>): { segments: Segment[]; parts: Part[] } {
 		const segments = Segments.find(
 			{
-				rundownId: this._id,
+				rundownId: rundown._id,
 			},
 			{ sort: { _rank: 1 } }
 		).fetch()
 
 		const parts = Parts.find(
 			{
-				rundownId: this._id,
+				rundownId: rundown._id,
 			},
 			{ sort: { _rank: 1 } }
 		).fetch()
@@ -196,27 +205,8 @@ export class Rundown implements DBRundown {
 			parts: RundownPlaylist._sortPartsInner(parts, segments),
 		}
 	}
-	getAllPartInstances(selector?: MongoQuery<PartInstance>, options?: FindOptions<DBPartInstance>) {
-		selector = selector || {}
-		options = options || {}
-		return PartInstances.find(
-			_.extend(
-				{
-					rundownId: this._id,
-				},
-				selector
-			),
-			_.extend(
-				{
-					sort: { takeCount: 1 },
-				},
-				options
-			)
-		).fetch()
-	}
 }
 
-// export const Rundowns = createMongoCollection<Rundown>('rundowns', {transform: (doc) => applyClassToDocument(Rundown, doc) })
 export const Rundowns = createMongoCollectionOLD<Rundown, DBRundown>('rundowns', {
 	transform: (doc) => applyClassToDocument(Rundown, doc),
 })

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -8,7 +8,7 @@ import { IBlueprintRundownDB } from '@sofie-automation/blueprints-integration'
 import { ShowStyleVariant, ShowStyleVariants } from './ShowStyleVariants'
 import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from './ShowStyleBases'
 import { RundownNote } from '../api/notes'
-import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from './RundownPlaylists'
+import { RundownPlaylists, RundownPlaylist, RundownPlaylistId, RundownPlaylistCollectionUtil } from './RundownPlaylists'
 import { createMongoCollection } from './lib'
 import { PeripheralDeviceId } from './PeripheralDevices'
 import { OrganizationId } from './Organization'
@@ -141,7 +141,7 @@ export class RundownCollectionUtil {
 			return parts
 		} else {
 			// Default to sorting within the rundown
-			return RundownPlaylist._sortPartsInner(
+			return RundownPlaylistCollectionUtil._sortPartsInner(
 				parts,
 				segmentsInOrder || RundownCollectionUtil.getSegments(rundown, undefined, { fields: { _id: 1 } })
 			)
@@ -165,7 +165,7 @@ export class RundownCollectionUtil {
 
 		return {
 			segments: segments,
-			parts: RundownPlaylist._sortPartsInner(parts, segments),
+			parts: RundownPlaylistCollectionUtil._sortPartsInner(parts, segments),
 		}
 	}
 }

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -10,7 +10,7 @@ import { ShowStyleVariantId, ShowStyleVariant, ShowStyleVariants } from './ShowS
 import { ShowStyleBase, ShowStyleBases, ShowStyleBaseId } from './ShowStyleBases'
 import { RundownNote } from '../api/notes'
 import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from './RundownPlaylists'
-import { createMongoCollection } from './lib'
+import { createMongoCollectionOLD } from './lib'
 import { PartInstances, PartInstance, DBPartInstance } from './PartInstances'
 import { PeripheralDeviceId } from './PeripheralDevices'
 import { OrganizationId } from './Organization'
@@ -217,7 +217,7 @@ export class Rundown implements DBRundown {
 }
 
 // export const Rundowns = createMongoCollection<Rundown>('rundowns', {transform: (doc) => applyClassToDocument(Rundown, doc) })
-export const Rundowns = createMongoCollection<Rundown, DBRundown>('rundowns', {
+export const Rundowns = createMongoCollectionOLD<Rundown, DBRundown>('rundowns', {
 	transform: (doc) => applyClassToDocument(Rundown, doc),
 })
 registerCollection('Rundowns', Rundowns)

--- a/meteor/lib/collections/Segments.ts
+++ b/meteor/lib/collections/Segments.ts
@@ -8,7 +8,7 @@ import { registerIndex } from '../database'
 /** A string, identifying a Segment */
 export type SegmentId = ProtectedString<'SegmentId'>
 /** A "Title" in NRK Lingo / "Stories" in ENPS Lingo. */
-export interface DBSegment extends ProtectedStringProperties<IBlueprintSegmentDB, '_id'> {
+export interface Segment extends ProtectedStringProperties<IBlueprintSegmentDB, '_id'> {
 	_id: SegmentId
 	/** Position inside rundown */
 	_rank: number
@@ -26,8 +26,8 @@ export interface DBSegment extends ProtectedStringProperties<IBlueprintSegmentDB
 	notes?: Array<SegmentNote>
 }
 
-/** @deprecated TODO: TransformedCollection */
-export type Segment = DBSegment
+/** Note: Use Segment instead */
+export type DBSegment = Segment
 
 export const Segments = createMongoCollection<DBSegment>('segments')
 registerCollection('Segments', Segments)

--- a/meteor/lib/collections/Segments.ts
+++ b/meteor/lib/collections/Segments.ts
@@ -25,9 +25,11 @@ export interface DBSegment extends ProtectedStringProperties<IBlueprintSegmentDB
 	/** Holds notes (warnings / errors) thrown by the blueprints during creation */
 	notes?: Array<SegmentNote>
 }
+
+/** @deprecated TODO: TransformedCollection */
 export type Segment = DBSegment
 
-export const Segments = createMongoCollection<Segment, DBSegment>('segments')
+export const Segments = createMongoCollection<DBSegment>('segments')
 registerCollection('Segments', Segments)
 
 registerIndex(Segments, {

--- a/meteor/lib/collections/ShowStyleBases.ts
+++ b/meteor/lib/collections/ShowStyleBases.ts
@@ -28,9 +28,10 @@ export interface DBShowStyleBase extends ProtectedStringProperties<IBlueprintSho
 	_rundownVersionHash: string
 }
 
+/** @deprecated TODO: TransformedCollection */
 export type ShowStyleBase = DBShowStyleBase
 
-export const ShowStyleBases = createMongoCollection<ShowStyleBase, DBShowStyleBase>('showStyleBases')
+export const ShowStyleBases = createMongoCollection<DBShowStyleBase>('showStyleBases')
 registerCollection('ShowStyleBases', ShowStyleBases)
 
 registerIndex(ShowStyleBases, {

--- a/meteor/lib/collections/ShowStyleBases.ts
+++ b/meteor/lib/collections/ShowStyleBases.ts
@@ -13,7 +13,7 @@ export interface HotkeyDefinition {
 }
 /** A string, identifying a ShowStyleBase */
 export type ShowStyleBaseId = ProtectedString<'ShowStyleBaseId'>
-export interface DBShowStyleBase extends ProtectedStringProperties<IBlueprintShowStyleBase, '_id' | 'blueprintId'> {
+export interface ShowStyleBase extends ProtectedStringProperties<IBlueprintShowStyleBase, '_id' | 'blueprintId'> {
 	_id: ShowStyleBaseId
 
 	/** Name of this show style */
@@ -28,8 +28,8 @@ export interface DBShowStyleBase extends ProtectedStringProperties<IBlueprintSho
 	_rundownVersionHash: string
 }
 
-/** @deprecated TODO: TransformedCollection */
-export type ShowStyleBase = DBShowStyleBase
+/** Note: Use ShowStyleBase instead */
+export type DBShowStyleBase = ShowStyleBase
 
 export const ShowStyleBases = createMongoCollection<DBShowStyleBase>('showStyleBases')
 registerCollection('ShowStyleBases', ShowStyleBases)

--- a/meteor/lib/collections/ShowStyleVariants.ts
+++ b/meteor/lib/collections/ShowStyleVariants.ts
@@ -21,8 +21,9 @@ export interface ShowStyleCompound extends ShowStyleBase {
 	_rundownVersionHashVariant: string
 }
 
+/** @deprecated TODO: TransformedCollection */
 export type ShowStyleVariant = DBShowStyleVariant
-export const ShowStyleVariants = createMongoCollection<ShowStyleVariant, DBShowStyleVariant>('showStyleVariants')
+export const ShowStyleVariants = createMongoCollection<DBShowStyleVariant>('showStyleVariants')
 registerCollection('ShowStyleVariants', ShowStyleVariants)
 
 registerIndex(ShowStyleVariants, {

--- a/meteor/lib/collections/ShowStyleVariants.ts
+++ b/meteor/lib/collections/ShowStyleVariants.ts
@@ -8,7 +8,7 @@ import { registerIndex } from '../database'
 /** A string, identifying a ShowStyleVariant */
 export type ShowStyleVariantId = ProtectedString<'ShowStyleVariantId'>
 
-export interface DBShowStyleVariant extends ProtectedStringProperties<IBlueprintShowStyleVariant, '_id'> {
+export interface ShowStyleVariant extends ProtectedStringProperties<IBlueprintShowStyleVariant, '_id'> {
 	_id: ShowStyleVariantId
 	/** Id of parent ShowStyleBase */
 	showStyleBaseId: ShowStyleBaseId
@@ -21,8 +21,9 @@ export interface ShowStyleCompound extends ShowStyleBase {
 	_rundownVersionHashVariant: string
 }
 
-/** @deprecated TODO: TransformedCollection */
-export type ShowStyleVariant = DBShowStyleVariant
+/** Note: Use ShowStyleVariant instead */
+export type DBShowStyleVariant = ShowStyleVariant
+
 export const ShowStyleVariants = createMongoCollection<DBShowStyleVariant>('showStyleVariants')
 registerCollection('ShowStyleVariants', ShowStyleVariants)
 

--- a/meteor/lib/collections/Snapshots.ts
+++ b/meteor/lib/collections/Snapshots.ts
@@ -55,7 +55,7 @@ export interface SnapshotDebug extends SnapshotBase {
 	type: SnapshotType.DEBUG
 }
 
-export const Snapshots = createMongoCollection<SnapshotItem, SnapshotItem>('snapshots')
+export const Snapshots = createMongoCollection<SnapshotItem>('snapshots')
 registerCollection('Snapshots', Snapshots)
 
 registerIndex(Snapshots, {

--- a/meteor/lib/collections/Studios.ts
+++ b/meteor/lib/collections/Studios.ts
@@ -250,8 +250,9 @@ export interface RoutedMappings {
 	mappings: { [layerName: string]: MappingExt }
 }
 
+/** @deprecated TODO: TransformedCollection */
 export type Studio = DBStudio
-export const Studios = createMongoCollection<Studio, DBStudio>('studios')
+export const Studios = createMongoCollection<DBStudio>('studios')
 registerCollection('Studios', Studios)
 
 registerIndex(Studios, {

--- a/meteor/lib/collections/Timeline.ts
+++ b/meteor/lib/collections/Timeline.ts
@@ -182,7 +182,7 @@ export interface RoutedTimeline {
 }
 
 // export const Timeline = createMongoCollection<TimelineObj>('timeline')
-export const Timeline = createMongoCollection<TimelineComplete, TimelineComplete>('timeline')
+export const Timeline = createMongoCollection<TimelineComplete>('timeline')
 registerCollection('Timeline', Timeline)
 
 // Note: this index is always created by default, so it's not needed.

--- a/meteor/lib/collections/TranslationsBundles.ts
+++ b/meteor/lib/collections/TranslationsBundles.ts
@@ -42,5 +42,5 @@ export interface TranslationsBundle {
 	data: Translation[]
 }
 
-export const TranslationsBundles = createMongoCollection<TranslationsBundle, TranslationsBundle>('translationsBundles')
+export const TranslationsBundles = createMongoCollection<TranslationsBundle>('translationsBundles')
 registerCollection('TranslationsBundles', TranslationsBundles)

--- a/meteor/lib/collections/TriggeredActions.ts
+++ b/meteor/lib/collections/TriggeredActions.ts
@@ -24,8 +24,9 @@ export interface DBTriggeredActions extends ProtectedStringProperties<IBlueprint
 	_rundownVersionHash: string
 }
 
-/** @deprecated TODO: TransformedCollection */
+/** Note: Use DBTriggeredActions instead */
 export type TriggeredActionsObj = DBTriggeredActions
+
 export const TriggeredActions = createMongoCollection<DBTriggeredActions>('triggeredActions')
 registerCollection('TriggeredActions', TriggeredActions)
 

--- a/meteor/lib/collections/TriggeredActions.ts
+++ b/meteor/lib/collections/TriggeredActions.ts
@@ -24,8 +24,9 @@ export interface DBTriggeredActions extends ProtectedStringProperties<IBlueprint
 	_rundownVersionHash: string
 }
 
+/** @deprecated TODO: TransformedCollection */
 export type TriggeredActionsObj = DBTriggeredActions
-export const TriggeredActions = createMongoCollection<TriggeredActionsObj, DBTriggeredActions>('triggeredActions')
+export const TriggeredActions = createMongoCollection<DBTriggeredActions>('triggeredActions')
 registerCollection('TriggeredActions', TriggeredActions)
 
 registerIndex(TriggeredActions, {

--- a/meteor/lib/collections/UserActionsLog.ts
+++ b/meteor/lib/collections/UserActionsLog.ts
@@ -31,7 +31,7 @@ export interface UserActionsLogItem {
 	timelineResolveDuration?: TimeDuration[]
 }
 
-export const UserActionsLog = createMongoCollection<UserActionsLogItem, UserActionsLogItem>('userActionsLog')
+export const UserActionsLog = createMongoCollection<UserActionsLogItem>('userActionsLog')
 registerCollection('UserActionsLog', UserActionsLog)
 
 registerIndex(UserActionsLog, {

--- a/meteor/lib/collections/lib.ts
+++ b/meteor/lib/collections/lib.ts
@@ -77,7 +77,6 @@ export function createMongoCollection<DBInterface extends { _id: ProtectedString
 	options?: {
 		connection?: Object | null
 		idGeneration?: string
-		transform?: Function
 	}
 ): AsyncTransformedCollection<DBInterface, DBInterface> {
 	return createMongoCollectionOLD<DBInterface, DBInterface>(name, options)

--- a/meteor/lib/collections/lib.ts
+++ b/meteor/lib/collections/lib.ts
@@ -18,13 +18,13 @@ const ObserveChangeBufferTimeout = 2000
 
 type Timeout = number
 
-export function ObserveChangesForHash<Ta extends Tb, Tb extends { _id: ProtectedString<any> }>(
-	collection: AsyncTransformedCollection<Ta, Tb>,
+export function ObserveChangesForHash<DBInterface extends { _id: ProtectedString<any> }>(
+	collection: AsyncMongoCollection<DBInterface>,
 	hashName: string,
 	hashFields: string[],
 	skipEnsureUpdatedOnStart?: boolean
 ) {
-	const doUpdate = (id: Tb['_id'], obj: any) => {
+	const doUpdate = (id: DBInterface['_id'], obj: any) => {
 		const newHash = getHash(stringifyObjects(_.pick(obj, ...hashFields)))
 
 		if (newHash !== obj[hashName]) {
@@ -35,10 +35,10 @@ export function ObserveChangesForHash<Ta extends Tb, Tb extends { _id: Protected
 		}
 	}
 
-	const observedChangesTimeouts = new Map<Tb['_id'], Timeout>()
+	const observedChangesTimeouts = new Map<DBInterface['_id'], Timeout>()
 
 	collection.find().observeChanges({
-		changed: (id: Tb['_id'], changedFields) => {
+		changed: (id: DBInterface['_id'], changedFields) => {
 			// Ignore the hash field, to stop an infinite loop
 			delete changedFields[hashName]
 
@@ -78,43 +78,35 @@ export function createMongoCollection<DBInterface extends { _id: ProtectedString
 		connection?: Object | null
 		idGeneration?: string
 	}
-): AsyncTransformedCollection<DBInterface, DBInterface> {
-	return createMongoCollectionOLD<DBInterface, DBInterface>(name, options)
-}
-
-export function createMongoCollectionOLD<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-	name: string | null,
-	options?: {
-		connection?: Object | null
-		idGeneration?: string
-		transform?: Function
-	}
-): AsyncTransformedCollection<Class, DBInterface> {
-	const collection: TransformedCollection<Class, DBInterface> = new Mongo.Collection<Class>(name, options) as any
+): AsyncMongoCollection<DBInterface> {
+	const collection: TransformedCollection<DBInterface, DBInterface> = new Mongo.Collection<DBInterface>(
+		name,
+		options
+	) as any
 
 	if ((collection as any)._isMock) {
 		return new WrappedMockCollection(collection, name)
 	} else {
 		// Override the default mongodb methods, because the errors thrown by them doesn't contain the proper call stack
-		return new WrappedAsyncTransformedCollection(collection, name)
+		return new WrappedAsyncMongoCollection(collection, name)
 	}
 }
 
 export function wrapMongoCollection<DBInterface extends { _id: ProtectedString<any> }>(
 	collection: Mongo.Collection<DBInterface>,
 	name: string
-): AsyncTransformedCollection<DBInterface, DBInterface> {
-	return new WrappedAsyncTransformedCollection<DBInterface, DBInterface>(collection as any, name)
+): AsyncMongoCollection<DBInterface> {
+	return new WrappedAsyncMongoCollection<DBInterface>(collection as any, name)
 }
 
-class WrappedTransformedCollection<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>
-	implements TransformedCollection<Class, DBInterface>
+class WrappedTransformedCollection<DBInterface extends { _id: ProtectedString<any> }>
+	implements TransformedCollection<DBInterface, DBInterface>
 {
-	readonly #collection: TransformedCollection<Class, DBInterface>
+	readonly #collection: TransformedCollection<DBInterface, DBInterface>
 
 	public readonly name: string | null
 
-	constructor(collection: TransformedCollection<Class, DBInterface>, name: string | null) {
+	constructor(collection: TransformedCollection<DBInterface, DBInterface>, name: string | null) {
 		this.#collection = collection
 		this.name = name
 	}
@@ -124,37 +116,32 @@ class WrappedTransformedCollection<Class extends DBInterface, DBInterface extend
 		return this.#collection._isMock
 	}
 
-	private get _transform() {
-		// @ts-expect-error re-export private property
-		return this.#collection._transform
-	}
-
 	private wrapMongoError(e: any): never {
 		const str = (e && e.reason) || e.toString() || e || 'Unknown MongoDB Error'
 		throw new Meteor.Error((e && e.error) || 500, `Collection "${this.name}": ${str}`)
 	}
 
-	allow(...args: Parameters<TransformedCollection<Class, DBInterface>['allow']>): boolean {
+	allow(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['allow']>): boolean {
 		return this.#collection.allow(...args)
 	}
-	deny(...args: Parameters<TransformedCollection<Class, DBInterface>['deny']>): boolean {
+	deny(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['deny']>): boolean {
 		return this.#collection.deny(...args)
 	}
-	find(...args: Parameters<TransformedCollection<Class, DBInterface>['find']>): Mongocursor<Class> {
+	find(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['find']>): Mongocursor<DBInterface> {
 		try {
 			return this.#collection.find(...args)
 		} catch (e) {
 			this.wrapMongoError(e)
 		}
 	}
-	findOne(...args: Parameters<TransformedCollection<Class, DBInterface>['findOne']>): Class | undefined {
+	findOne(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['findOne']>): DBInterface | undefined {
 		try {
 			return this.#collection.findOne(...args)
 		} catch (e) {
 			this.wrapMongoError(e)
 		}
 	}
-	insert(...args: Parameters<TransformedCollection<Class, DBInterface>['insert']>): DBInterface['_id'] {
+	insert(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['insert']>): DBInterface['_id'] {
 		try {
 			return this.#collection.insert(...args)
 		} catch (e) {
@@ -167,21 +154,21 @@ class WrappedTransformedCollection<Class extends DBInterface, DBInterface extend
 	rawDatabase(): any {
 		return this.#collection.rawDatabase()
 	}
-	remove(...args: Parameters<TransformedCollection<Class, DBInterface>['remove']>): number {
+	remove(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['remove']>): number {
 		try {
 			return this.#collection.remove(...args)
 		} catch (e) {
 			this.wrapMongoError(e)
 		}
 	}
-	update(...args: Parameters<TransformedCollection<Class, DBInterface>['update']>): number {
+	update(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['update']>): number {
 		try {
 			return this.#collection.update(...args)
 		} catch (e) {
 			this.wrapMongoError(e)
 		}
 	}
-	upsert(...args: Parameters<TransformedCollection<Class, DBInterface>['upsert']>): {
+	upsert(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['upsert']>): {
 		numberAffected?: number
 		insertedId?: DBInterface['_id']
 	} {
@@ -192,14 +179,14 @@ class WrappedTransformedCollection<Class extends DBInterface, DBInterface extend
 		}
 	}
 
-	_ensureIndex(...args: Parameters<TransformedCollection<Class, DBInterface>['_ensureIndex']>): void {
+	_ensureIndex(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['_ensureIndex']>): void {
 		try {
 			return this.#collection._ensureIndex(...args)
 		} catch (e) {
 			this.wrapMongoError(e)
 		}
 	}
-	_dropIndex(...args: Parameters<TransformedCollection<Class, DBInterface>['_dropIndex']>): void {
+	_dropIndex(...args: Parameters<TransformedCollection<DBInterface, DBInterface>['_dropIndex']>): void {
 		try {
 			return this.#collection._dropIndex(...args)
 		} catch (e) {
@@ -208,14 +195,14 @@ class WrappedTransformedCollection<Class extends DBInterface, DBInterface extend
 	}
 }
 
-class WrappedAsyncTransformedCollection<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>
-	extends WrappedTransformedCollection<Class, DBInterface>
-	implements AsyncTransformedCollection<Class, DBInterface>
+class WrappedAsyncMongoCollection<DBInterface extends { _id: ProtectedString<any> }>
+	extends WrappedTransformedCollection<DBInterface>
+	implements AsyncMongoCollection<DBInterface>
 {
 	async findFetchAsync(
 		selector: MongoQuery<DBInterface> | string,
 		options?: FindOptions<DBInterface>
-	): Promise<Array<Class>> {
+	): Promise<Array<DBInterface>> {
 		// Make the collection fethcing in another Fiber:
 		const p = makePromise(() => {
 			return this.find(selector as any, options).fetch()
@@ -228,7 +215,7 @@ class WrappedAsyncTransformedCollection<Class extends DBInterface, DBInterface e
 	async findOneAsync(
 		selector: MongoQuery<DBInterface> | DBInterface['_id'],
 		options?: FindOptions<DBInterface>
-	): Promise<Class | undefined> {
+	): Promise<DBInterface | undefined> {
 		const arr = await this.findFetchAsync(selector, { ...options, limit: 1 })
 		return arr[0]
 	}
@@ -337,13 +324,13 @@ class WrappedAsyncTransformedCollection<Class extends DBInterface, DBInterface e
 }
 
 /** This is for the mock mongo collection, as internally it is sync and so we dont need or want to play around with fibers */
-class WrappedMockCollection<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>
-	extends WrappedTransformedCollection<Class, DBInterface>
-	implements AsyncTransformedCollection<Class, DBInterface>
+class WrappedMockCollection<DBInterface extends { _id: ProtectedString<any> }>
+	extends WrappedTransformedCollection<DBInterface>
+	implements AsyncMongoCollection<DBInterface>
 {
 	private readonly realSleep: (time: number) => Promise<void>
 
-	constructor(collection: TransformedCollection<Class, DBInterface>, name: string | null) {
+	constructor(collection: TransformedCollection<DBInterface, DBInterface>, name: string | null) {
 		super(collection, name)
 
 		if (!this._isMock) throw new Meteor.Error(500, 'WrappedMockCollection is only valid for a mock collection')
@@ -355,7 +342,7 @@ class WrappedMockCollection<Class extends DBInterface, DBInterface extends { _id
 	async findFetchAsync(
 		selector: MongoQuery<DBInterface> | string,
 		options?: FindOptions<DBInterface>
-	): Promise<Array<Class>> {
+	): Promise<Array<DBInterface>> {
 		await this.realSleep(0)
 		return this.find(selector as any, options).fetch()
 	}
@@ -363,7 +350,7 @@ class WrappedMockCollection<Class extends DBInterface, DBInterface extends { _id
 	async findOneAsync(
 		selector: MongoQuery<DBInterface> | DBInterface['_id'],
 		options?: FindOptions<DBInterface>
-	): Promise<Class | undefined> {
+	): Promise<DBInterface | undefined> {
 		const arr = await this.findFetchAsync(selector, { ...options, limit: 1 })
 		return arr[0]
 	}
@@ -453,17 +440,15 @@ class WrappedMockCollection<Class extends DBInterface, DBInterface extends { _id
 	}
 }
 
-export interface AsyncTransformedCollection<
-	Class extends DBInterface,
-	DBInterface extends { _id: ProtectedString<any> }
-> extends TransformedCollection<Class, DBInterface> {
+export interface AsyncMongoCollection<DBInterface extends { _id: ProtectedString<any> }>
+	extends TransformedCollection<DBInterface, DBInterface> {
 	name: string | null
 
-	findFetchAsync(selector: MongoQuery<DBInterface>, options?: FindOptions<DBInterface>): Promise<Array<Class>>
+	findFetchAsync(selector: MongoQuery<DBInterface>, options?: FindOptions<DBInterface>): Promise<Array<DBInterface>>
 	findOneAsync(
 		selector: MongoQuery<DBInterface> | DBInterface['_id'],
 		options?: FindOptions<DBInterface>
-	): Promise<Class | undefined>
+	): Promise<DBInterface | undefined>
 
 	insertAsync(doc: DBInterface): Promise<DBInterface['_id']>
 

--- a/meteor/lib/collections/lib.ts
+++ b/meteor/lib/collections/lib.ts
@@ -72,7 +72,18 @@ export function ObserveChangesForHash<Ta extends Tb, Tb extends { _id: Protected
 	}
 }
 
-export function createMongoCollection<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
+export function createMongoCollection<DBInterface extends { _id: ProtectedString<any> }>(
+	name: string | null,
+	options?: {
+		connection?: Object | null
+		idGeneration?: string
+		transform?: Function
+	}
+): AsyncTransformedCollection<DBInterface, DBInterface> {
+	return createMongoCollectionOLD<DBInterface, DBInterface>(name, options)
+}
+
+export function createMongoCollectionOLD<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
 	name: string | null,
 	options?: {
 		connection?: Object | null

--- a/meteor/lib/database.ts
+++ b/meteor/lib/database.ts
@@ -1,13 +1,13 @@
 import { IndexSpecifier } from './typings/meteor'
 import { ProtectedString } from './lib'
 import { Meteor } from 'meteor/meteor'
-import { AsyncTransformedCollection } from './collections/lib'
+import { AsyncMongoCollection } from './collections/lib'
 
 interface CollectionsIndexes {
-	[collectionName: string]: CollectionIndexes<any, any>
+	[collectionName: string]: CollectionIndexes<any>
 }
-interface CollectionIndexes<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }> {
-	collection: AsyncTransformedCollection<Class, DBInterface>
+interface CollectionIndexes<DBInterface extends { _id: ProtectedString<any> }> {
+	collection: AsyncMongoCollection<DBInterface>
 	indexes: IndexSpecifier<DBInterface>[]
 }
 
@@ -17,8 +17,8 @@ const indexes: CollectionsIndexes = {}
  * @param collection
  * @param index
  */
-export function registerIndex<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-	collection: AsyncTransformedCollection<Class, DBInterface>,
+export function registerIndex<DBInterface extends { _id: ProtectedString<any> }>(
+	collection: AsyncMongoCollection<DBInterface>,
 	index: IndexSpecifier<DBInterface>
 ) {
 	if (!Meteor.isServer) return // only used server-side

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -9,7 +9,7 @@ import * as objectPath from 'object-path'
 import { iterateDeeply, iterateDeeplyEnum } from '@sofie-automation/blueprints-integration'
 import { ReadonlyDeep, PartialDeep } from 'type-fest'
 import { ITranslatableMessage } from './api/TranslatableMessage'
-import { AsyncTransformedCollection } from './collections/lib'
+import { AsyncMongoCollection } from './collections/lib'
 
 export * from './hash'
 
@@ -236,11 +236,11 @@ export function stringifyObjects(objs: any): string {
 		return objs + ''
 	}
 }
-export const Collections: { [name: string]: AsyncTransformedCollection<any, any> } = {}
-export function registerCollection(name: string, collection: AsyncTransformedCollection<any, any>) {
+export const Collections: { [name: string]: AsyncMongoCollection<any> } = {}
+export function registerCollection(name: string, collection: AsyncMongoCollection<any>) {
 	Collections[name] = collection
 }
-export function getCollectionKey(collection: AsyncTransformedCollection<any, any>): string {
+export function getCollectionKey(collection: AsyncMongoCollection<any>): string {
 	const o = Object.entries(Collections).find(([_key, col]) => col === collection)
 	if (!o) throw new Meteor.Error(500, `Collection "${collection.name}" not found in Collections!`)
 	return o[0] // collectionName
@@ -674,10 +674,10 @@ export function mongoWhere<T>(o: any, selector: MongoQuery<T>): boolean {
 	})
 	return ok
 }
-export function mongoFindOptions<Class extends DBInterface, DBInterface extends { _id?: ProtectedString<any> }>(
-	docs0: ReadonlyArray<Class>,
+export function mongoFindOptions<DBInterface extends { _id?: ProtectedString<any> }>(
+	docs0: ReadonlyArray<DBInterface>,
 	options: FindOptions<DBInterface> | undefined
-): Class[] {
+): DBInterface[] {
 	let docs = [...docs0] // Shallow clone it
 	if (options) {
 		const sortOptions = options.sort

--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -135,9 +135,6 @@ export function omit<T, P extends keyof T>(obj: T, ...props: P[]): Omit<T, P> {
 	return _.omit(obj, ...(props as string[]))
 }
 
-export function applyClassToDocument(docClass, document) {
-	return new docClass(document)
-}
 export function formatDateAsTimecode(date: Date) {
 	const tc = Timecode.init({
 		framerate: Settings.frameRate + '',

--- a/meteor/lib/rundown/__tests__/infinites.test.ts
+++ b/meteor/lib/rundown/__tests__/infinites.test.ts
@@ -470,32 +470,30 @@ describe('Infinites', () => {
 			name: string,
 			externalId: string
 		): Rundown {
-			return new Rundown(
-				literal<DBRundown>({
-					_rank: 0,
-					_id: id,
-					externalId,
-					organizationId: protectString('test'),
-					name,
-					showStyleVariantId: protectString('test-variant'),
-					showStyleBaseId: protectString('test-base'),
-					studioId: protectString('studio0'),
-					created: 0,
-					modified: 0,
-					importVersions: {
-						studio: '0.0.0',
-						showStyleBase: '0.0.0',
-						showStyleVariant: '0.0.0',
-						blueprint: '0.0.0',
-						core: '0.0.0`',
-					},
-					externalNRCSName: 'test',
-					playlistId,
-					timing: {
-						type: PlaylistTimingType.None,
-					},
-				})
-			)
+			return literal<DBRundown>({
+				_rank: 0,
+				_id: id,
+				externalId,
+				organizationId: protectString('test'),
+				name,
+				showStyleVariantId: protectString('test-variant'),
+				showStyleBaseId: protectString('test-base'),
+				studioId: protectString('studio0'),
+				created: 0,
+				modified: 0,
+				importVersions: {
+					studio: '0.0.0',
+					showStyleBase: '0.0.0',
+					showStyleVariant: '0.0.0',
+					blueprint: '0.0.0',
+					core: '0.0.0`',
+				},
+				externalNRCSName: 'test',
+				playlistId,
+				timing: {
+					type: PlaylistTimingType.None,
+				},
+			})
 		}
 
 		testInFiber('multiple continued pieces starting at 0 should preserve the newest', () => {

--- a/meteor/lib/rundown/__tests__/rundownTiming.test.ts
+++ b/meteor/lib/rundown/__tests__/rundownTiming.test.ts
@@ -8,23 +8,21 @@ import { RundownTimingCalculator, RundownTimingContext } from '../rundownTiming'
 const DEFAULT_DURATION = 4000
 
 function makeMockPlaylist(): RundownPlaylist {
-	return new RundownPlaylist(
-		literal<DBRundownPlaylist>({
-			_id: protectString('mock-playlist'),
-			externalId: 'mock-playlist',
-			organizationId: protectString('test'),
-			studioId: protectString('studio0'),
-			name: 'Mock Playlist',
-			created: 0,
-			modified: 0,
-			currentPartInstanceId: null,
-			nextPartInstanceId: null,
-			previousPartInstanceId: null,
-			timing: {
-				type: 'none' as any,
-			},
-		})
-	)
+	return literal<DBRundownPlaylist>({
+		_id: protectString('mock-playlist'),
+		externalId: 'mock-playlist',
+		organizationId: protectString('test'),
+		studioId: protectString('studio0'),
+		name: 'Mock Playlist',
+		created: 0,
+		modified: 0,
+		currentPartInstanceId: null,
+		nextPartInstanceId: null,
+		previousPartInstanceId: null,
+		timing: {
+			type: 'none' as any,
+		},
+	})
 }
 
 function makeMockPart(

--- a/meteor/lib/rundown/__tests__/rundownTiming.test.ts
+++ b/meteor/lib/rundown/__tests__/rundownTiming.test.ts
@@ -1,7 +1,7 @@
 import { PartInstance } from '../../collections/PartInstances'
 import { DBPart, Part, PartId } from '../../collections/Parts'
 import { DBRundownPlaylist, RundownPlaylist } from '../../collections/RundownPlaylists'
-import { DBRundown, Rundown } from '../../collections/Rundowns'
+import { DBRundown } from '../../collections/Rundowns'
 import { literal, protectString, unprotectString } from '../../lib'
 import { RundownTimingCalculator, RundownTimingContext } from '../rundownTiming'
 
@@ -53,27 +53,25 @@ function makeMockPart(
 }
 
 function makeMockRundown(id: string, playlistId: string, rank: number) {
-	return new Rundown(
-		literal<DBRundown>({
-			_id: protectString(id),
-			externalId: id,
-			timing: {
-				type: 'none' as any,
-			},
-			studioId: protectString('studio0'),
-			showStyleBaseId: protectString(''),
-			showStyleVariantId: protectString('variant0'),
-			peripheralDeviceId: protectString(''),
-			created: 0,
-			modified: 0,
-			importVersions: {} as any,
-			name: 'test',
-			externalNRCSName: 'mockNRCS',
-			organizationId: protectString(''),
-			playlistId: protectString(playlistId),
-			_rank: rank,
-		})
-	)
+	return literal<DBRundown>({
+		_id: protectString(id),
+		externalId: id,
+		timing: {
+			type: 'none' as any,
+		},
+		studioId: protectString('studio0'),
+		showStyleBaseId: protectString(''),
+		showStyleVariantId: protectString('variant0'),
+		peripheralDeviceId: protectString(''),
+		created: 0,
+		modified: 0,
+		importVersions: {} as any,
+		name: 'test',
+		externalNRCSName: 'mockNRCS',
+		organizationId: protectString(''),
+		playlistId: protectString(playlistId),
+		_rank: rank,
+	})
 }
 
 describe('rundown Timing Calculator', () => {

--- a/meteor/lib/rundown/__tests__/rundownTiming.test.ts
+++ b/meteor/lib/rundown/__tests__/rundownTiming.test.ts
@@ -39,17 +39,15 @@ function makeMockPart(
 		displayDurationGroup?: string
 	}
 ): Part {
-	return new Part(
-		literal<DBPart>({
-			_id: protectString(id),
-			externalId: id,
-			title: '',
-			segmentId: protectString(segmentId),
-			_rank: rank,
-			rundownId: protectString(rundownId),
-			...durations,
-		})
-	)
+	return literal<DBPart>({
+		_id: protectString(id),
+		externalId: id,
+		title: '',
+		segmentId: protectString(segmentId),
+		_rank: rank,
+		rundownId: protectString(rundownId),
+		...durations,
+	})
 }
 
 function makeMockRundown(id: string, playlistId: string, rank: number) {

--- a/meteor/lib/rundown/infinites.ts
+++ b/meteor/lib/rundown/infinites.ts
@@ -1,7 +1,7 @@
 import _ from 'underscore'
 import { PartInstance, PartInstanceId } from '../collections/PartInstances'
 import { PieceInstance, PieceInstancePiece, rewrapPieceToInstance } from '../collections/PieceInstances'
-import { DBPart, PartId } from '../collections/Parts'
+import { DBPart, Part, PartId } from '../collections/Parts'
 import { Piece } from '../collections/Pieces'
 import { SegmentId } from '../collections/Segments'
 import { PieceLifespan } from '@sofie-automation/blueprints-integration'
@@ -91,8 +91,8 @@ export function getPlayheadTrackingInfinitesForPart(
 	rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,
 	currentPartInstance: PartInstance,
 	currentPartPieceInstances: PieceInstance[],
-	rundown: ReadonlyDeep<Rundown>,
-	part: DBPart,
+	rundown: ReadonlyDeep<Pick<Rundown, '_id' | 'showStyleBaseId'>>,
+	part: Part,
 	newInstanceId: PartInstanceId,
 	nextPartIsAfterCurrentPart: boolean,
 	isTemporary: boolean
@@ -260,8 +260,8 @@ export function isPiecePotentiallyActiveInPart(
 	segmentsBeforeThisInRundown: Set<SegmentId>,
 	rundownsBeforeThisInPlaylist: RundownId[],
 	rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,
-	rundown: ReadonlyDeep<Rundown>,
-	part: DBPart,
+	rundown: ReadonlyDeep<Pick<Rundown, '_id' | 'showStyleBaseId'>>,
+	part: Part,
 	pieceToCheck: Piece
 ): boolean {
 	// If its from the current part
@@ -330,8 +330,8 @@ export function getPieceInstancesForPart(
 	playlistActivationId: RundownPlaylistActivationId,
 	playingPartInstance: PartInstance | undefined,
 	playingPieceInstances: PieceInstance[] | undefined,
-	rundown: ReadonlyDeep<Rundown>,
-	part: DBPart,
+	rundown: ReadonlyDeep<Pick<Rundown, '_id' | 'showStyleBaseId'>>,
+	part: Part,
 	partsBeforeThisInSegmentSet: Set<PartId>,
 	segmentsBeforeThisInRundownSet: Set<SegmentId>,
 	rundownsBeforeThisInPlaylist: RundownId[],
@@ -698,7 +698,7 @@ function continueShowStyleEndInfinites(
 	rundownsBeforeThisInPlaylist: RundownId[],
 	rundownsToShowstyles: Map<RundownId, ShowStyleBaseId>,
 	previousRundownId: RundownId,
-	rundown: ReadonlyDeep<Rundown>
+	rundown: ReadonlyDeep<Pick<Rundown, '_id' | 'showStyleBaseId'>>
 ): boolean {
 	let canContinueShowStyleEndInfinites = true
 	if (rundown.showStyleBaseId !== rundownsToShowstyles.get(previousRundownId)) {

--- a/meteor/lib/rundownNotifications.ts
+++ b/meteor/lib/rundownNotifications.ts
@@ -6,7 +6,7 @@ import { unprotectString, literal, generateTranslation, normalizeArrayToMap, ass
 import * as _ from 'underscore'
 import { DBPartInstance, PartInstance, PartInstances } from './collections/PartInstances'
 import { MongoFieldSpecifierOnes } from './typings/meteor'
-import { RundownPlaylist } from './collections/RundownPlaylists'
+import { RundownPlaylistCollectionUtil } from './collections/RundownPlaylists'
 import { ITranslatableMessage } from './api/TranslatableMessage'
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 
@@ -82,8 +82,8 @@ export function getSegmentPartNotes(rundownIds: RundownId[]): TrackedNote[] {
 		}
 	).fetch()
 
-	const sortedSegments = RundownPlaylist._sortSegments(segments, rundowns)
-	const sortedParts = RundownPlaylist._sortPartsInner(parts, segments)
+	const sortedSegments = RundownPlaylistCollectionUtil._sortSegments(segments, rundowns)
+	const sortedParts = RundownPlaylistCollectionUtil._sortPartsInner(parts, segments)
 
 	return getAllNotesForSegmentAndParts(rundowns, sortedSegments, sortedParts, deletedPartInstances)
 }

--- a/meteor/server/api/ExternalMessageQueue.ts
+++ b/meteor/server/api/ExternalMessageQueue.ts
@@ -15,7 +15,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import { getCurrentTime, removeNullyProperties, getRandomId, protectString, omit } from '../../lib/lib'
 import { registerClassToMeteorMethods } from '../methods'
-import { Rundown } from '../../lib/collections/Rundowns'
+import { Rundown, RundownCollectionUtil } from '../../lib/collections/Rundowns'
 import { NewExternalMessageQueueAPI, ExternalMessageQueueAPIMethods } from '../../lib/api/ExternalMessageQueue'
 import { sendSOAPMessage } from './integration/soap'
 import { sendSlackMessageToWebhook } from './integration/slack'
@@ -32,7 +32,7 @@ export function queueExternalMessages(
 	rundown: ReadonlyDeep<Rundown>,
 	messages: Array<IBlueprintExternalMessageQueueObj>
 ) {
-	const playlist = rundown.getRundownPlaylist()
+	const playlist = RundownCollectionUtil.getRundownPlaylist(rundown)
 
 	_.each(messages, (message: IBlueprintExternalMessageQueueObj) => {
 		// check the output:

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -23,7 +23,12 @@ import * as MOS from 'mos-connection'
 import { testInFiber } from '../../../__mocks__/helpers/jest'
 import { setupDefaultStudioEnvironment, DefaultEnvironment } from '../../../__mocks__/helpers/database'
 import { setLogLevel } from '../../logging'
-import { RundownPlaylists, RundownPlaylistId, RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylistId,
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+} from '../../../lib/collections/RundownPlaylists'
 import {
 	IngestDeviceSettings,
 	IngestDeviceSecretSettings,
@@ -309,7 +314,8 @@ describe('test peripheralDevice general API methods', () => {
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
 		expect(playlist).toBeTruthy()
-		const currentPartInstance = playlist?.getSelectedPartInstances()?.currentPartInstance as PartInstance
+		const currentPartInstance = (playlist &&
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)?.currentPartInstance) as PartInstance
 		expect(currentPartInstance).toBeTruthy()
 		const partPlaybackStartedResult: PeripheralDeviceAPI.PartPlaybackStartedResult = {
 			rundownPlaylistId: rundownPlaylistID,
@@ -334,7 +340,8 @@ describe('test peripheralDevice general API methods', () => {
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
 		expect(playlist).toBeTruthy()
-		const currentPartInstance = playlist?.getSelectedPartInstances().currentPartInstance as PartInstance
+		const currentPartInstance = (playlist &&
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)?.currentPartInstance) as PartInstance
 		expect(currentPartInstance).toBeTruthy()
 		const partPlaybackStoppedResult: PeripheralDeviceAPI.PartPlaybackStoppedResult = {
 			rundownPlaylistId: rundownPlaylistID,
@@ -360,7 +367,8 @@ describe('test peripheralDevice general API methods', () => {
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
 		expect(playlist).toBeTruthy()
-		const currentPartInstance = playlist?.getSelectedPartInstances().currentPartInstance as PartInstance
+		const currentPartInstance = (playlist &&
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)?.currentPartInstance) as PartInstance
 		expect(currentPartInstance).toBeTruthy()
 		const pieces = PieceInstances.find({
 			partInstanceId: currentPartInstance._id,
@@ -394,7 +402,8 @@ describe('test peripheralDevice general API methods', () => {
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
 		expect(playlist).toBeTruthy()
-		const currentPartInstance = playlist?.getSelectedPartInstances().currentPartInstance as PartInstance
+		const currentPartInstance = (playlist &&
+			RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)?.currentPartInstance) as PartInstance
 		expect(currentPartInstance).toBeTruthy()
 		const pieces = PieceInstances.find({
 			partInstanceId: currentPartInstance._id,

--- a/meteor/server/api/__tests__/rundown-updatePartInstanceRanks.test.ts
+++ b/meteor/server/api/__tests__/rundown-updatePartInstanceRanks.test.ts
@@ -265,14 +265,14 @@ describe('updatePartInstanceRanks', () => {
 		// insert an adlib part
 		const adlibId = 'adlib0'
 		insertPartInstance(
-			new Part({
+			{
 				_id: protectString(adlibId),
 				_rank: 3.5, // after part03
 				rundownId,
 				segmentId,
 				externalId: adlibId,
 				title: adlibId,
-			}),
+			},
 			'adlib-part'
 		)
 

--- a/meteor/server/api/__tests__/rundown-updatePartInstanceRanks.test.ts
+++ b/meteor/server/api/__tests__/rundown-updatePartInstanceRanks.test.ts
@@ -362,6 +362,7 @@ describe('updatePartInstanceRanks', () => {
 		insertAllPartInstances()
 
 		const initialInstanceRanks = getPartInstanceRanks()
+		expect(initialInstanceRanks.filter((r) => r.orphaned)).toHaveLength(0)
 		expect(initialInstanceRanks).toHaveLength(5)
 
 		// Delete the segment

--- a/meteor/server/api/__tests__/userActions/general.test.ts
+++ b/meteor/server/api/__tests__/userActions/general.test.ts
@@ -6,7 +6,7 @@ import {
 	DefaultEnvironment,
 	setupDefaultRundownPlaylist,
 } from '../../../../__mocks__/helpers/database'
-import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import { setMinimumTakeSpan } from '../../userActions'
 import { RundownPlaylists, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import { RESTART_SALT } from '../../../../lib/api/userActions'
@@ -113,7 +113,7 @@ describe('User Actions - General', () => {
 		expect(getRundown1()).toBeTruthy()
 		expect(getRundown0()._id).not.toEqual(getRundown1()._id)
 
-		const parts = getRundown0().getParts()
+		const parts = RundownCollectionUtil.getParts(getRundown0())
 
 		expect(getPlaylist0()).toMatchObject({
 			activationId: undefined,

--- a/meteor/server/api/__tests__/userActions/general.test.ts
+++ b/meteor/server/api/__tests__/userActions/general.test.ts
@@ -8,7 +8,11 @@ import {
 } from '../../../../__mocks__/helpers/database'
 import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import { setMinimumTakeSpan } from '../../userActions'
-import { RundownPlaylists, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+} from '../../../../lib/collections/RundownPlaylists'
 import { RESTART_SALT } from '../../../../lib/api/userActions'
 import { getHash } from '../../../../lib/lib'
 import { UserActionsLog } from '../../../../lib/collections/UserActionsLog'
@@ -126,7 +130,9 @@ describe('User Actions - General', () => {
 				success: 200,
 			})
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeFalsy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(nextPartInstance!.part._id).toEqual(parts[0]._id)
@@ -148,7 +154,9 @@ describe('User Actions - General', () => {
 			// Take the first Part:
 			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[0]._id)
@@ -159,7 +167,9 @@ describe('User Actions - General', () => {
 			// Take the second Part:
 			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[1]._id)
@@ -172,7 +182,9 @@ describe('User Actions - General', () => {
 				success: 200,
 			})
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeFalsy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(nextPartInstance!.part._id).toEqual(parts[0]._id)
@@ -189,7 +201,9 @@ describe('User Actions - General', () => {
 				Meteor.call(UserActionAPI.methods.setNext, 'e', playlistId0, parts[parts.length - 2]._id)
 			).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeFalsy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(nextPartInstance!.part._id).toEqual(parts[parts.length - 2]._id)
@@ -204,7 +218,9 @@ describe('User Actions - General', () => {
 			// Take the Nexted Part:
 			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[parts.length - 2]._id)
@@ -214,7 +230,9 @@ describe('User Actions - General', () => {
 		{
 			// Take the last Part:
 			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeFalsy()
 			expect(currentPartInstance!.part._id).toEqual(parts[parts.length - 1]._id)
@@ -229,7 +247,9 @@ describe('User Actions - General', () => {
 			// Move the next-point backwards:
 			expect(Meteor.call(UserActionAPI.methods.moveNext, 'e', playlistId0, -1, 0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[parts.length - 1]._id)
@@ -240,7 +260,9 @@ describe('User Actions - General', () => {
 			// Move the next-point backwards:
 			expect(Meteor.call(UserActionAPI.methods.moveNext, 'e', playlistId0, -1, 0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[parts.length - 1]._id)
@@ -251,7 +273,9 @@ describe('User Actions - General', () => {
 			// Take the nexted Part:
 			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
 
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[parts.length - 3]._id)

--- a/meteor/server/api/blueprints/__tests__/cache.test.ts
+++ b/meteor/server/api/blueprints/__tests__/cache.test.ts
@@ -1,6 +1,6 @@
 import '../../../../__mocks__/_extendJest'
 import { setupDefaultStudioEnvironment } from '../../../../__mocks__/helpers/database'
-import { Rundown, DBRundown } from '../../../../lib/collections/Rundowns'
+import { DBRundown } from '../../../../lib/collections/Rundowns'
 import { literal, protectString } from '../../../../lib/lib'
 import {
 	loadSystemBlueprints,
@@ -351,27 +351,25 @@ describe('Test blueprint cache', () => {
 
 	describe('getBlueprintOfRundown', () => {
 		function getRundown() {
-			return new Rundown(
-				literal<DBRundown>({
-					_id: protectString('ro1'),
-					playlistId: protectString('pls0'),
-					_rank: 1,
-					externalId: 'ro1',
-					studioId: protectString('studio0'),
-					showStyleBaseId: protectString(''),
-					showStyleVariantId: protectString('variant0'),
-					peripheralDeviceId: protectString(''),
-					created: 0,
-					modified: 0,
-					importVersions: {} as any,
-					name: 'test',
-					externalNRCSName: 'mockNRCS',
-					organizationId: protectString(''),
-					timing: {
-						type: 'none' as any,
-					},
-				})
-			)
+			return literal<DBRundown>({
+				_id: protectString('ro1'),
+				playlistId: protectString('pls0'),
+				_rank: 1,
+				externalId: 'ro1',
+				studioId: protectString('studio0'),
+				showStyleBaseId: protectString(''),
+				showStyleVariantId: protectString('variant0'),
+				peripheralDeviceId: protectString(''),
+				created: 0,
+				modified: 0,
+				importVersions: {} as any,
+				name: 'test',
+				externalNRCSName: 'mockNRCS',
+				organizationId: protectString(''),
+				timing: {
+					type: 'none' as any,
+				},
+			})
 		}
 		test('Valid showStyleBase', async () => {
 			const showStyle = ShowStyleBases.findOne() as ShowStyleBase

--- a/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-adlibActions.test.ts
@@ -8,7 +8,7 @@ import { protectString, unprotectString, getRandomId, getCurrentTime, clone } fr
 import { Studio, Studios } from '../../../../lib/collections/Studios'
 import { IBlueprintPart, IBlueprintPiece, PieceLifespan } from '@sofie-automation/blueprints-integration'
 import { ActionExecutionContext, ActionPartChange } from '../context'
-import { Rundown, Rundowns } from '../../../../lib/collections/Rundowns'
+import { Rundown, RundownCollectionUtil, Rundowns } from '../../../../lib/collections/Rundowns'
 import { PartInstance, PartInstanceId, PartInstances } from '../../../../lib/collections/PartInstances'
 import {
 	PieceInstance,
@@ -63,7 +63,7 @@ describe('Test blueprint api context', () => {
 		const activationId = playlist.activationId as RundownPlaylistActivationId
 		expect(activationId).toBeTruthy()
 
-		rundown.getParts().forEach((part, i) => {
+		RundownCollectionUtil.getParts(rundown).forEach((part, i) => {
 			// make into a partInstance
 			PartInstances.insert({
 				_id: protectString(`${part._id}_instance`),

--- a/meteor/server/api/blueprints/__tests__/context-events.test.ts
+++ b/meteor/server/api/blueprints/__tests__/context-events.test.ts
@@ -13,7 +13,7 @@ import {
 	RundownDataChangedEventContext,
 	RundownTimingEventContext,
 } from '../context'
-import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import { DBPart, PartId } from '../../../../lib/collections/Parts'
 import {
 	wrapPartToTemporaryInstance,
@@ -30,7 +30,7 @@ import { getShowStyleCompoundForRundown } from '../../showStyles'
 describe('Test blueprint api context', () => {
 	function generateSparsePieceInstances(rundown: Rundown) {
 		const playlistActivationId = protectString('active')
-		_.each(rundown.getParts(), (part, i) => {
+		_.each(RundownCollectionUtil.getParts(rundown), (part, i) => {
 			// make into a partInstance
 			PartInstances.insert({
 				_id: protectString(`${part._id}_instance`),

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -356,7 +356,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			throw new Error('New part must contain at least one piece')
 		}
 
-		const newPartInstance = new PartInstance({
+		const newPartInstance: PartInstance = {
 			_id: getRandomId(),
 			rundownId: currentPartInstance.rundownId,
 			segmentId: currentPartInstance.segmentId,
@@ -375,7 +375,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 				invalidReason: undefined,
 				floated: false,
 			},
-		})
+		}
 
 		if (!isPartPlayable(newPartInstance.part)) {
 			throw new Error('Cannot queue a part which is not playable')

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -12,7 +12,7 @@ import {
 	UnprotectedStringProperties,
 	clone,
 } from '../../../../lib/lib'
-import { Part } from '../../../../lib/collections/Parts'
+import { isPartPlayable } from '../../../../lib/collections/Parts'
 import { logger } from '../../../../lib/logging'
 import {
 	IEventContext,
@@ -364,7 +364,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			segmentPlayoutId: currentPartInstance.segmentPlayoutId,
 			takeCount: currentPartInstance.takeCount + 1,
 			rehearsal: currentPartInstance.rehearsal,
-			part: new Part({
+			part: {
 				...rawPart,
 				_id: getRandomId(),
 				rundownId: currentPartInstance.rundownId,
@@ -374,10 +374,10 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 				invalid: false,
 				invalidReason: undefined,
 				floated: false,
-			}),
+			},
 		})
 
-		if (!newPartInstance.part.isPlayable()) {
+		if (!isPartPlayable(newPartInstance.part)) {
 			throw new Error('Cannot queue a part which is not playable')
 		}
 

--- a/meteor/server/api/blueprints/context/context.ts
+++ b/meteor/server/api/blueprints/context/context.ts
@@ -52,7 +52,7 @@ import {
 import { Rundown } from '../../../../lib/collections/Rundowns'
 import { ShowStyleCompound } from '../../../../lib/collections/ShowStyleVariants'
 import { INoteBase } from '../../../../lib/api/notes'
-import { RundownPlaylistId, ABSessionInfo, RundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
+import { RundownPlaylistId, ABSessionInfo, DBRundownPlaylist } from '../../../../lib/collections/RundownPlaylists'
 import {
 	PieceInstances,
 	protectPieceInstance,
@@ -456,7 +456,7 @@ export class TimelineEventContext extends RundownContext implements ITimelineEve
 	constructor(
 		studio: ReadonlyDeep<Studio>,
 		showStyleCompound: ReadonlyDeep<ShowStyleCompound>,
-		playlist: ReadonlyDeep<RundownPlaylist>,
+		playlist: ReadonlyDeep<DBRundownPlaylist>,
 		rundown: ReadonlyDeep<Rundown>,
 		previousPartInstance: PartInstance | undefined,
 		currentPartInstance: PartInstance | undefined,

--- a/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
+++ b/meteor/server/api/blueprints/context/syncIngestUpdateToPartInstance.ts
@@ -8,7 +8,7 @@ import {
 	ISyncIngestUpdateToPartInstanceContext,
 	NoteSeverity,
 } from '@sofie-automation/blueprints-integration'
-import { PartInstance, DBPartInstance, PartInstances } from '../../../../lib/collections/PartInstances'
+import { PartInstance, PartInstances } from '../../../../lib/collections/PartInstances'
 import _ from 'underscore'
 import { IBlueprintPieceSampleKeys, IBlueprintMutatablePartSampleKeys } from './lib'
 import { postProcessPieces, postProcessTimelineObjects } from '../postProcess'
@@ -42,8 +42,8 @@ export class SyncIngestUpdateToPartInstanceContext
 	extends RundownContext
 	implements ISyncIngestUpdateToPartInstanceContext
 {
-	private readonly _partInstanceCache: DbCacheWriteCollection<PartInstance, DBPartInstance>
-	private readonly _pieceInstanceCache: DbCacheWriteCollection<PieceInstance, PieceInstance>
+	private readonly _partInstanceCache: DbCacheWriteCollection<PartInstance>
+	private readonly _pieceInstanceCache: DbCacheWriteCollection<PieceInstance>
 	private readonly _proposedPieceInstances: Map<PieceInstanceId, PieceInstance>
 	public readonly notes: INoteBase[] = []
 	private readonly tempSendNotesIntoBlackHole: boolean

--- a/meteor/server/api/blueprints/context/watchedPackages.ts
+++ b/meteor/server/api/blueprints/context/watchedPackages.ts
@@ -16,8 +16,8 @@ import { CacheForIngest } from '../../ingest/cache'
  */
 export class WatchedPackagesHelper {
 	private constructor(
-		private readonly packages: DbCacheReadCollection<ExpectedPackageDB, ExpectedPackageDB>,
-		private readonly packageInfos: DbCacheReadCollection<PackageInfoDB, PackageInfoDB>
+		private readonly packages: DbCacheReadCollection<ExpectedPackageDB>,
+		private readonly packageInfos: DbCacheReadCollection<PackageInfoDB>
 	) {}
 
 	/**

--- a/meteor/server/api/blueprints/events.ts
+++ b/meteor/server/api/blueprints/events.ts
@@ -5,7 +5,12 @@ import { logger } from '../../../lib/logging'
 import { queueExternalMessages } from '../ExternalMessageQueue'
 import { loadShowStyleBlueprint } from './cache'
 import { RundownTimingEventContext, RundownDataChangedEventContext } from './context'
-import { RundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylists,
+	RundownPlaylistId,
+	DBRundownPlaylist,
+} from '../../../lib/collections/RundownPlaylists'
 import { PartInstance, PartInstanceId, PartInstances } from '../../../lib/collections/PartInstances'
 import { PieceInstances, PieceInstance } from '../../../lib/collections/PieceInstances'
 import { profiler } from '../profiler'
@@ -148,7 +153,7 @@ function handlePartInstanceTimingEvent(playlistId: RundownPlaylistId, partInstan
 	}
 }
 export function reportRundownDataHasChanged(
-	playlist: ReadonlyDeep<RundownPlaylist>,
+	playlist: ReadonlyDeep<DBRundownPlaylist>,
 	rundown: ReadonlyDeep<Rundown>
 ): void {
 	Meteor.defer(async () => {

--- a/meteor/server/api/cleanup.ts
+++ b/meteor/server/api/cleanup.ts
@@ -43,7 +43,7 @@ import { PackageContainerPackageStatuses } from '../../lib/collections/PackageCo
 import { PackageInfos } from '../../lib/collections/PackageInfos'
 import { Settings } from '../../lib/Settings'
 import { TriggeredActions } from '../../lib/collections/TriggeredActions'
-import { AsyncTransformedCollection } from '../../lib/collections/lib'
+import { AsyncMongoCollection } from '../../lib/collections/lib'
 
 export function cleanupOldDataInner(actuallyCleanup: boolean = false): CollectionCleanupResult | string {
 	if (actuallyCleanup) {
@@ -63,8 +63,8 @@ export function cleanupOldDataInner(actuallyCleanup: boolean = false): Collectio
 	}
 
 	// Preparations: ------------------------------------------------------------------------------
-	const getAllIdsInCollection = <Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-		collection: TransformedCollection<Class, DBInterface>
+	const getAllIdsInCollection = <DBInterface extends { _id: ProtectedString<any> }>(
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): DBInterface['_id'][] => {
 		return collection
 			.find(
@@ -83,9 +83,9 @@ export function cleanupOldDataInner(actuallyCleanup: boolean = false): Collectio
 	const rundownIds = getAllIdsInCollection(Rundowns)
 	const playlistIds = getAllIdsInCollection(RundownPlaylists)
 
-	const removeByQuery = <Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
+	const removeByQuery = <DBInterface extends { _id: ProtectedString<any> }>(
 		// collectionName: string,
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		query: MongoQuery<DBInterface>
 	): void => {
 		const collectionName = getCollectionKey(collection)
@@ -97,43 +97,33 @@ export function cleanupOldDataInner(actuallyCleanup: boolean = false): Collectio
 		addToResult(collectionName, count)
 	}
 
-	const ownedByRundownId = <
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any>; rundownId: RundownId }
-	>(
-		collection: TransformedCollection<Class, DBInterface>
+	const ownedByRundownId = <DBInterface extends { _id: ProtectedString<any>; rundownId: RundownId }>(
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			rundownId: { $nin: rundownIds },
 		})
 	}
-	const ownedByRundownPlaylistId = <
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any>; playlistId: RundownPlaylistId }
-	>(
-		collection: TransformedCollection<Class, DBInterface>
+	const ownedByRundownPlaylistId = <DBInterface extends { _id: ProtectedString<any>; playlistId: RundownPlaylistId }>(
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			playlistId: { $nin: playlistIds },
 		})
 	}
-	const ownedByStudioId = <
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any>; studioId: StudioId }
-	>(
-		collection: TransformedCollection<Class, DBInterface>
+	const ownedByStudioId = <DBInterface extends { _id: ProtectedString<any>; studioId: StudioId }>(
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			studioId: { $nin: studioIds },
 		})
 	}
 	const ownedByRundownIdOrStudioId = <
-		Class extends DBInterface,
 		DBInterface extends { _id: ProtectedString<any>; rundownId?: RundownId; studioId: StudioId }
 	>(
-		collection: TransformedCollection<Class, DBInterface>
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			$or: [
 				{
 					rundownId: { $exists: true, $nin: rundownIds },
@@ -146,12 +136,11 @@ export function cleanupOldDataInner(actuallyCleanup: boolean = false): Collectio
 		})
 	}
 	const ownedByOrganizationId = <
-		Class extends DBInterface,
 		DBInterface extends { _id: ProtectedString<any>; organizationId: OrganizationId | null | undefined }
 	>(
-		collection: TransformedCollection<Class, DBInterface>
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			$and: [
 				{
 					organizationId: { $nin: [organizationIds] },
@@ -165,13 +154,10 @@ export function cleanupOldDataInner(actuallyCleanup: boolean = false): Collectio
 			],
 		})
 	}
-	const ownedByDeviceId = <
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any>; deviceId: PeripheralDeviceId }
-	>(
-		collection: TransformedCollection<Class, DBInterface>
+	const ownedByDeviceId = <DBInterface extends { _id: ProtectedString<any>; deviceId: PeripheralDeviceId }>(
+		collection: TransformedCollection<DBInterface, DBInterface>
 	): void => {
-		removeByQuery(collection as AsyncTransformedCollection<any, any>, {
+		removeByQuery(collection as AsyncMongoCollection<any>, {
 			deviceId: { $nin: deviceIds },
 		})
 	}

--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import { PeripheralDeviceAPI, PeripheralDeviceAPIMethods } from '../../../../lib/api/peripheralDevice'
 import { setupDefaultStudioEnvironment, setupMockPeripheralDevice } from '../../../../__mocks__/helpers/database'
-import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import { PeripheralDevice } from '../../../../lib/collections/PeripheralDevices'
 import { testInFiber } from '../../../../__mocks__/helpers/jest'
 import { Segment, SegmentId, Segments } from '../../../../lib/collections/Segments'
@@ -1365,11 +1365,11 @@ describe('Test ingest actions for rundowns and segments', () => {
 			expect(rundown).toMatchObject({
 				externalId: rundownData.externalId,
 			})
-			const playlist = rundown.getRundownPlaylist()
+			const playlist = RundownCollectionUtil.getRundownPlaylist(rundown)
 			expect(playlist).toBeTruthy()
 
 			const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
-			const getPlaylist = () => rundown.getRundownPlaylist() as RundownPlaylist
+			const getPlaylist = () => RundownCollectionUtil.getRundownPlaylist(rundown)
 			const getSegment = (id: SegmentId) => Segments.findOne(id) as Segment
 			const resyncRundown = async () => {
 				try {
@@ -1390,8 +1390,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 				}
 			}
 
-			const segments = getRundown().getSegments()
-			const parts = getRundown().getParts()
+			const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 			expect(segments).toHaveLength(2)
 			expect(parts).toHaveLength(3)
@@ -1525,14 +1524,13 @@ describe('Test ingest actions for rundowns and segments', () => {
 			expect(rundown).toMatchObject({
 				externalId: rundownData.externalId,
 			})
-			const playlist = rundown.getRundownPlaylist()
+			const playlist = RundownCollectionUtil.getRundownPlaylist(rundown)
 			expect(playlist).toBeTruthy()
 
-			const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
-			const getPlaylist = () => rundown.getRundownPlaylist() as RundownPlaylist
+			// const getRundown = () => Rundowns.findOne(rundown._id) as Rundown
+			const getPlaylist = () => RundownCollectionUtil.getRundownPlaylist(rundown)
 
-			const segments = getRundown().getSegments()
-			const parts = getRundown().getParts()
+			const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 			expect(segments).toHaveLength(2)
 			expect(parts).toHaveLength(3)
@@ -1572,8 +1570,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 				updatedSegmentData
 			)
 			{
-				const segments2 = getRundown().getSegments()
-				const parts2 = getRundown().getParts()
+				const { segments: segments2, parts: parts2 } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 				expect(segments2).toHaveLength(2)
 				expect(parts2).toHaveLength(3)

--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -16,7 +16,12 @@ import {
 import { ServerRundownAPI } from '../../rundown'
 import { ServerPlayoutAPI } from '../../playout/playout'
 import { RundownInput } from '../rundownInput'
-import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylist,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../../lib/collections/RundownPlaylists'
 import { PartInstance, PartInstances } from '../../../../lib/collections/PartInstances'
 import { MethodContext } from '../../../../lib/api/methods'
 import { removeRundownPlaylistFromDb } from '../../rundownPlaylist'
@@ -1546,7 +1551,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 
 			{
 				// Check which parts are current and next
-				const selectedInstances = getPlaylist().getSelectedPartInstances()
+				const selectedInstances = RundownPlaylistCollectionUtil.getSelectedPartInstances(getPlaylist())
 				const currentPartInstance = selectedInstances.currentPartInstance as PartInstance
 				const nextPartInstance = selectedInstances.nextPartInstance as PartInstance
 				expect(currentPartInstance).toBeTruthy()
@@ -1587,7 +1592,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 
 			{
 				// Check if the partInstance was updated
-				const selectedInstances = getPlaylist().getSelectedPartInstances()
+				const selectedInstances = RundownPlaylistCollectionUtil.getSelectedPartInstances(getPlaylist())
 				const currentPartInstance = selectedInstances.currentPartInstance as PartInstance
 				const nextPartInstance = selectedInstances.nextPartInstance as PartInstance
 				expect(currentPartInstance).toBeTruthy()

--- a/meteor/server/api/ingest/cache.ts
+++ b/meteor/server/api/ingest/cache.ts
@@ -2,7 +2,7 @@ import { AdLibAction, AdLibActions } from '../../../lib/collections/AdLibActions
 import { AdLibPiece, AdLibPieces } from '../../../lib/collections/AdLibPieces'
 import { ExpectedMediaItem, ExpectedMediaItems } from '../../../lib/collections/ExpectedMediaItems'
 import { ExpectedPlayoutItem, ExpectedPlayoutItems } from '../../../lib/collections/ExpectedPlayoutItems'
-import { Part, DBPart, Parts } from '../../../lib/collections/Parts'
+import { Part, Parts } from '../../../lib/collections/Parts'
 import { Piece, Pieces } from '../../../lib/collections/Pieces'
 import {
 	RundownBaselineAdLibAction,
@@ -13,8 +13,8 @@ import {
 	RundownBaselineAdLibPieces,
 } from '../../../lib/collections/RundownBaselineAdLibPieces'
 import { RundownBaselineObj, RundownBaselineObjs } from '../../../lib/collections/RundownBaselineObjs'
-import { Rundown, DBRundown, Rundowns } from '../../../lib/collections/Rundowns'
-import { Segment, DBSegment, Segments } from '../../../lib/collections/Segments'
+import { Rundown, Rundowns } from '../../../lib/collections/Rundowns'
+import { Segment, Segments } from '../../../lib/collections/Segments'
 import { Studio, Studios, StudioId } from '../../../lib/collections/Studios'
 import { DbCacheWriteCollection } from '../../cache/CacheCollection'
 import { DbCacheReadObject, DbCacheWriteOptionalObject } from '../../cache/CacheObject'
@@ -29,28 +29,24 @@ export class CacheForIngest extends CacheBase<CacheForIngest> {
 	public readonly isIngest = true
 	private toBeRemoved = false
 
-	public readonly Studio: DbCacheReadObject<Studio, Studio>
-	public readonly Rundown: DbCacheWriteOptionalObject<Rundown, DBRundown>
+	public readonly Studio: DbCacheReadObject<Studio>
+	public readonly Rundown: DbCacheWriteOptionalObject<Rundown>
 	public readonly RundownExternalId: string
 
-	public readonly Segments: DbCacheWriteCollection<Segment, DBSegment>
-	public readonly Parts: DbCacheWriteCollection<Part, DBPart>
-	public readonly Pieces: DbCacheWriteCollection<Piece, Piece>
+	public readonly Segments: DbCacheWriteCollection<Segment>
+	public readonly Parts: DbCacheWriteCollection<Part>
+	public readonly Pieces: DbCacheWriteCollection<Piece>
 
-	public readonly AdLibPieces: DbCacheWriteCollection<AdLibPiece, AdLibPiece>
-	public readonly AdLibActions: DbCacheWriteCollection<AdLibAction, AdLibAction>
+	public readonly AdLibPieces: DbCacheWriteCollection<AdLibPiece>
+	public readonly AdLibActions: DbCacheWriteCollection<AdLibAction>
 
-	public readonly ExpectedMediaItems: DbCacheWriteCollection<ExpectedMediaItem, ExpectedMediaItem>
-	public readonly ExpectedPlayoutItems: DbCacheWriteCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>
-	public readonly ExpectedPackages: DbCacheWriteCollection<ExpectedPackageDB, ExpectedPackageDB>
+	public readonly ExpectedMediaItems: DbCacheWriteCollection<ExpectedMediaItem>
+	public readonly ExpectedPlayoutItems: DbCacheWriteCollection<ExpectedPlayoutItem>
+	public readonly ExpectedPackages: DbCacheWriteCollection<ExpectedPackageDB>
 
-	public readonly RundownBaselineObjs: LazyInitialise<DbCacheWriteCollection<RundownBaselineObj, RundownBaselineObj>>
-	public readonly RundownBaselineAdLibPieces: LazyInitialise<
-		DbCacheWriteCollection<RundownBaselineAdLibItem, RundownBaselineAdLibItem>
-	>
-	public readonly RundownBaselineAdLibActions: LazyInitialise<
-		DbCacheWriteCollection<RundownBaselineAdLibAction, RundownBaselineAdLibAction>
-	>
+	public readonly RundownBaselineObjs: LazyInitialise<DbCacheWriteCollection<RundownBaselineObj>>
+	public readonly RundownBaselineAdLibPieces: LazyInitialise<DbCacheWriteCollection<RundownBaselineAdLibItem>>
+	public readonly RundownBaselineAdLibActions: LazyInitialise<DbCacheWriteCollection<RundownBaselineAdLibAction>>
 
 	public get RundownId() {
 		return this.Rundown.doc?._id ?? getRundownId(this.Studio.doc._id, this.RundownExternalId)
@@ -58,16 +54,16 @@ export class CacheForIngest extends CacheBase<CacheForIngest> {
 
 	private constructor(
 		rundownExternalId: string,
-		studio: DbCacheReadObject<Studio, Studio>,
-		rundown: DbCacheWriteOptionalObject<Rundown, DBRundown>,
-		segments: DbCacheWriteCollection<Segment, DBSegment>,
-		parts: DbCacheWriteCollection<Part, DBPart>,
-		pieces: DbCacheWriteCollection<Piece, Piece>,
-		adLibPieces: DbCacheWriteCollection<AdLibPiece, AdLibPiece>,
-		adLibActions: DbCacheWriteCollection<AdLibAction, AdLibAction>,
-		expectedMediaItems: DbCacheWriteCollection<ExpectedMediaItem, ExpectedMediaItem>,
-		expectedPlayoutItems: DbCacheWriteCollection<ExpectedPlayoutItem, ExpectedPlayoutItem>,
-		expectedPackages: DbCacheWriteCollection<ExpectedPackageDB, ExpectedPackageDB>
+		studio: DbCacheReadObject<Studio>,
+		rundown: DbCacheWriteOptionalObject<Rundown>,
+		segments: DbCacheWriteCollection<Segment>,
+		parts: DbCacheWriteCollection<Part>,
+		pieces: DbCacheWriteCollection<Piece>,
+		adLibPieces: DbCacheWriteCollection<AdLibPiece>,
+		adLibActions: DbCacheWriteCollection<AdLibAction>,
+		expectedMediaItems: DbCacheWriteCollection<ExpectedMediaItem>,
+		expectedPlayoutItems: DbCacheWriteCollection<ExpectedPlayoutItem>,
+		expectedPackages: DbCacheWriteCollection<ExpectedPackageDB>
 	) {
 		super()
 
@@ -124,9 +120,9 @@ export class CacheForIngest extends CacheBase<CacheForIngest> {
 	}
 
 	async loadBaselineCollections(): Promise<{
-		baselineObjects: DbCacheWriteCollection<RundownBaselineObj, RundownBaselineObj>
-		baselineAdlibPieces: DbCacheWriteCollection<RundownBaselineAdLibItem, RundownBaselineAdLibItem>
-		baselineAdlibActions: DbCacheWriteCollection<RundownBaselineAdLibAction, RundownBaselineAdLibAction>
+		baselineObjects: DbCacheWriteCollection<RundownBaselineObj>
+		baselineAdlibPieces: DbCacheWriteCollection<RundownBaselineAdLibItem>
+		baselineAdlibActions: DbCacheWriteCollection<RundownBaselineAdLibAction>
 	}> {
 		const [baselineObjects, baselineAdlibPieces, baselineAdlibActions] = await Promise.all([
 			this.RundownBaselineObjs.get(),

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -10,7 +10,7 @@ import { ensureNextPartIsValid } from './updateNext'
 import { SegmentId } from '../../../lib/collections/Segments'
 import { logger } from '../../logging'
 import { isTooCloseToAutonext, LOW_PRIO_DEFER_TIME } from '../playout/lib'
-import { DBRundown, Rundown, RundownId, Rundowns } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownId, Rundowns } from '../../../lib/collections/Rundowns'
 import { ReadonlyDeep } from 'type-fest'
 import {
 	RundownPlaylist,

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -12,7 +12,12 @@ import { logger } from '../../logging'
 import { isTooCloseToAutonext, LOW_PRIO_DEFER_TIME } from '../playout/lib'
 import { DBRundown, Rundown, RundownId, Rundowns } from '../../../lib/collections/Rundowns'
 import { ReadonlyDeep } from 'type-fest'
-import { RundownPlaylist, RundownPlaylistId, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylistId,
+	RundownPlaylists,
+} from '../../../lib/collections/RundownPlaylists'
 import {
 	getPlaylistIdFromExternalId,
 	produceRundownPlaylistInfoFromRundown,
@@ -202,7 +207,8 @@ export async function CommitIngestOperation(
 
 					// Do the segment removals
 					if (data.removedSegmentIds.length > 0) {
-						const { currentPartInstance, nextPartInstance } = newPlaylist.getSelectedPartInstances()
+						const { currentPartInstance, nextPartInstance } =
+							RundownPlaylistCollectionUtil.getSelectedPartInstances(newPlaylist)
 
 						const purgeSegmentIds = new Set<SegmentId>()
 						const orphanSegmentIds = new Set<SegmentId>()

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -303,7 +303,7 @@ export async function CommitIngestOperation(
 async function generatePlaylistAndRundownsCollection(
 	ingestCache: CacheForIngest,
 	newPlaylistIds: PlaylistIdPair
-): Promise<[RundownPlaylist, DbCacheWriteCollection<Rundown, DBRundown>]> {
+): Promise<[RundownPlaylist, DbCacheWriteCollection<Rundown>]> {
 	// Load existing playout data
 	const finalRundown = getRundown(ingestCache)
 
@@ -338,8 +338,8 @@ async function generatePlaylistAndRundownsCollectionInner(
 	newPlaylistId: RundownPlaylistId,
 	newPlaylistExternalId: string,
 	existingPlaylist0?: ReadonlyDeep<RundownPlaylist>,
-	existingRundownsCollection?: DbCacheWriteCollection<Rundown, DBRundown>
-): Promise<[RundownPlaylist, DbCacheWriteCollection<Rundown, DBRundown>] | null> {
+	existingRundownsCollection?: DbCacheWriteCollection<Rundown>
+): Promise<[RundownPlaylist, DbCacheWriteCollection<Rundown>] | null> {
 	if (existingPlaylist0) {
 		if (existingPlaylist0._id !== newPlaylistId) {
 			throw new Meteor.Error(
@@ -465,7 +465,7 @@ function updatePartInstancesBasicProperties(
 export async function regeneratePlaylistAndRundownOrder(
 	studio: ReadonlyDeep<Studio>,
 	oldPlaylist: ReadonlyDeep<RundownPlaylist>,
-	existingRundownsCollection?: DbCacheWriteCollection<Rundown, DBRundown>
+	existingRundownsCollection?: DbCacheWriteCollection<Rundown>
 ): Promise<RundownPlaylist | null> {
 	const result = await generatePlaylistAndRundownsCollectionInner(
 		studio,

--- a/meteor/server/api/ingest/commit.ts
+++ b/meteor/server/api/ingest/commit.ts
@@ -380,7 +380,7 @@ async function generatePlaylistAndRundownsCollectionInner(
 	if (allRundowns.length > 0) {
 		// Skip the update, if there are no rundowns left
 		// Generate the new playlist, and ranks for the rundowns
-		const { rundownPlaylist: newPlaylist0, order: newRundownOrder } = produceRundownPlaylistInfoFromRundown(
+		const { rundownPlaylist: newPlaylist, order: newRundownOrder } = produceRundownPlaylistInfoFromRundown(
 			studio,
 			studioBlueprint,
 			existingPlaylist,
@@ -388,7 +388,6 @@ async function generatePlaylistAndRundownsCollectionInner(
 			newPlaylistExternalId,
 			allRundowns
 		)
-		const newPlaylist = new RundownPlaylist(newPlaylist0)
 
 		// Update the ranks of the rundowns
 		if (!newPlaylist.rundownRanksAreSetInSofie) {

--- a/meteor/server/api/ingest/expectedMediaItems.ts
+++ b/meteor/server/api/ingest/expectedMediaItems.ts
@@ -220,5 +220,5 @@ export function updateExpectedMediaItemsOnRundown(cache: CacheForIngest): void {
 	const actions = cache.AdLibActions.findFetch({})
 
 	const eMIs = generateExpectedMediaItemsFull(cache.Studio.doc._id, cache.RundownId, pieces, adlibs, actions)
-	saveIntoCache<ExpectedMediaItem, ExpectedMediaItem>(cache.ExpectedMediaItems, {}, eMIs)
+	saveIntoCache<ExpectedMediaItem>(cache.ExpectedMediaItems, {}, eMIs)
 }

--- a/meteor/server/api/ingest/expectedPackages.ts
+++ b/meteor/server/api/ingest/expectedPackages.ts
@@ -116,7 +116,7 @@ export function updateExpectedPackagesOnRundown(cache: CacheForIngest): void {
 		preserveTypesDuringSave.push(ExpectedPackageDBType.BASELINE_ADLIB_ACTION)
 	}
 
-	saveIntoCache<ExpectedPackageDB, ExpectedPackageDB>(
+	saveIntoCache<ExpectedPackageDB>(
 		cache.ExpectedPackages,
 		{
 			fromPieceType: { $nin: preserveTypesDuringSave as any },
@@ -382,7 +382,7 @@ export function updateBaselineExpectedPackagesOnRundown(
 	setDefaultIdOnExpectedPackages(baseline.expectedPackages)
 
 	const bases = generateExpectedPackageBases(cache.Studio.doc, cache.RundownId, baseline.expectedPackages ?? [])
-	saveIntoCache<ExpectedPackageDB, ExpectedPackageDB>(
+	saveIntoCache<ExpectedPackageDB>(
 		cache.ExpectedPackages,
 		{
 			fromPieceType: ExpectedPackageDBType.RUNDOWN_BASELINE_OBJECTS,

--- a/meteor/server/api/ingest/expectedPackages.ts
+++ b/meteor/server/api/ingest/expectedPackages.ts
@@ -416,7 +416,7 @@ export function updateBaselineExpectedPackagesOnStudio(
 
 	const bases = generateExpectedPackageBases(cache.Studio.doc, cache.Studio.doc._id, baseline.expectedPackages ?? [])
 	cache.deferAfterSave(async () => {
-		await saveIntoDb<ExpectedPackageDB, ExpectedPackageDB>(
+		await saveIntoDb<ExpectedPackageDB>(
 			ExpectedPackages,
 			{
 				studioId: cache.Studio.doc._id,

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -73,7 +73,7 @@ export function updateExpectedPlayoutItemsOnRundown(cache: CacheForIngest): void
 		expectedPlayoutItems.push(...extractExpectedPlayoutItems(studioId, rundownId, undefined, action))
 	}
 
-	saveIntoCache<ExpectedPlayoutItem, ExpectedPlayoutItem>(
+	saveIntoCache<ExpectedPlayoutItem>(
 		cache.ExpectedPlayoutItems,
 		{ baseline: { $exists: false } },
 		expectedPlayoutItems
@@ -84,7 +84,7 @@ export function updateBaselineExpectedPlayoutItemsOnRundown(
 	cache: CacheForIngest,
 	items?: ExpectedPlayoutItemGeneric[]
 ) {
-	saveIntoCache<ExpectedPlayoutItem, ExpectedPlayoutItem>(
+	saveIntoCache<ExpectedPlayoutItem>(
 		cache.ExpectedPlayoutItems,
 		{ baseline: 'rundown' },
 		(items || []).map((item): ExpectedPlayoutItemRundown => {

--- a/meteor/server/api/ingest/generation.ts
+++ b/meteor/server/api/ingest/generation.ts
@@ -314,7 +314,7 @@ export function saveSegmentChangesToCache(
 	const newPartIds = data.parts.map((p) => p._id)
 	const newSegmentIds = data.segments.map((p) => p._id)
 
-	const partChanges = saveIntoCache<Part, DBPart>(
+	const partChanges = saveIntoCache<Part>(
 		cache.Parts,
 		isWholeRundownUpdate ? {} : { $or: [{ segmentId: { $in: newSegmentIds } }, { _id: { $in: newPartIds } }] },
 		data.parts
@@ -324,7 +324,7 @@ export function saveSegmentChangesToCache(
 
 	logChanges(
 		'Pieces',
-		saveIntoCache<Piece, Piece>(
+		saveIntoCache<Piece>(
 			cache.Pieces,
 			isWholeRundownUpdate ? {} : { startPartId: { $in: affectedPartIds } },
 			data.pieces
@@ -332,7 +332,7 @@ export function saveSegmentChangesToCache(
 	)
 	logChanges(
 		'AdLibActions',
-		saveIntoCache<AdLibAction, AdLibAction>(
+		saveIntoCache<AdLibAction>(
 			cache.AdLibActions,
 			isWholeRundownUpdate ? {} : { partId: { $in: affectedPartIds } },
 			data.adlibActions
@@ -340,7 +340,7 @@ export function saveSegmentChangesToCache(
 	)
 	logChanges(
 		'AdLibPieces',
-		saveIntoCache<AdLibPiece, AdLibPiece>(
+		saveIntoCache<AdLibPiece>(
 			cache.AdLibPieces,
 			isWholeRundownUpdate ? {} : { partId: { $in: affectedPartIds } },
 			data.adlibPieces
@@ -629,7 +629,7 @@ export async function saveChangesForRundown(
 
 	const { baselineObjects, baselineAdlibPieces, baselineAdlibActions } = await cache.loadBaselineCollections()
 	const rundownBaselineChanges = sumChanges(
-		saveIntoCache<RundownBaselineObj, RundownBaselineObj>(baselineObjects, {}, [
+		saveIntoCache<RundownBaselineObj>(baselineObjects, {}, [
 			{
 				_id: protectString<RundownBaselineObjId>(Random.id(7)),
 				rundownId: dbRundown._id,
@@ -640,12 +640,12 @@ export async function saveChangesForRundown(
 			},
 		]),
 		// Save the global adlibs
-		saveIntoCache<RundownBaselineAdLibItem, RundownBaselineAdLibItem>(
+		saveIntoCache<RundownBaselineAdLibItem>(
 			baselineAdlibPieces,
 			{},
 			postProcessAdLibPieces(showStyle.base.blueprintId, dbRundown._id, undefined, rundownRes.globalAdLibPieces)
 		),
-		saveIntoCache<RundownBaselineAdLibAction, RundownBaselineAdLibAction>(
+		saveIntoCache<RundownBaselineAdLibAction>(
 			baselineAdlibActions,
 			{},
 			postProcessGlobalAdLibActions(showStyle.base.blueprintId, dbRundown._id, rundownRes.globalActions || [])

--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -55,7 +55,7 @@ export function makeNewIngestPart(ingestPart: IngestPart): LocalIngestPart {
 export class RundownIngestDataCache {
 	private constructor(
 		private readonly rundownId: RundownId,
-		private readonly collection: DbCacheWriteCollection<IngestDataCacheObj, IngestDataCacheObj>
+		private readonly collection: DbCacheWriteCollection<IngestDataCacheObj>
 	) {}
 
 	static async create(rundownId: RundownId): Promise<RundownIngestDataCache> {
@@ -140,7 +140,7 @@ export class RundownIngestDataCache {
 	update(ingestRundown: LocalIngestRundown): void {
 		// cache the Data:
 		const cacheEntries: IngestDataCacheObj[] = generateCacheForRundown(this.rundownId, ingestRundown)
-		saveIntoCache<IngestDataCacheObj, IngestDataCacheObj>(this.collection, {}, cacheEntries)
+		saveIntoCache<IngestDataCacheObj>(this.collection, {}, cacheEntries)
 	}
 
 	delete(): void {

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -12,7 +12,11 @@ import { literal, protectString } from '../../../../../lib/lib'
 import { mockRO } from './mock-mos-data'
 import { fixSnapshot } from '../../../../../__mocks__/helpers/snapshot'
 import { Pieces } from '../../../../../lib/collections/Pieces'
-import { RundownPlaylists, RundownPlaylist } from '../../../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+} from '../../../../../lib/collections/RundownPlaylists'
 import { MeteorCall } from '../../../../../lib/api/methods'
 import { IngestDataCache, IngestCacheType } from '../../../../../lib/collections/IngestDataCache'
 import { getPartId } from '../../lib'
@@ -30,8 +34,8 @@ const ensureNextPartIsValidMock = ensureNextPartIsValid as TensureNextPartIsVali
 require('../../../peripheralDevice.ts') // include in order to create the Meteor methods needed
 require('../../../userActions.ts') // include in order to create the Meteor methods needed
 
-function getPartIdMap(segments: Segment[], parts: DBPart[]) {
-	const sortedParts = RundownPlaylist._sortPartsInner(parts, segments)
+function getPartIdMap(segments: Segment[], parts: Part[]) {
+	const sortedParts = RundownPlaylistCollectionUtil._sortPartsInner(parts, segments)
 
 	const groupedParts = _.groupBy(sortedParts, (p) => p.segmentId)
 	const arr: [string, DBPart[]][] = _.pairs(groupedParts)
@@ -403,7 +407,7 @@ describe('Test recieved mos ingest payloads', () => {
 	testInFiber('mosRoStoryInsert: Into segment', async () => {
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -445,7 +449,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -469,7 +473,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -573,7 +577,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -608,7 +612,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -654,7 +658,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -763,7 +767,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -796,7 +800,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -866,7 +870,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -901,7 +905,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -929,7 +933,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -945,7 +949,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const { segments, parts } = playlist.getSegmentsAndPartsSync()
+		const { segments, parts } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
 		const partMap = mockRO.segmentIdMap()
 		partMap[0].parts[1] = 'ro1;s1;p3'
 		partMap[0].parts[2] = 'ro1;s1;p2'
@@ -963,7 +967,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 
@@ -981,7 +985,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const { segments, parts } = playlist.getSegmentsAndPartsSync()
+		const { segments, parts } = RundownPlaylistCollectionUtil.getSegmentsAndPartsSync(playlist)
 		const partMap = mockRO.segmentIdMap()
 		const old = partMap.splice(0, 1)
 		partMap.splice(3, 0, ...old)
@@ -1312,7 +1316,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const playlist = RundownPlaylists.findOne() as RundownPlaylist
 		expect(playlist).toBeTruthy()
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 		expect(rundown.orphaned).toBeFalsy()

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -1172,7 +1172,7 @@ describe('Test recieved mos ingest payloads', () => {
 	) {
 		return PartInstances.find(
 			{
-				rundownId: this._id,
+				rundownId: rundownId,
 				...selector,
 			},
 			{

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -3,8 +3,8 @@ import * as _ from 'underscore'
 import { setupDefaultStudioEnvironment } from '../../../../../__mocks__/helpers/database'
 import { testInFiber } from '../../../../../__mocks__/helpers/jest'
 import '../../../../../__mocks__/_extendJest'
-import { Rundowns, Rundown, DBRundown } from '../../../../../lib/collections/Rundowns'
-import { Segments, DBSegment, SegmentId, Segment } from '../../../../../lib/collections/Segments'
+import { Rundowns, Rundown, DBRundown, RundownCollectionUtil, RundownId } from '../../../../../lib/collections/Rundowns'
+import { Segments, Segment, SegmentId } from '../../../../../lib/collections/Segments'
 import { Parts, DBPart, Part } from '../../../../../lib/collections/Parts'
 import { PeripheralDevice } from '../../../../../lib/collections/PeripheralDevices'
 import { literal, protectString } from '../../../../../lib/lib'
@@ -16,20 +16,21 @@ import { RundownPlaylists, RundownPlaylist } from '../../../../../lib/collection
 import { MeteorCall } from '../../../../../lib/api/methods'
 import { IngestDataCache, IngestCacheType } from '../../../../../lib/collections/IngestDataCache'
 import { getPartId } from '../../lib'
-import { PartInstance } from '../../../../../lib/collections/PartInstances'
+import { DBPartInstance, PartInstance, PartInstances } from '../../../../../lib/collections/PartInstances'
 import { resetRandomId, restartRandomId } from '../../../../../__mocks__/random'
 import { UserActionsLog } from '../../../../../lib/collections/UserActionsLog'
 import { removeRundownPlaylistFromDb } from '../../../rundownPlaylist'
 
 jest.mock('../../updateNext')
 import { ensureNextPartIsValid } from '../../updateNext'
+import { MongoQuery, FindOptions } from '../../../../../lib/typings/meteor'
 type TensureNextPartIsValid = jest.MockedFunction<typeof ensureNextPartIsValid>
 const ensureNextPartIsValidMock = ensureNextPartIsValid as TensureNextPartIsValid
 
 require('../../../peripheralDevice.ts') // include in order to create the Meteor methods needed
 require('../../../userActions.ts') // include in order to create the Meteor methods needed
 
-function getPartIdMap(segments: DBSegment[], parts: DBPart[]) {
+function getPartIdMap(segments: Segment[], parts: DBPart[]) {
 	const sortedParts = RundownPlaylist._sortPartsInner(parts, segments)
 
 	const groupedParts = _.groupBy(sortedParts, (p) => p.segmentId)
@@ -87,8 +88,7 @@ describe('Test recieved mos ingest payloads', () => {
 			playlistId: rundownPlaylist._id,
 		})
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		expect(getPartIdMap(segments, parts)).toEqual(mockRO.segmentIdMap())
 
@@ -120,8 +120,7 @@ describe('Test recieved mos ingest payloads', () => {
 			playlistId: rundownPlaylist._id,
 		})
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap2 = mockRO.segmentIdMap()
 		partMap2[1].parts.splice(1, 0, ...partMap2[3].parts)
@@ -419,8 +418,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[0].parts.splice(2, 0, newPartData.ID.toString())
@@ -460,7 +458,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		await MeteorCall.peripheralDevice.mosRoStoryInsert(device._id, device.token, action, [newPartData])
 
-		const parts = rundown.getParts()
+		const parts = RundownCollectionUtil.getParts(rundown)
 
 		expect(Rundowns.findOne(rundown._id)?.orphaned).toEqual('deleted')
 		expect(parts.find((p) => p.externalId === newPartData.ID.toString())).toBeUndefined()
@@ -486,8 +484,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap.splice(1, 0, {
@@ -593,8 +590,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[0].parts[1] = newPartData.ID.toString()
@@ -625,7 +621,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		await MeteorCall.peripheralDevice.mosRoStoryReplace(device._id, device.token, action, [newPartData])
 
-		const parts = rundown.getParts()
+		const parts = RundownCollectionUtil.getParts(rundown)
 
 		expect(Rundowns.findOne(rundown._id)?.orphaned).toEqual('deleted')
 		expect(parts.find((p) => p.externalId === newPartData.ID.toString())).toBeUndefined()
@@ -674,8 +670,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[1].parts.push(...partMap[3].parts)
@@ -782,8 +777,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[0].parts[1] = 'ro1;s1;p3'
@@ -816,8 +810,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[0].segmentId = 'apDVfF5nk1_StK474hEUxLMZIag_'
@@ -887,8 +880,7 @@ describe('Test recieved mos ingest payloads', () => {
 
 		expect(ensureNextPartIsValid).toHaveBeenCalledTimes(1)
 
-		const segments = rundown.getSegments()
-		const parts = rundown.getParts({}, undefined, segments)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		const partMap = mockRO.segmentIdMap()
 		partMap[1].parts.push('ro1;s4;p1')
@@ -1077,10 +1069,10 @@ describe('Test recieved mos ingest payloads', () => {
 
 		const partExternalId = 'ro1;s1;p1'
 
-		const partToBeRemoved = rundown.getParts({ externalId: partExternalId })[0]
+		const partToBeRemoved = RundownCollectionUtil.getParts(rundown, { externalId: partExternalId })[0]
 		expect(partToBeRemoved).toBeTruthy()
 
-		const partsInSegmentBefore = rundown.getParts({ segmentId: partToBeRemoved.segmentId })
+		const partsInSegmentBefore = RundownCollectionUtil.getParts(rundown, { segmentId: partToBeRemoved.segmentId })
 		expect(partsInSegmentBefore).toHaveLength(3)
 
 		const action = literal<MOS.IMOSROAction>({
@@ -1095,7 +1087,7 @@ describe('Test recieved mos ingest payloads', () => {
 		const partAfter = Parts.findOne(partsInSegmentBefore[2]._id) as Part
 		expect(partAfter).toBeTruthy()
 
-		const partsInSegmentAfter = rundown.getParts({ segmentId: partAfter.segmentId })
+		const partsInSegmentAfter = RundownCollectionUtil.getParts(rundown, { segmentId: partAfter.segmentId })
 		expect(partsInSegmentAfter).toHaveLength(2)
 
 		// The other parts in the segment should not not have changed:
@@ -1169,6 +1161,23 @@ describe('Test recieved mos ingest payloads', () => {
 		}
 	}
 
+	function rundownGetAllPartInstances(
+		rundownId: RundownId,
+		selector?: MongoQuery<PartInstance>,
+		options?: FindOptions<DBPartInstance>
+	) {
+		return PartInstances.find(
+			{
+				rundownId: this._id,
+				...selector,
+			},
+			{
+				sort: { takeCount: 1 },
+				...options,
+			}
+		).fetch()
+	}
+
 	testInFiber('Rename segment during update while on air', async () => {
 		await resetOrphanedRundown()
 
@@ -1180,14 +1189,14 @@ describe('Test recieved mos ingest payloads', () => {
 		await MeteorCall.userAction.setNext('', rundown.playlistId, getPartId(rundown._id, 'ro1;s2;p1'))
 		await MeteorCall.userAction.take('', rundown.playlistId)
 
-		const partInstances0 = rundown.getAllPartInstances()
-		const { segments: segments0, parts: parts0 } = rundown.getSegmentsAndPartsSync()
+		const partInstances0 = rundownGetAllPartInstances(rundown._id)
+		const { segments: segments0, parts: parts0 } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		await mosReplaceBasicStory(rundown.externalId, 'ro1;s2;p1', 'ro1;s2;p1', 'SEGMENT2b;PART1')
 		await mosReplaceBasicStory(rundown.externalId, 'ro1;s2;p2', 'ro1;s2;p2', 'SEGMENT2b;PART2')
 
-		const partInstances = rundown.getAllPartInstances()
-		const { segments, parts } = rundown.getSegmentsAndPartsSync()
+		const partInstances = rundownGetAllPartInstances(rundown._id)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		// Update expected data, for just the segment name and ids changing
 		applySegmentRenameToContents('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
@@ -1211,8 +1220,8 @@ describe('Test recieved mos ingest payloads', () => {
 		await MeteorCall.userAction.setNext('', rundown.playlistId, getPartId(rundown._id, 'ro1;s2;p1'))
 		await MeteorCall.userAction.take('', rundown.playlistId)
 
-		const partInstances0 = rundown.getAllPartInstances()
-		const { segments: segments0, parts: parts0 } = rundown.getSegmentsAndPartsSync()
+		const partInstances0 = rundownGetAllPartInstances(rundown._id)
+		const { segments: segments0, parts: parts0 } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		// rename the segment
 		for (const story of mosRO.Stories) {
@@ -1232,8 +1241,8 @@ describe('Test recieved mos ingest payloads', () => {
 			expect(rundown2.orphaned).toBeFalsy()
 		}
 
-		const partInstances = rundown.getAllPartInstances()
-		const { segments, parts } = rundown.getSegmentsAndPartsSync()
+		const partInstances = rundownGetAllPartInstances(rundown._id)
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 
 		// Update expected data, for just the segment name and ids changing
 		applySegmentRenameToContents('SEGMENT2', 'SEGMENT2b', segments0, segments, parts0, partInstances0)
@@ -1307,7 +1316,7 @@ describe('Test recieved mos ingest payloads', () => {
 		expect(rundowns).toHaveLength(1)
 		const rundown = rundowns[0]
 		expect(rundown.orphaned).toBeFalsy()
-		expect(rundown.getSegments()).toHaveLength(4)
+		expect(RundownCollectionUtil.getSegments(rundown)).toHaveLength(4)
 
 		// insert a part after segment1
 		const newPartData = mockRO.newItem('ro1;s2a;newPart1', 'SEGMENT2pre;new1')
@@ -1318,7 +1327,7 @@ describe('Test recieved mos ingest payloads', () => {
 		await MeteorCall.peripheralDevice.mosRoStoryInsert(device._id, device.token, action, [newPartData])
 
 		{
-			const segments = rundown.getSegments()
+			const segments = RundownCollectionUtil.getSegments(rundown)
 			expect(segments).toHaveLength(5)
 
 			// Make sure we inserted, not replaced
@@ -1351,7 +1360,7 @@ describe('Test recieved mos ingest payloads', () => {
 		])
 
 		{
-			const segments = rundown.getSegments()
+			const segments = RundownCollectionUtil.getSegments(rundown)
 			expect(segments).toHaveLength(4)
 
 			// Make sure first segment is unchanged

--- a/meteor/server/api/ingest/updateNext.ts
+++ b/meteor/server/api/ingest/updateNext.ts
@@ -6,6 +6,7 @@ import {
 	getOrderedSegmentsAndPartsFromPlayoutCache,
 	getSelectedPartInstancesFromCache,
 } from '../playout/cache'
+import { isPartPlayable } from '../../../lib/collections/Parts'
 
 export async function ensureNextPartIsValid(cache: CacheForPlayout): Promise<void> {
 	const span = profiler.startSpan('api.ingest.ensureNextPartIsValid')
@@ -15,7 +16,7 @@ export async function ensureNextPartIsValid(cache: CacheForPlayout): Promise<voi
 	if (playlist && playlist.activationId) {
 		const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache)
 
-		if (playlist.nextPartManual && nextPartInstance?.part?.isPlayable()) {
+		if (playlist.nextPartManual && nextPartInstance?.part && isPartPlayable(nextPartInstance.part)) {
 			// Manual next part is always valid. This includes orphaned (adlib-part) partinstances
 			span?.end()
 			return
@@ -38,7 +39,7 @@ export async function ensureNextPartIsValid(cache: CacheForPlayout): Promise<voi
 				return
 			}
 
-			if (newNextPart?.part?._id !== nextPartInstance.part._id || !nextPartInstance.part.isPlayable()) {
+			if (newNextPart?.part?._id !== nextPartInstance.part._id || !isPartPlayable(nextPartInstance.part)) {
 				// The 'new' next part is before the current next, so move the next point
 				await ServerPlayoutAPI.setNextPartInner(cache, newNextPart.part)
 			}

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -40,7 +40,7 @@ import { MethodContextAPI, MethodContext } from '../../lib/api/methods'
 import { triggerWriteAccess, triggerWriteAccessBecauseNoCheckNecessary } from '../security/lib/securityVerify'
 import { checkAccessAndGetPeripheralDevice } from './ingest/lib'
 import { PickerPOST } from './http'
-import { RundownPlaylist } from '../../lib/collections/RundownPlaylists'
+import { DBRundownPlaylist } from '../../lib/collections/RundownPlaylists'
 import { getValidActivationCache } from '../cache/ActivationCache'
 import { UserActionsLog } from '../../lib/collections/UserActionsLog'
 import { PieceGroupMetadata } from '../../lib/rundown/pieces'
@@ -290,8 +290,8 @@ export namespace ServerPeripheralDeviceAPI {
 	function timelineTriggerTimeInner(
 		cache: CacheForStudio,
 		results: PeripheralDeviceAPI.TimelineTriggerTimeResult,
-		pieceInstanceCache: DbCacheWriteCollection<PieceInstance, PieceInstance> | undefined,
-		activePlaylist: RundownPlaylist | undefined
+		pieceInstanceCache: DbCacheWriteCollection<PieceInstance> | undefined,
+		activePlaylist: DBRundownPlaylist | undefined
 	) {
 		let lastTakeTime: number | undefined
 

--- a/meteor/server/api/playout/__tests__/infinites.test.ts
+++ b/meteor/server/api/playout/__tests__/infinites.test.ts
@@ -1,6 +1,6 @@
 import { ReadonlyDeep } from 'type-fest'
 import { wrapPartToTemporaryInstance } from '../../../../lib/collections/PartInstances'
-import { RundownPlaylist, RundownPlaylists } from '../../../../lib/collections/RundownPlaylists'
+import { DBRundownPlaylist, RundownPlaylist, RundownPlaylists } from '../../../../lib/collections/RundownPlaylists'
 import { Rundown, Rundowns } from '../../../../lib/collections/Rundowns'
 import { getRandomId, protectString } from '../../../../lib/lib'
 import {
@@ -21,7 +21,7 @@ describe('canContinueAdlibOnEndInfinites', () => {
 	})
 
 	async function wrapWithCache<T>(
-		fcn: (cache: CacheForPlayout, playlist: ReadonlyDeep<RundownPlaylist>) => Promise<T>
+		fcn: (cache: CacheForPlayout, playlist: ReadonlyDeep<DBRundownPlaylist>) => Promise<T>
 	): Promise<T> {
 		const defaultSetup = setupDefaultRundownPlaylist(env)
 

--- a/meteor/server/api/playout/__tests__/playout.test.ts
+++ b/meteor/server/api/playout/__tests__/playout.test.ts
@@ -10,7 +10,7 @@ import {
 	setupMockPeripheralDevice,
 	setupRundownWithAutoplayPart0,
 } from '../../../../__mocks__/helpers/database'
-import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import '../api'
 import { Timeline as OrgTimeline } from '../../../../lib/collections/Timeline'
 import { ServerPlayoutAPI } from '../playout'
@@ -58,9 +58,10 @@ describe('Playout API', () => {
 		return PeripheralDeviceCommands.find({ deviceId: device._id }, { sort: { time: 1 } }).fetch()
 	}
 	function getAllRundownData(rundown: Rundown) {
+		const { segments, parts } = RundownCollectionUtil.getSegmentsAndPartsSync(rundown)
 		return {
-			parts: rundown.getParts(),
-			segments: rundown.getSegments(),
+			parts,
+			segments,
 			rundown: Rundowns.findOne(rundown._id) as Rundown,
 			pieces: Pieces.find({ rundown: rundown._id }, { sort: { _id: 1 } }).fetch(),
 			adLibPieces: AdLibPieces.find({ rundown: rundown._id }, { sort: { _id: 1 } }).fetch(),
@@ -116,7 +117,8 @@ describe('Playout API', () => {
 			playlist.activationId = playlist.activationId ?? undefined
 			return playlist
 		}
-		const parts = getRundown0().getParts()
+
+		const parts = RundownCollectionUtil.getParts(getRundown0())
 
 		expect(getPlaylist0()).toMatchObject({
 			activationId: undefined,

--- a/meteor/server/api/playout/__tests__/timeline.test.ts
+++ b/meteor/server/api/playout/__tests__/timeline.test.ts
@@ -12,7 +12,12 @@ import '../api'
 import { Timeline } from '../../../../lib/collections/Timeline'
 import { ServerPlayoutAPI } from '../playout'
 import { updateTimeline } from '../timeline'
-import { RundownPlaylists, RundownPlaylist, RundownPlaylistId } from '../../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylists,
+	RundownPlaylist,
+	RundownPlaylistId,
+	RundownPlaylistCollectionUtil,
+} from '../../../../lib/collections/RundownPlaylists'
 import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
 import { PlayoutLockFunctionPriority, runPlayoutOperationWithCache } from '../lockFunction'
 import { VerifiedRundownPlaylistContentAccess } from '../../lib'
@@ -60,7 +65,9 @@ describe('Timeline', () => {
 		{
 			// Prepare and activate in rehersal:
 			await ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(playlistId0), playlistId0, false)
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeFalsy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(nextPartInstance!.part._id).toEqual(parts[0]._id)
@@ -75,7 +82,9 @@ describe('Timeline', () => {
 		{
 			// Take the first Part:
 			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId0), playlistId0)
-			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
+			const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(
+				getPlaylist0()
+			)
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()
 			expect(currentPartInstance!.part._id).toEqual(parts[0]._id)

--- a/meteor/server/api/playout/__tests__/timeline.test.ts
+++ b/meteor/server/api/playout/__tests__/timeline.test.ts
@@ -7,7 +7,7 @@ import {
 	setupDefaultRundownPlaylist,
 	setupMockPeripheralDevice,
 } from '../../../../__mocks__/helpers/database'
-import { Rundowns, Rundown } from '../../../../lib/collections/Rundowns'
+import { Rundowns, Rundown, RundownCollectionUtil } from '../../../../lib/collections/Rundowns'
 import '../api'
 import { Timeline } from '../../../../lib/collections/Timeline'
 import { ServerPlayoutAPI } from '../playout'
@@ -50,7 +50,7 @@ describe('Timeline', () => {
 		expect(getRundown0()).toBeTruthy()
 		expect(getPlaylist0()).toBeTruthy()
 
-		const parts = getRundown0().getParts()
+		const parts = RundownCollectionUtil.getParts(getRundown0())
 
 		expect(getPlaylist0()).toMatchObject({
 			activationId: undefined,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -12,7 +12,7 @@ import {
 	stringifyError,
 } from '../../../lib/lib'
 import { logger } from '../../../lib/logging'
-import { RundownHoldState, Rundown } from '../../../lib/collections/Rundowns'
+import { RundownHoldState, Rundown, RundownCollectionUtil } from '../../../lib/collections/Rundowns'
 import { TimelineObjGeneric, TimelineObjType } from '../../../lib/collections/Timeline'
 import { AdLibPieces, AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
@@ -101,7 +101,7 @@ export namespace ServerPlayoutAdLibAPI {
 				const rundown = cache.Rundowns.findOne(partInstance.rundownId)
 				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
 
-				const showStyleBase = rundown.getShowStyleBase() // todo: database
+				const showStyleBase = RundownCollectionUtil.getShowStyleBase(rundown) // todo: database
 				if (!pieceToCopy.allowDirectPlay) {
 					throw new Meteor.Error(
 						403,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -17,7 +17,6 @@ import { TimelineObjGeneric, TimelineObjType } from '../../../lib/collections/Ti
 import { AdLibPieces, AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { Piece, PieceId, Pieces } from '../../../lib/collections/Pieces'
-import { Part } from '../../../lib/collections/Parts'
 import { prefixAllObjectIds, setNextPart, selectNextPart } from './lib'
 import {
 	convertAdLibToPieceInstance,
@@ -360,7 +359,7 @@ export namespace ServerPlayoutAdLibAPI {
 				takeCount: currentPartInstance.takeCount + 1,
 				rehearsal: !!playlist.rehearsal,
 				orphaned: 'adlib-part',
-				part: new Part({
+				part: {
 					_id: getRandomId(),
 					_rank: 99999, // Corrected in innerStartQueuedAdLib
 					externalId: '',
@@ -369,7 +368,7 @@ export namespace ServerPlayoutAdLibAPI {
 					title: adLibPiece.name,
 					prerollDuration: adLibPiece.adlibPreroll,
 					expectedDuration: adLibPiece.expectedDuration,
-				}),
+				},
 			})
 			const newPieceInstance = convertAdLibToPieceInstance(
 				playlist.activationId,

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -350,7 +350,7 @@ export namespace ServerPlayoutAdLibAPI {
 
 		const span = profiler.startSpan('innerStartOrQueueAdLibPiece')
 		if (queue || adLibPiece.toBeQueued) {
-			const newPartInstance = new PartInstance({
+			const newPartInstance: PartInstance = {
 				_id: getRandomId(),
 				rundownId: rundown._id,
 				segmentId: currentPartInstance.segmentId,
@@ -369,7 +369,7 @@ export namespace ServerPlayoutAdLibAPI {
 					prerollDuration: adLibPiece.adlibPreroll,
 					expectedDuration: adLibPiece.expectedDuration,
 				},
-			})
+			}
 			const newPieceInstance = convertAdLibToPieceInstance(
 				playlist.activationId,
 				adLibPiece,

--- a/meteor/server/api/playout/cache.ts
+++ b/meteor/server/api/playout/cache.ts
@@ -1,7 +1,7 @@
 import { ReadonlyDeep } from 'type-fest'
 import _ from 'underscore'
-import { PartInstance, DBPartInstance, PartInstances } from '../../../lib/collections/PartInstances'
-import { Part, DBPart, Parts } from '../../../lib/collections/Parts'
+import { PartInstance, PartInstances } from '../../../lib/collections/PartInstances'
+import { Part, Parts } from '../../../lib/collections/Parts'
 import { PeripheralDevice, PeripheralDevices } from '../../../lib/collections/PeripheralDevices'
 import { PieceInstance, PieceInstances } from '../../../lib/collections/PieceInstances'
 import {
@@ -10,8 +10,8 @@ import {
 	RundownPlaylistId,
 	RundownPlaylists,
 } from '../../../lib/collections/RundownPlaylists'
-import { Rundown, DBRundown, Rundowns, RundownId } from '../../../lib/collections/Rundowns'
-import { Segment, DBSegment, Segments } from '../../../lib/collections/Segments'
+import { Rundown, Rundowns, RundownId } from '../../../lib/collections/Rundowns'
+import { Segment, Segments } from '../../../lib/collections/Segments'
 import { Studio, Studios } from '../../../lib/collections/Studios'
 import { Timeline, TimelineComplete } from '../../../lib/collections/Timeline'
 import { ActivationCache, getActivationCache } from '../../cache/ActivationCache'
@@ -36,19 +36,19 @@ export class CacheForPlayoutPreInit extends CacheBase<CacheForPlayout> {
 
 	public readonly activationCache: ActivationCache
 
-	public readonly Studio: DbCacheReadObject<Studio, Studio>
-	public readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>
+	public readonly Studio: DbCacheReadObject<Studio>
+	public readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice>
 
-	public readonly Playlist: DbCacheWriteObject<RundownPlaylist, DBRundownPlaylist>
-	public readonly Rundowns: DbCacheReadCollection<Rundown, DBRundown>
+	public readonly Playlist: DbCacheWriteObject<DBRundownPlaylist>
+	public readonly Rundowns: DbCacheReadCollection<Rundown>
 
 	protected constructor(
 		playlistId: RundownPlaylistId,
 		activationCache: ActivationCache,
-		studio: DbCacheReadObject<Studio, Studio>,
-		peripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>,
-		playlist: DbCacheWriteObject<RundownPlaylist, DBRundownPlaylist>,
-		rundowns: DbCacheReadCollection<Rundown, DBRundown>
+		studio: DbCacheReadObject<Studio>,
+		peripheralDevices: DbCacheReadCollection<PeripheralDevice>,
+		playlist: DbCacheWriteObject<DBRundownPlaylist>,
+		rundowns: DbCacheReadCollection<Rundown>
 	) {
 		super()
 
@@ -61,22 +61,22 @@ export class CacheForPlayoutPreInit extends CacheBase<CacheForPlayout> {
 		this.Rundowns = rundowns
 	}
 
-	static async createPreInit(tmpPlaylist: ReadonlyDeep<RundownPlaylist>): Promise<CacheForPlayoutPreInit> {
+	static async createPreInit(tmpPlaylist: ReadonlyDeep<DBRundownPlaylist>): Promise<CacheForPlayoutPreInit> {
 		const initData = await CacheForPlayoutPreInit.loadInitData(tmpPlaylist, true, undefined)
 		return new CacheForPlayoutPreInit(tmpPlaylist._id, ...initData)
 	}
 
 	protected static async loadInitData(
-		tmpPlaylist: ReadonlyDeep<RundownPlaylist>,
+		tmpPlaylist: ReadonlyDeep<DBRundownPlaylist>,
 		reloadPlaylist: boolean,
-		existingRundowns: DbCacheReadCollection<Rundown, DBRundown> | undefined
+		existingRundowns: DbCacheReadCollection<Rundown> | undefined
 	): Promise<
 		[
 			ActivationCache,
-			DbCacheReadObject<Studio, Studio>,
-			DbCacheReadCollection<PeripheralDevice, PeripheralDevice>,
-			DbCacheWriteObject<RundownPlaylist, DBRundownPlaylist>,
-			DbCacheReadCollection<Rundown, DBRundown>
+			DbCacheReadObject<Studio>,
+			DbCacheReadCollection<PeripheralDevice>,
+			DbCacheWriteObject<DBRundownPlaylist>,
+			DbCacheReadCollection<Rundown>
 		]
 	> {
 		const activationCache = getActivationCache(tmpPlaylist.studioId, tmpPlaylist._id)
@@ -84,11 +84,7 @@ export class CacheForPlayoutPreInit extends CacheBase<CacheForPlayout> {
 		const [playlist, rundowns] = await Promise.all([
 			reloadPlaylist
 				? await DbCacheWriteObject.createFromDatabase(RundownPlaylists, false, tmpPlaylist._id)
-				: DbCacheWriteObject.createFromDoc<RundownPlaylist, DBRundownPlaylist>(
-						RundownPlaylists,
-						false,
-						tmpPlaylist
-				  ),
+				: DbCacheWriteObject.createFromDoc<DBRundownPlaylist>(RundownPlaylists, false, tmpPlaylist),
 			existingRundowns ?? DbCacheReadCollection.createFromDatabase(Rundowns, { playlistId: tmpPlaylist._id }),
 		])
 
@@ -110,25 +106,25 @@ export class CacheForPlayoutPreInit extends CacheBase<CacheForPlayout> {
 export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForStudioBase {
 	private toBeRemoved: boolean = false
 
-	public readonly Timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+	public readonly Timeline: DbCacheWriteCollection<TimelineComplete>
 
-	public readonly Segments: DbCacheReadCollection<Segment, DBSegment>
-	public readonly Parts: DbCacheReadCollection<Part, DBPart>
-	public readonly PartInstances: DbCacheWriteCollection<PartInstance, DBPartInstance>
-	public readonly PieceInstances: DbCacheWriteCollection<PieceInstance, PieceInstance>
+	public readonly Segments: DbCacheReadCollection<Segment>
+	public readonly Parts: DbCacheReadCollection<Part>
+	public readonly PartInstances: DbCacheWriteCollection<PartInstance>
+	public readonly PieceInstances: DbCacheWriteCollection<PieceInstance>
 
 	protected constructor(
 		playlistId: RundownPlaylistId,
 		activationCache: ActivationCache,
-		studio: DbCacheReadObject<Studio, Studio>,
-		peripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>,
-		playlist: DbCacheWriteObject<RundownPlaylist, DBRundownPlaylist>,
-		rundowns: DbCacheReadCollection<Rundown, DBRundown>,
-		segments: DbCacheReadCollection<Segment, DBSegment>,
-		parts: DbCacheReadCollection<Part, DBPart>,
-		partInstances: DbCacheWriteCollection<PartInstance, DBPartInstance>,
-		pieceInstances: DbCacheWriteCollection<PieceInstance, PieceInstance>,
-		timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+		studio: DbCacheReadObject<Studio>,
+		peripheralDevices: DbCacheReadCollection<PeripheralDevice>,
+		playlist: DbCacheWriteObject<DBRundownPlaylist>,
+		rundowns: DbCacheReadCollection<Rundown>,
+		segments: DbCacheReadCollection<Segment>,
+		parts: DbCacheReadCollection<Part>,
+		partInstances: DbCacheWriteCollection<PartInstance>,
+		pieceInstances: DbCacheWriteCollection<PieceInstance>,
+		timeline: DbCacheWriteCollection<TimelineComplete>
 	) {
 		super(playlistId, activationCache, studio, peripheralDevices, playlist, rundowns)
 
@@ -177,7 +173,7 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 		const initData = await CacheForPlayoutPreInit.loadInitData(
 			newPlaylist,
 			false,
-			DbCacheReadCollection.createFromArray<Rundown, DBRundown>(Rundowns, newRundowns)
+			DbCacheReadCollection.createFromArray<Rundown>(Rundowns, newRundowns)
 		)
 
 		const contentData = await CacheForPlayout.loadContent(
@@ -196,15 +192,15 @@ export class CacheForPlayout extends CacheForPlayoutPreInit implements CacheForS
 	 */
 	private static async loadContent(
 		ingestCache: ReadOnlyCache<CacheForIngest> | null,
-		playlist: ReadonlyDeep<RundownPlaylist>,
+		playlist: ReadonlyDeep<DBRundownPlaylist>,
 		rundownIds: RundownId[]
 	): Promise<
 		[
-			DbCacheReadCollection<Segment, DBSegment>,
-			DbCacheReadCollection<Part, DBPart>,
-			DbCacheWriteCollection<PartInstance, DBPartInstance>,
-			DbCacheWriteCollection<PieceInstance, PieceInstance>,
-			DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+			DbCacheReadCollection<Segment>,
+			DbCacheReadCollection<Part>,
+			DbCacheWriteCollection<PartInstance>,
+			DbCacheWriteCollection<PieceInstance>,
+			DbCacheWriteCollection<TimelineComplete>
 		]
 	> {
 		const selectedPartInstanceIds = _.compact([

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -8,7 +8,7 @@ import {
 	wrapPartToTemporaryInstance,
 } from '../../../lib/collections/PartInstances'
 import { PieceInstance } from '../../../lib/collections/PieceInstances'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
+import { DBRundownPlaylist } from '../../../lib/collections/RundownPlaylists'
 import { saveIntoCache } from '../../cache/lib'
 import {
 	getPieceInstancesForPart as libgetPieceInstancesForPart,
@@ -30,7 +30,7 @@ import { flatten, getCurrentTime } from '../../../lib/lib'
 import { CacheForIngest } from '../ingest/cache'
 import { ReadOnlyCache } from '../../cache/CacheBase'
 import { Rundown } from '../../../lib/collections/Rundowns'
-import { DBSegment } from '../../../lib/collections/Segments'
+import { Segment } from '../../../lib/collections/Segments'
 
 // /** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
 export const DEFINITELY_ENDED_FUTURE_DURATION = 1 * 1000
@@ -39,8 +39,8 @@ export const DEFINITELY_ENDED_FUTURE_DURATION = 1 * 1000
  * We can only continue adlib onEnd infinites if we go forwards in the rundown. Any distance backwards will clear them.
  * */
 export function canContinueAdlibOnEndInfinites(
-	playlist: ReadonlyDeep<RundownPlaylist>,
-	orderedSegments: DBSegment[],
+	playlist: ReadonlyDeep<DBRundownPlaylist>,
+	orderedSegments: Segment[],
 	previousPartInstance: PartInstance | undefined,
 	candidateInstance: DBPartInstance
 ): boolean {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor'
 import { Random } from 'meteor/random'
 import * as _ from 'underscore'
 import { logger } from '../../logging'
-import { DBRundown, RundownHoldState, RundownId } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownHoldState, RundownId } from '../../../lib/collections/Rundowns'
 import { Part, DBPart, isPartPlayable } from '../../../lib/collections/Parts'
 import {
 	getCurrentTime,
@@ -683,9 +683,9 @@ export function isTooCloseToAutonext(currentPartInstance: ReadonlyDeep<PartInsta
 }
 
 export function getRundownsSegmentsAndPartsFromCache(
-	partsCache: DbCacheReadCollection<Part, DBPart>,
-	segmentsCache: DbCacheReadCollection<Segment, DBSegment>,
-	rundowns: Array<ReadonlyDeep<DBRundown>>
+	partsCache: DbCacheReadCollection<Part>,
+	segmentsCache: DbCacheReadCollection<Segment>,
+	rundowns: Array<ReadonlyDeep<Rundown>>
 ): { segments: Segment[]; parts: Part[] } {
 	const segments = RundownPlaylist._sortSegments(
 		segmentsCache.findFetch(

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -21,9 +21,9 @@ import {
 	getPieceInstancesForPart,
 	syncPlayheadInfinitesForNextPartInstance,
 } from './infinites'
-import { Segment, DBSegment, SegmentId } from '../../../lib/collections/Segments'
-import { RundownPlaylist } from '../../../lib/collections/RundownPlaylists'
-import { PartInstance, DBPartInstance, PartInstanceId, SegmentPlayoutId } from '../../../lib/collections/PartInstances'
+import { DBSegment, Segment, SegmentId } from '../../../lib/collections/Segments'
+import { RundownPlaylist, RundownPlaylistCollectionUtil } from '../../../lib/collections/RundownPlaylists'
+import { DBPartInstance, PartInstance, PartInstanceId, SegmentPlayoutId } from '../../../lib/collections/PartInstances'
 import { TSR } from '@sofie-automation/blueprints-integration'
 import { profiler } from '../profiler'
 import { ReadonlyDeep } from 'type-fest'
@@ -687,7 +687,7 @@ export function getRundownsSegmentsAndPartsFromCache(
 	segmentsCache: DbCacheReadCollection<Segment>,
 	rundowns: Array<ReadonlyDeep<Rundown>>
 ): { segments: Segment[]; parts: Part[] } {
-	const segments = RundownPlaylist._sortSegments(
+	const segments = RundownPlaylistCollectionUtil._sortSegments(
 		segmentsCache.findFetch(
 			{},
 			{
@@ -700,7 +700,7 @@ export function getRundownsSegmentsAndPartsFromCache(
 		rundowns
 	)
 
-	const parts = RundownPlaylist._sortPartsInner(
+	const parts = RundownPlaylistCollectionUtil._sortPartsInner(
 		partsCache.findFetch(
 			{},
 			{

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -471,7 +471,7 @@ export function setNextSegment(cache: CacheForPlayout, nextSegment: Segment | nu
 	if (nextSegment) {
 		// Just run so that errors will be thrown if something wrong:
 		const partsInSegment = cache.Parts.findFetch({ segmentId: nextSegment._id })
-		if (!partsInSegment.find((p) => p.isPlayable())) {
+		if (!partsInSegment.find(isPartPlayable)) {
 			throw new Meteor.Error(400, 'Segment contains no valid parts')
 		}
 

--- a/meteor/server/api/playout/lockFunction.ts
+++ b/meteor/server/api/playout/lockFunction.ts
@@ -1,6 +1,11 @@
 import { Meteor } from 'meteor/meteor'
 import { ReadonlyDeep } from 'type-fest'
-import { RundownPlaylistId, RundownPlaylist, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylistId,
+	RundownPlaylist,
+	RundownPlaylists,
+	DBRundownPlaylist,
+} from '../../../lib/collections/RundownPlaylists'
 import { assertNever } from '../../../lib/lib'
 import { ReadOnlyCache } from '../../cache/CacheBase'
 import { pushWorkToQueue } from '../../codeControl'
@@ -147,7 +152,7 @@ export async function runPlayoutOperationWithLock<T>(
 export async function runPlayoutOperationWithCacheFromStudioOperation<T>(
 	context: string,
 	cacheOrLock: ReadOnlyCache<CacheForStudio> | ReadOnlyCache<CacheForPlayoutPreInit> | StudioLock | PlaylistLock, // Important to verify correct lock is held
-	tmpPlaylist: ReadonlyDeep<RundownPlaylist>,
+	tmpPlaylist: ReadonlyDeep<DBRundownPlaylist>,
 	priority: PlayoutLockFunctionPriority,
 	preInitFcn: null | ((cache: ReadOnlyCache<CacheForPlayoutPreInit>) => Promise<void>),
 	fcn: (cache: CacheForPlayout) => Promise<T>
@@ -227,7 +232,7 @@ interface PlayoutLockOptions {
 async function playoutLockFunctionInner<T>(
 	context: string,
 	lock: StudioLock,
-	tmpPlaylist: ReadonlyDeep<RundownPlaylist>,
+	tmpPlaylist: ReadonlyDeep<DBRundownPlaylist>,
 	priority: PlayoutLockFunctionPriority,
 	preInitFcn: null | ((cache: ReadOnlyCache<CacheForPlayoutPreInit>) => Promise<void>),
 	fcn: (cache: CacheForPlayout) => Promise<T>,

--- a/meteor/server/api/playout/lookahead/__tests__/findForLayer.test.ts
+++ b/meteor/server/api/playout/lookahead/__tests__/findForLayer.test.ts
@@ -143,7 +143,7 @@ describe('findLookaheadForLayer', () => {
 			{ _id: 'p4' },
 			{ _id: 'p5' },
 		].map((p) => ({
-			part: new Part(p as any),
+			part: p as any,
 			pieces: [{ _id: p._id + '_p1' } as any],
 		}))
 

--- a/meteor/server/api/playout/lookahead/__tests__/lookahead.test.ts
+++ b/meteor/server/api/playout/lookahead/__tests__/lookahead.test.ts
@@ -8,7 +8,7 @@ import { DBRundown, RundownId, Rundowns } from '../../../../../lib/collections/R
 import { RundownPlaylist, RundownPlaylistId, RundownPlaylists } from '../../../../../lib/collections/RundownPlaylists'
 import { getCurrentTime, getRandomId, protectString } from '../../../../../lib/lib'
 import { SegmentId } from '../../../../../lib/collections/Segments'
-import { DBPart, Part, PartId, Parts } from '../../../../../lib/collections/Parts'
+import { DBPart, PartId, Parts } from '../../../../../lib/collections/Parts'
 import { LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
 import { MappingsExt, Studios } from '../../../../../lib/collections/Studios'
 import { OnGenerateTimelineObjExt, TimelineObjRundown } from '../../../../../lib/collections/Timeline'
@@ -161,7 +161,7 @@ describe('Lookahead', () => {
 
 		const partInstancesInfo: SelectedPartInstancesTimelineInfo = {}
 
-		const fakeParts = partIds.map((p) => ({ part: new Part({ _id: p } as any), pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValueOnce(fakeParts.map((p) => p.part))
 
 		const res = await runPlayoutOperationWithCache(
@@ -191,7 +191,7 @@ describe('Lookahead', () => {
 	testInFiber('got some objects', async () => {
 		const partInstancesInfo: SelectedPartInstancesTimelineInfo = {}
 
-		const fakeParts = partIds.map((p) => ({ part: new Part({ _id: p } as any), pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValueOnce(fakeParts.map((p) => p.part))
 
 		findLookaheadForLayerMock
@@ -276,7 +276,7 @@ describe('Lookahead', () => {
 	})
 
 	testInFiber('PartInstances translation', async () => {
-		const fakeParts = partIds.map((p) => ({ part: new Part({ _id: p } as any), pieces: [] }))
+		const fakeParts = partIds.map((p) => ({ part: { _id: p } as any, pieces: [] }))
 		getOrderedPartsAfterPlayheadMock.mockReturnValue(fakeParts.map((p) => p.part))
 
 		const partInstancesInfo: SelectedPartInstancesTimelineInfo = {

--- a/meteor/server/api/playout/lookahead/findForLayer.ts
+++ b/meteor/server/api/playout/lookahead/findForLayer.ts
@@ -1,5 +1,5 @@
 import { PartInstanceId } from '../../../../lib/collections/PartInstances'
-import { Part } from '../../../../lib/collections/Parts'
+import { isPartPlayable, Part } from '../../../../lib/collections/Parts'
 import { OnGenerateTimelineObjExt, TimelineObjRundown } from '../../../../lib/collections/Timeline'
 import { profiler } from '../../profiler'
 import { sortPieceInstancesByStart } from '../pieces'
@@ -65,7 +65,7 @@ export function findLookaheadForLayer(
 				break
 			}
 
-			if (partInfo.pieces.length > 0 && partInfo.part.isPlayable()) {
+			if (partInfo.pieces.length > 0 && isPartPlayable(partInfo.part)) {
 				const objs = findLookaheadObjectsForPart(currentPartInstanceId, layer, previousPart, partInfo, null)
 				res.future.push(...objs)
 				previousPart = partInfo.part

--- a/meteor/server/api/playout/lookahead/util.ts
+++ b/meteor/server/api/playout/lookahead/util.ts
@@ -1,6 +1,6 @@
 import { TimelineObjectCoreExt } from '@sofie-automation/blueprints-integration'
 import { PartInstance } from '../../../../lib/collections/PartInstances'
-import { Part } from '../../../../lib/collections/Parts'
+import { isPartPlayable, Part } from '../../../../lib/collections/Parts'
 import { PieceInstance, PieceInstancePiece } from '../../../../lib/collections/PieceInstances'
 import { Piece } from '../../../../lib/collections/Pieces'
 import { profiler } from '../../profiler'
@@ -62,7 +62,7 @@ export function getOrderedPartsAfterPlayhead(cache: CacheForPlayout, partCount: 
 		return []
 	}
 
-	const playablePartsSlice = partsAndSegments.parts.slice(nextNextPart.index).filter((p) => p.isPlayable())
+	const playablePartsSlice = partsAndSegments.parts.slice(nextNextPart.index).filter(isPartPlayable)
 
 	const res: Part[] = []
 
@@ -87,7 +87,7 @@ export function getOrderedPartsAfterPlayhead(cache: CacheForPlayout, partCount: 
 
 	if (res.length < partCount && playlist.loop) {
 		// The rundown would loop here, so lets run with that
-		const playableParts = partsAndSegments.parts.filter((p) => p.isPlayable())
+		const playableParts = partsAndSegments.parts.filter(isPartPlayable)
 		// Note: We only add it once, as lookahead is unlikely to show anything new in a second pass
 		res.push(...playableParts)
 

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -24,7 +24,7 @@ import {
 	reportPartInstanceHasStopped,
 	reportPieceHasStopped,
 } from '../blueprints/events'
-import { RundownPlaylist, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
+import { RundownPlaylistCollectionUtil, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { loadShowStyleBlueprint } from '../blueprints/cache'
 import { ActionExecutionContext, ActionPartChange } from '../blueprints/context/adlibActions'
 import { updateStudioTimeline, updateTimeline } from './timeline'
@@ -468,7 +468,10 @@ export namespace ServerPlayoutAPI {
 			let refPartIndex = playabaleParts.findIndex((p) => p._id === refPart._id)
 			if (refPartIndex === -1) {
 				const tmpRefPart = { ...refPart, invalid: true } // make sure it won't be found as playable
-				playabaleParts = RundownPlaylist._sortPartsInner([...playabaleParts, tmpRefPart], rawSegments)
+				playabaleParts = RundownPlaylistCollectionUtil._sortPartsInner(
+					[...playabaleParts, tmpRefPart],
+					rawSegments
+				)
 				refPartIndex = playabaleParts.findIndex((p) => p._id === refPart._id)
 				if (refPartIndex === -1) throw new Meteor.Error(500, `Part "${refPart._id}" not found after insert!`)
 			}

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-use-before-declare */
 import { Meteor } from 'meteor/meteor'
 import { Rundown, RundownCollectionUtil, RundownHoldState, Rundowns } from '../../../lib/collections/Rundowns'
-import { Part, DBPart, PartId } from '../../../lib/collections/Parts'
+import { Part, DBPart, PartId, isPartPlayable } from '../../../lib/collections/Parts'
 import { PieceId } from '../../../lib/collections/Pieces'
 import {
 	getCurrentTime,
@@ -437,10 +437,7 @@ export namespace ServerPlayoutAPI {
 					: considerSegments.slice(0, targetSegmentIndex + 1).reverse()
 			// const allowedSegmentIds = new Set(allowedSegments.map((s) => s._id))
 
-			const playablePartsBySegment = _.groupBy(
-				rawParts.filter((p) => p.isPlayable()),
-				(p) => p.segmentId
-			)
+			const playablePartsBySegment = _.groupBy(rawParts.filter(isPartPlayable), (p) => p.segmentId)
 
 			// Iterate through segments and find the first part
 			let selectedPart: Part | undefined
@@ -467,7 +464,7 @@ export namespace ServerPlayoutAPI {
 				return null
 			}
 		} else if (partDelta) {
-			let playabaleParts: DBPart[] = rawParts.filter((p) => refPart._id === p._id || p.isPlayable())
+			let playabaleParts: DBPart[] = rawParts.filter((p) => refPart._id === p._id || isPartPlayable(p))
 			let refPartIndex = playabaleParts.findIndex((p) => p._id === refPart._id)
 			if (refPartIndex === -1) {
 				const tmpRefPart = { ...refPart, invalid: true } // make sure it won't be found as playable

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-use-before-declare */
 import { Meteor } from 'meteor/meteor'
-import { Rundown, RundownHoldState, Rundowns } from '../../../lib/collections/Rundowns'
+import { Rundown, RundownCollectionUtil, RundownHoldState, Rundowns } from '../../../lib/collections/Rundowns'
 import { Part, DBPart, PartId } from '../../../lib/collections/Parts'
 import { PieceId } from '../../../lib/collections/Pieces'
 import {
@@ -642,7 +642,7 @@ export namespace ServerPlayoutAPI {
 
 				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
 				if (!rundown) throw new Meteor.Error(404, `Rundown "${currentPartInstance.rundownId}" not found!`)
-				const showStyleBase = rundown.getShowStyleBase()
+				const showStyleBase = RundownCollectionUtil.getShowStyleBase(rundown)
 
 				// @ts-ignore stringify
 				// logger.info(o)

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -228,12 +228,12 @@ export function updatePartInstanceRanks(cache: CacheForPlayout, changedSegments:
 				delete partInstance.orphaned
 				partInstance.part._rank = part._rank
 			} else if (!partInstance.orphaned) {
-				partInstance.orphaned = 'deleted'
 				cache.PartInstances.update(partInstance._id, {
 					$set: {
 						orphaned: 'deleted',
 					},
 				})
+				partInstance.orphaned = 'deleted'
 			}
 		}
 

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -29,7 +29,11 @@ import { ExtendedIngestRundown } from '@sofie-automation/blueprints-integration'
 import { loadStudioBlueprint, loadShowStyleBlueprint } from './blueprints/cache'
 import { PackageInfo } from '../coreSystem'
 import { IngestActions } from './ingest/actions'
-import { RundownPlaylistId, RundownPlaylist } from '../../lib/collections/RundownPlaylists'
+import {
+	RundownPlaylistId,
+	RundownPlaylist,
+	RundownPlaylistCollectionUtil,
+} from '../../lib/collections/RundownPlaylists'
 import { ReloadRundownPlaylistResponse, TriggerReloadDataResponse } from '../../lib/api/userActions'
 import { MethodContextAPI, MethodContext } from '../../lib/api/methods'
 import { StudioContentWriteAccess } from '../security/studio'
@@ -157,7 +161,7 @@ export function allowedToMoveRundownOutOfPlaylist(
 	playlist: ReadonlyDeep<RundownPlaylist>,
 	rundown: ReadonlyDeep<DBRundown>
 ) {
-	const { currentPartInstance, nextPartInstance } = playlist.getSelectedPartInstances()
+	const { currentPartInstance, nextPartInstance } = RundownPlaylistCollectionUtil.getSelectedPartInstances(playlist)
 
 	if (rundown.playlistId !== playlist._id)
 		throw new Meteor.Error(
@@ -417,7 +421,7 @@ export namespace ClientRundownAPI {
 		const access = StudioContentWriteAccess.rundownPlaylist(context, playlistId)
 		const playlist = access.playlist
 
-		const rundowns = playlist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(playlist)
 		const errors = rundowns.map((rundown) => {
 			if (!rundown.importVersions) return 'unknown'
 
@@ -455,11 +459,11 @@ export namespace ClientRundownAPI {
 		const access = StudioContentWriteAccess.rundownPlaylist(context, playlistId)
 		const rundownPlaylist = access.playlist
 
-		const studio = rundownPlaylist.getStudio()
+		const studio = RundownPlaylistCollectionUtil.getStudio(rundownPlaylist)
 		const studioBlueprint = studio.blueprintId ? await fetchBlueprintLight(studio.blueprintId) : null
 		if (!studioBlueprint) throw new Meteor.Error(404, `Studio blueprint "${studio.blueprintId}" not found!`)
 
-		const rundowns = rundownPlaylist.getRundowns()
+		const rundowns = RundownPlaylistCollectionUtil.getRundowns(rundownPlaylist)
 		const uniqueShowStyleCompounds = _.uniq(
 			rundowns,
 			undefined,

--- a/meteor/server/api/rundownPlaylist.ts
+++ b/meteor/server/api/rundownPlaylist.ts
@@ -99,7 +99,7 @@ export function getPlaylistIdFromExternalId(studioId: StudioId, playlistExternal
 	return protectString(getHash(`${studioId}_${playlistExternalId}`))
 }
 
-export async function removeRundownPlaylistFromDb(playlist: ReadonlyDeep<RundownPlaylist>): Promise<void> {
+export async function removeRundownPlaylistFromDb(playlist: ReadonlyDeep<DBRundownPlaylist>): Promise<void> {
 	if (playlist.activationId)
 		throw new Meteor.Error(500, `RundownPlaylist "${playlist._id}" is active and cannot be removed`)
 
@@ -235,7 +235,7 @@ function defaultPlaylistForRundown(
 export function updateRundownsInPlaylist(
 	_playlist: DBRundownPlaylist,
 	rundownRanks: BlueprintResultOrderedRundowns,
-	rundownCollection: DbCacheWriteCollection<Rundown, DBRundown>
+	rundownCollection: DbCacheWriteCollection<Rundown>
 ) {
 	let maxRank: number = Number.NEGATIVE_INFINITY
 	const unrankedRundowns: DBRundown[] = []

--- a/meteor/server/api/studio/cache.ts
+++ b/meteor/server/api/studio/cache.ts
@@ -1,10 +1,5 @@
 import { PeripheralDevice, PeripheralDevices } from '../../../lib/collections/PeripheralDevices'
-import {
-	RundownPlaylist,
-	DBRundownPlaylist,
-	RundownPlaylists,
-	RundownPlaylistId,
-} from '../../../lib/collections/RundownPlaylists'
+import { DBRundownPlaylist, RundownPlaylists, RundownPlaylistId } from '../../../lib/collections/RundownPlaylists'
 import { Studio, Studios, StudioId } from '../../../lib/collections/Studios'
 import { Timeline, TimelineComplete } from '../../../lib/collections/Timeline'
 import { protectString } from '../../../lib/lib'
@@ -13,10 +8,10 @@ import { DbCacheReadObject } from '../../cache/CacheObject'
 import { CacheBase } from '../../cache/CacheBase'
 
 export interface CacheForStudioBase {
-	readonly Studio: DbCacheReadObject<Studio, Studio>
-	readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>
+	readonly Studio: DbCacheReadObject<Studio>
+	readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice>
 
-	readonly Timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+	readonly Timeline: DbCacheWriteCollection<TimelineComplete>
 }
 
 /**
@@ -25,17 +20,17 @@ export interface CacheForStudioBase {
 export class CacheForStudio extends CacheBase<CacheForStudio> implements CacheForStudioBase {
 	public readonly isStudio = true
 
-	public readonly Studio: DbCacheReadObject<Studio, Studio>
-	public readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>
+	public readonly Studio: DbCacheReadObject<Studio>
+	public readonly PeripheralDevices: DbCacheReadCollection<PeripheralDevice>
 
-	public readonly RundownPlaylists: DbCacheReadCollection<RundownPlaylist, DBRundownPlaylist>
-	public readonly Timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+	public readonly RundownPlaylists: DbCacheReadCollection<DBRundownPlaylist>
+	public readonly Timeline: DbCacheWriteCollection<TimelineComplete>
 
 	private constructor(
-		studio: DbCacheReadObject<Studio, Studio>,
-		peripheralDevices: DbCacheReadCollection<PeripheralDevice, PeripheralDevice>,
-		rundownPlaylists: DbCacheReadCollection<RundownPlaylist, DBRundownPlaylist>,
-		timeline: DbCacheWriteCollection<TimelineComplete, TimelineComplete>
+		studio: DbCacheReadObject<Studio>,
+		peripheralDevices: DbCacheReadCollection<PeripheralDevice>,
+		rundownPlaylists: DbCacheReadCollection<DBRundownPlaylist>,
+		timeline: DbCacheWriteCollection<TimelineComplete>
 	) {
 		super()
 
@@ -58,7 +53,7 @@ export class CacheForStudio extends CacheBase<CacheForStudio> implements CacheFo
 		return new CacheForStudio(studio, ...collections)
 	}
 
-	public getActiveRundownPlaylists(excludeRundownPlaylistId?: RundownPlaylistId): RundownPlaylist[] {
+	public getActiveRundownPlaylists(excludeRundownPlaylistId?: RundownPlaylistId): DBRundownPlaylist[] {
 		return this.RundownPlaylists.findFetch({
 			activationId: { $exists: true },
 			_id: {

--- a/meteor/server/api/system.ts
+++ b/meteor/server/api/system.ts
@@ -115,7 +115,7 @@ let mongoTest: TransformedCollection<any, any> | undefined = undefined
 /** Runs a set of system benchmarks, that are designed to test various aspects of the hardware-performance on the server */
 async function doSystemBenchmarkInner() {
 	if (!mongoTest) {
-		mongoTest = createMongoCollection<any, any>('benchmark-test')
+		mongoTest = createMongoCollection<any>('benchmark-test')
 		mongoTest._ensureIndex({
 			indexedProp: 1,
 		})

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -4,7 +4,7 @@ import { Meteor } from 'meteor/meteor'
 import { ClientAPI } from '../../lib/api/client'
 import { getCurrentTime, getHash, makePromise } from '../../lib/lib'
 import { Rundowns, RundownHoldState, RundownId } from '../../lib/collections/Rundowns'
-import { Parts, Part, PartId } from '../../lib/collections/Parts'
+import { Parts, Part, PartId, isPartPlayable } from '../../lib/collections/Parts'
 import { logger } from '../logging'
 import { ServerPlayoutAPI } from './playout/playout'
 import { NewUserActionAPI, RESTART_SALT, UserActionAPIMethods } from '../../lib/api/userActions'
@@ -138,7 +138,7 @@ export async function setNext(
 		nextPart = await Parts.findOneAsync(nextPartId)
 		if (!nextPart) throw new Meteor.Error(404, `Part "${nextPartId}" not found!`)
 
-		if (!nextPart.isPlayable()) return ClientAPI.responseError('Part is unplayable, cannot set as next.')
+		if (!isPartPlayable(nextPart)) return ClientAPI.responseError('Part is unplayable, cannot set as next.')
 	}
 
 	if (playlist.holdState && playlist.holdState !== RundownHoldState.COMPLETE) {
@@ -178,7 +178,7 @@ export async function setNextSegment(
 			rundownId: nextSegment.rundownId,
 			segmentId: nextSegment._id,
 		})
-		const firstValidPartInSegment = partsInSegment.find((p) => p.isPlayable())
+		const firstValidPartInSegment = partsInSegment.find(isPartPlayable)
 
 		if (!firstValidPartInSegment) return ClientAPI.responseError('Segment contains no valid parts')
 

--- a/meteor/server/cache/ActivationCache.ts
+++ b/meteor/server/cache/ActivationCache.ts
@@ -1,4 +1,4 @@
-import { RundownPlaylist, RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
+import { DBRundownPlaylist, RundownPlaylist, RundownPlaylistId } from '../../lib/collections/RundownPlaylists'
 import { ProtectedString, clone } from '../../lib/lib'
 import { Meteor } from 'meteor/meteor'
 import { Studio, Studios, StudioId } from '../../lib/collections/Studios'
@@ -106,7 +106,7 @@ export class ActivationCache {
 		this._initialized = false
 		this._persistant = false
 	}
-	async initialize(playlist: ReadonlyDeep<RundownPlaylist>, rundownsInPlaylist: Rundown[]) {
+	async initialize(playlist: ReadonlyDeep<DBRundownPlaylist>, rundownsInPlaylist: Rundown[]) {
 		if (this._initialized && (!this._playlist || playlist.activationId !== this._playlist.activationId)) {
 			// activationId has changed, we should clear out the data because it might not be valid anymore
 			this._uninitialize()
@@ -118,7 +118,7 @@ export class ActivationCache {
 			throw new Error(
 				`ActivationCache.initialize playlist._id "${playlist._id}" not equal to this.playlistId "${this.playlistId}"`
 			)
-		this._playlist = clone<RundownPlaylist>(playlist)
+		this._playlist = new RundownPlaylist(clone<DBRundownPlaylist>(playlist))
 
 		const pStudio = Studios.findOneAsync(this._playlist.studioId)
 

--- a/meteor/server/cache/ActivationCache.ts
+++ b/meteor/server/cache/ActivationCache.ts
@@ -118,7 +118,7 @@ export class ActivationCache {
 			throw new Error(
 				`ActivationCache.initialize playlist._id "${playlist._id}" not equal to this.playlistId "${this.playlistId}"`
 			)
-		this._playlist = new RundownPlaylist(clone<DBRundownPlaylist>(playlist))
+		this._playlist = clone<DBRundownPlaylist>(playlist)
 
 		const pStudio = Studios.findOneAsync(this._playlist.studioId)
 

--- a/meteor/server/cache/CacheBase.ts
+++ b/meteor/server/cache/CacheBase.ts
@@ -11,17 +11,17 @@ import { anythingChanged, sumChanges } from '../lib/database'
 
 type DeferredFunction<Cache> = (cache: Cache) => void | Promise<void>
 
-type DbCacheWritable<T1 extends T2, T2 extends { _id: ProtectedString<any> }> =
-	| DbCacheWriteCollection<T1, T2>
-	| DbCacheWriteObject<T1, T2>
-	| DbCacheWriteOptionalObject<T1, T2>
+type DbCacheWritable<T extends { _id: ProtectedString<any> }> =
+	| DbCacheWriteCollection<T>
+	| DbCacheWriteObject<T>
+	| DbCacheWriteOptionalObject<T>
 
-export type ReadOnlyCacheInner<T> = T extends DbCacheWriteCollection<infer A, infer B>
-	? DbCacheReadCollection<A, B>
-	: T extends DbCacheWriteObject<infer A, infer B>
-	? DbCacheReadObject<A, B>
-	: T extends DbCacheWriteOptionalObject<infer A, infer B>
-	? DbCacheReadObject<A, B, true>
+export type ReadOnlyCacheInner<T> = T extends DbCacheWriteCollection<infer A>
+	? DbCacheReadCollection<A>
+	: T extends DbCacheWriteObject<infer A>
+	? DbCacheReadObject<A>
+	: T extends DbCacheWriteOptionalObject<infer A>
+	? DbCacheReadObject<A, true>
 	: T
 export type ReadOnlyCache<T extends CacheBase<any>> = Omit<
 	{ [K in keyof T]: ReadOnlyCacheInner<T[K]> },
@@ -62,8 +62,8 @@ export abstract class ReadOnlyCacheBase<T extends ReadOnlyCacheBase<never>> {
 	}
 
 	protected getAllCollections() {
-		const highPrioDBs: DbCacheWritable<any, any>[] = []
-		const lowPrioDBs: DbCacheWritable<any, any>[] = []
+		const highPrioDBs: DbCacheWritable<any>[] = []
+		const lowPrioDBs: DbCacheWritable<any>[] = []
 
 		_.map(_.keys(this), (key) => {
 			let db = this[key]

--- a/meteor/server/cache/CacheCollection.ts
+++ b/meteor/server/cache/CacheCollection.ts
@@ -29,32 +29,29 @@ type DbCacheCollectionDocument<Class> = {
 } | null // removed
 
 /** Caches data, allowing reads from cache, but not writes */
-export class DbCacheReadCollection<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }> {
-	documents = new Map<DBInterface['_id'], DbCacheCollectionDocument<Class>>()
-	protected originalDocuments: ReadonlyDeep<Array<Class>> = []
+export class DbCacheReadCollection<DBInterface extends { _id: ProtectedString<any> }> {
+	documents = new Map<DBInterface['_id'], DbCacheCollectionDocument<DBInterface>>()
+	protected originalDocuments: ReadonlyDeep<Array<DBInterface>> = []
 
 	// Set when the whole cache is to be removed from the db, to indicate that writes are not valid and will be ignored
 	protected isToBeRemoved = false
 
-	protected constructor(protected _collection: AsyncTransformedCollection<Class, DBInterface>) {
+	protected constructor(protected _collection: AsyncTransformedCollection<DBInterface, DBInterface>) {
 		//
 	}
 
-	public static createFromArray<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
-		docs: Class[] | ReadonlyDeep<Array<Class>>
-	): DbCacheReadCollection<Class, DBInterface> {
+	public static createFromArray<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		docs: DBInterface[] | ReadonlyDeep<Array<DBInterface>>
+	): DbCacheReadCollection<DBInterface> {
 		const col = new DbCacheReadCollection(collection)
 		col.fillWithDataFromArray(docs as any)
 		return col
 	}
-	public static async createFromDatabase<
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any> }
-	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+	public static async createFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		selector: MongoQuery<DBInterface>
-	): Promise<DbCacheReadCollection<Class, DBInterface>> {
+	): Promise<DbCacheReadCollection<DBInterface>> {
 		const docs = await collection.findFetchAsync(selector)
 
 		return DbCacheReadCollection.createFromArray(collection, docs)
@@ -67,7 +64,7 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 	findFetch(
 		selector?: MongoQuery<DBInterface> | DBInterface['_id'] | SelectorFunction<DBInterface>,
 		options?: FindOptions<DBInterface>
-	): Class[] {
+	): DBInterface[] {
 		const span = profiler.startSpan(`DBCache.findFetch.${this.name}`)
 
 		selector = selector || {}
@@ -85,7 +82,7 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 			}
 		}
 
-		const results: Class[] = []
+		const results: DBInterface[] = []
 		docsToSearch.forEach((doc, _id) => {
 			if (doc === null) return
 			if (
@@ -114,7 +111,7 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 	findOne(
 		selector?: MongoQuery<DBInterface> | DBInterface['_id'] | SelectorFunction<DBInterface>,
 		options?: FindOneOptions<DBInterface>
-	): Class | undefined {
+	): DBInterface | undefined {
 		return this.findFetch(selector, options)[0]
 	}
 
@@ -133,7 +130,7 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 	 * Note: By default this wipes the current collection first
 	 * @param documents The documents to store
 	 */
-	fillWithDataFromArray(documents: ReadonlyDeep<Array<Class>>, append = false) {
+	fillWithDataFromArray(documents: ReadonlyDeep<Array<DBInterface>>, append = false) {
 		if (append) {
 			this.originalDocuments = this.originalDocuments.concat(documents)
 		} else {
@@ -149,15 +146,8 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 				)
 			}
 
-			this.documents.set(id, { document: this._transform(clone(doc)) })
+			this.documents.set(id, { document: clone(doc) })
 		})
-	}
-	protected _transform(doc: DBInterface): Class {
-		// @ts-ignore hack: using internal function in collection
-		const transform = this._collection._transform
-		if (transform) {
-			return transform(doc)
-		} else return doc as Class
 	}
 
 	/** Called by the Cache when the Cache is marked as to be removed. The collection is emptied and marked to reject any further updates */
@@ -169,9 +159,8 @@ export class DbCacheReadCollection<Class extends DBInterface, DBInterface extend
 }
 /** Caches data, allowing writes that will later be committed to mongo */
 export class DbCacheWriteCollection<
-	Class extends DBInterface,
 	DBInterface extends { _id: ProtectedString<any> }
-> extends DbCacheReadCollection<Class, DBInterface> {
+> extends DbCacheReadCollection<DBInterface> {
 	protected assertNotToBeRemoved(methodName: string): void {
 		if (this.isToBeRemoved) {
 			const msg = `DbCacheWriteCollection: got call to "${methodName} when cache has been flagged for removal"`
@@ -183,21 +172,18 @@ export class DbCacheWriteCollection<
 		}
 	}
 
-	public static createFromArray<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
-		docs: Class[]
-	): DbCacheWriteCollection<Class, DBInterface> {
+	public static createFromArray<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		docs: DBInterface[]
+	): DbCacheWriteCollection<DBInterface> {
 		const col = new DbCacheWriteCollection(collection)
 		col.fillWithDataFromArray(docs as any)
 		return col
 	}
-	public static async createFromDatabase<
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any> }
-	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+	public static async createFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		selector: MongoQuery<DBInterface>
-	): Promise<DbCacheWriteCollection<Class, DBInterface>> {
+	): Promise<DbCacheWriteCollection<DBInterface>> {
 		const docs = await collection.findFetchAsync(selector)
 
 		return DbCacheWriteCollection.createFromArray(collection, docs)
@@ -221,7 +207,7 @@ export class DbCacheWriteCollection<
 		this.documents.set(doc._id, {
 			inserted: existing !== null,
 			updated: existing === null,
-			document: this._transform(newDoc), // Unlinke a normal collection, this class stores the transformed objects
+			document: newDoc,
 		})
 		if (span) span.end()
 		return doc._id
@@ -300,7 +286,7 @@ export class DbCacheWriteCollection<
 
 			const hasPendingChanges = docEntry.inserted || docEntry.updated // If the doc is already dirty, then there is no point trying to diff it
 			if (forceUpdate || hasPendingChanges || !_.isEqual(doc, newDoc)) {
-				docEntry.document = this._transform(newDoc)
+				docEntry.document = newDoc
 				docEntry.updated = true
 			}
 			changedIds.push(_id)
@@ -327,11 +313,11 @@ export class DbCacheWriteCollection<
 		const oldDoc = this.documents.get(_id)
 		if (oldDoc) {
 			oldDoc.updated = true
-			oldDoc.document = this._transform(newDoc)
+			oldDoc.document = newDoc
 		} else {
 			this.documents.set(_id, {
 				inserted: true,
-				document: this._transform(newDoc),
+				document: newDoc,
 			})
 		}
 
@@ -392,7 +378,7 @@ export class DbCacheWriteCollection<
 		}
 
 		const updates: BulkWriteOperation<DBInterface>[] = []
-		const removedDocs: Class['_id'][] = []
+		const removedDocs: DBInterface['_id'][] = []
 		this.documents.forEach((doc, id) => {
 			if (doc === null) {
 				removedDocs.push(id)
@@ -455,7 +441,7 @@ export class DbCacheWriteCollection<
 	 * Write all the documents in this cache into another. This assumes that this cache is a subset of the other and was populated with a subset of its data
 	 * @param otherCache The cache to update
 	 */
-	updateOtherCacheWithData(otherCache: DbCacheWriteCollection<Class, DBInterface>): ChangedIds<DBInterface['_id']> {
+	updateOtherCacheWithData(otherCache: DbCacheWriteCollection<DBInterface>): ChangedIds<DBInterface['_id']> {
 		const changes: ChangedIds<DBInterface['_id']> = {
 			added: [],
 			updated: [],

--- a/meteor/server/cache/CacheCollection.ts
+++ b/meteor/server/cache/CacheCollection.ts
@@ -18,7 +18,7 @@ import { BulkWriteOperation } from 'mongodb'
 import { ReadonlyDeep } from 'type-fest'
 import { logger } from '../logging'
 import { ChangedIds, Changes } from '../lib/database'
-import { AsyncTransformedCollection } from '../../lib/collections/lib'
+import { AsyncMongoCollection } from '../../lib/collections/lib'
 
 type SelectorFunction<DBInterface> = (doc: DBInterface) => boolean
 type DbCacheCollectionDocument<Class> = {
@@ -36,12 +36,12 @@ export class DbCacheReadCollection<DBInterface extends { _id: ProtectedString<an
 	// Set when the whole cache is to be removed from the db, to indicate that writes are not valid and will be ignored
 	protected isToBeRemoved = false
 
-	protected constructor(protected _collection: AsyncTransformedCollection<DBInterface, DBInterface>) {
+	protected constructor(protected _collection: AsyncMongoCollection<DBInterface>) {
 		//
 	}
 
 	public static createFromArray<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		docs: DBInterface[] | ReadonlyDeep<Array<DBInterface>>
 	): DbCacheReadCollection<DBInterface> {
 		const col = new DbCacheReadCollection(collection)
@@ -49,7 +49,7 @@ export class DbCacheReadCollection<DBInterface extends { _id: ProtectedString<an
 		return col
 	}
 	public static async createFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		selector: MongoQuery<DBInterface>
 	): Promise<DbCacheReadCollection<DBInterface>> {
 		const docs = await collection.findFetchAsync(selector)
@@ -173,7 +173,7 @@ export class DbCacheWriteCollection<
 	}
 
 	public static createFromArray<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		docs: DBInterface[]
 	): DbCacheWriteCollection<DBInterface> {
 		const col = new DbCacheWriteCollection(collection)
@@ -181,7 +181,7 @@ export class DbCacheWriteCollection<
 		return col
 	}
 	public static async createFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		selector: MongoQuery<DBInterface>
 	): Promise<DbCacheWriteCollection<DBInterface>> {
 		const docs = await collection.findFetchAsync(selector)

--- a/meteor/server/cache/CacheObject.ts
+++ b/meteor/server/cache/CacheObject.ts
@@ -13,7 +13,7 @@ import { profiler } from '../api/profiler'
 import { ReadonlyDeep } from 'type-fest'
 import { logger } from '../logging'
 import { Changes } from '../lib/database'
-import { AsyncTransformedCollection } from '../../lib/collections/lib'
+import { AsyncMongoCollection } from '../../lib/collections/lib'
 
 /**
  * Caches a single object, allowing reads from cache, but not writes
@@ -27,7 +27,7 @@ export class DbCacheReadObject<DBInterface extends { _id: ProtectedString<any> }
 	protected isToBeRemoved = false
 
 	protected constructor(
-		protected readonly _collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		protected readonly _collection: AsyncMongoCollection<DBInterface>,
 		private readonly _optional: DocOptional,
 		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	) {
@@ -39,7 +39,7 @@ export class DbCacheReadObject<DBInterface extends { _id: ProtectedString<any> }
 	}
 
 	public static createFromDoc<DBInterface extends { _id: ProtectedString<any> }, DocOptional extends boolean = false>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		optional: DocOptional,
 		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	): DbCacheReadObject<DBInterface, DocOptional> {
@@ -50,7 +50,7 @@ export class DbCacheReadObject<DBInterface extends { _id: ProtectedString<any> }
 		DBInterface extends { _id: ProtectedString<any> },
 		DocOptional extends boolean = false
 	>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		optional: DocOptional,
 		id: DBInterface['_id']
 	): Promise<DbCacheReadObject<DBInterface, DocOptional>> {
@@ -86,7 +86,7 @@ export class DbCacheWriteObject<
 	private _updated = false
 
 	constructor(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		optional: DocOptional,
 		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	) {
@@ -94,7 +94,7 @@ export class DbCacheWriteObject<
 	}
 
 	public static createFromDoc<DBInterface extends { _id: ProtectedString<any> }, DocOptional extends boolean = false>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		optional: DocOptional,
 		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	): DbCacheWriteObject<DBInterface, DocOptional> {
@@ -105,7 +105,7 @@ export class DbCacheWriteObject<
 		DBInterface extends { _id: ProtectedString<any> },
 		DocOptional extends boolean = false
 	>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		optional: DocOptional,
 		id: DBInterface['_id']
 	): Promise<DbCacheWriteObject<DBInterface, DocOptional>> {
@@ -208,22 +208,19 @@ export class DbCacheWriteOptionalObject<DBInterface extends { _id: ProtectedStri
 > {
 	private _inserted = false
 
-	constructor(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
-		doc: ReadonlyDeep<DBInterface> | undefined
-	) {
+	constructor(collection: AsyncMongoCollection<DBInterface>, doc: ReadonlyDeep<DBInterface> | undefined) {
 		super(collection, true, doc)
 	}
 
 	public static createOptionalFromDoc<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		doc: ReadonlyDeep<DBInterface> | undefined
 	): DbCacheWriteOptionalObject<DBInterface> {
 		return new DbCacheWriteOptionalObject<DBInterface>(collection, doc)
 	}
 
 	public static async createOptionalFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		collection: AsyncMongoCollection<DBInterface>,
 		id: DBInterface['_id']
 	): Promise<DbCacheWriteOptionalObject<DBInterface>> {
 		const doc = await collection.findOneAsync(id)

--- a/meteor/server/cache/CacheObject.ts
+++ b/meteor/server/cache/CacheObject.ts
@@ -19,50 +19,41 @@ import { AsyncTransformedCollection } from '../../lib/collections/lib'
  * Caches a single object, allowing reads from cache, but not writes
  * This should be used when the cache can only have one of something, and that must exist
  */
-export class DbCacheReadObject<
-	Class extends DBInterface,
-	DBInterface extends { _id: ProtectedString<any> },
-	DocOptional extends boolean = false
-> {
-	protected _document: Class
-	protected _rawDocument: Class
+export class DbCacheReadObject<DBInterface extends { _id: ProtectedString<any> }, DocOptional extends boolean = false> {
+	protected _document: DBInterface
+	protected _rawDocument: DBInterface
 
 	// Set when the whole cache is to be removed from the db, to indicate that writes are not valid and will be ignored
 	protected isToBeRemoved = false
 
 	protected constructor(
-		protected readonly _collection: AsyncTransformedCollection<Class, DBInterface>,
+		protected readonly _collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		private readonly _optional: DocOptional,
-		doc: DocOptional extends true ? ReadonlyDeep<Class> | undefined : ReadonlyDeep<Class>
+		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	) {
-		this._document = (doc ? this._transform(clone(doc as any)) : doc) as any
+		this._document = doc ? clone(doc as any) : doc
 		this._rawDocument = clone(doc as any)
 	}
 	get name(): string | null {
 		return this._collection.name
 	}
 
-	public static createFromDoc<
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any> },
-		DocOptional extends boolean = false
-	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+	public static createFromDoc<DBInterface extends { _id: ProtectedString<any> }, DocOptional extends boolean = false>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		optional: DocOptional,
-		doc: DocOptional extends true ? ReadonlyDeep<Class> | undefined : ReadonlyDeep<Class>
-	): DbCacheReadObject<Class, DBInterface, DocOptional> {
-		return new DbCacheReadObject<Class, DBInterface, DocOptional>(collection, optional, doc)
+		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
+	): DbCacheReadObject<DBInterface, DocOptional> {
+		return new DbCacheReadObject<DBInterface, DocOptional>(collection, optional, doc)
 	}
 
 	public static async createFromDatabase<
-		Class extends DBInterface,
 		DBInterface extends { _id: ProtectedString<any> },
 		DocOptional extends boolean = false
 	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		optional: DocOptional,
 		id: DBInterface['_id']
-	): Promise<DbCacheReadObject<Class, DBInterface, DocOptional>> {
+	): Promise<DbCacheReadObject<DBInterface, DocOptional>> {
 		const doc = await collection.findOneAsync(id)
 		if (!doc && !optional) {
 			throw new Meteor.Error(
@@ -71,19 +62,11 @@ export class DbCacheReadObject<
 			)
 		}
 
-		return DbCacheReadObject.createFromDoc<Class, DBInterface, DocOptional>(collection, optional, doc as any)
+		return DbCacheReadObject.createFromDoc<DBInterface, DocOptional>(collection, optional, doc as any)
 	}
 
-	get doc(): DocOptional extends true ? ReadonlyDeep<Class> | undefined : ReadonlyDeep<Class> {
+	get doc(): DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface> {
 		return this._document as any
-	}
-
-	protected _transform(doc: DBInterface): Class {
-		// @ts-ignore hack: using internal function in collection
-		const transform = this._collection._transform
-		if (transform) {
-			return transform(doc)
-		} else return doc as Class
 	}
 
 	/** Called by the Cache when the Cache is marked as to be removed. The collection is emptied and marked to reject any further updates */
@@ -97,41 +80,35 @@ export class DbCacheReadObject<
  * This should be used when the cache can only have one of something, and that must exist
  */
 export class DbCacheWriteObject<
-	Class extends DBInterface,
 	DBInterface extends { _id: ProtectedString<any> },
 	DocOptional extends boolean = false
-> extends DbCacheReadObject<Class, DBInterface, DocOptional> {
+> extends DbCacheReadObject<DBInterface, DocOptional> {
 	private _updated = false
 
 	constructor(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		optional: DocOptional,
-		doc: DocOptional extends true ? ReadonlyDeep<Class> | undefined : ReadonlyDeep<Class>
+		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
 	) {
 		super(collection, optional, doc)
 	}
 
-	public static createFromDoc<
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any> },
-		DocOptional extends boolean = false
-	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+	public static createFromDoc<DBInterface extends { _id: ProtectedString<any> }, DocOptional extends boolean = false>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		optional: DocOptional,
-		doc: DocOptional extends true ? ReadonlyDeep<Class> | undefined : ReadonlyDeep<Class>
-	): DbCacheWriteObject<Class, DBInterface, DocOptional> {
-		return new DbCacheWriteObject<Class, DBInterface, DocOptional>(collection, optional, doc)
+		doc: DocOptional extends true ? ReadonlyDeep<DBInterface> | undefined : ReadonlyDeep<DBInterface>
+	): DbCacheWriteObject<DBInterface, DocOptional> {
+		return new DbCacheWriteObject<DBInterface, DocOptional>(collection, optional, doc)
 	}
 
 	public static async createFromDatabase<
-		Class extends DBInterface,
 		DBInterface extends { _id: ProtectedString<any> },
 		DocOptional extends boolean = false
 	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		optional: DocOptional,
 		id: DBInterface['_id']
-	): Promise<DbCacheWriteObject<Class, DBInterface, DocOptional>> {
+	): Promise<DbCacheWriteObject<DBInterface, DocOptional>> {
 		const doc = await collection.findOneAsync(id)
 		if (!doc && !optional) {
 			throw new Meteor.Error(
@@ -140,7 +117,7 @@ export class DbCacheWriteObject<
 			)
 		}
 
-		return DbCacheWriteObject.createFromDoc<Class, DBInterface, DocOptional>(collection, optional, doc as any)
+		return DbCacheWriteObject.createFromDoc<DBInterface, DocOptional>(collection, optional, doc as any)
 	}
 
 	protected assertNotToBeRemoved(methodName: string): void {
@@ -157,7 +134,7 @@ export class DbCacheWriteObject<
 	update(modifier: ((doc: DBInterface) => DBInterface) | MongoModifier<DBInterface>): boolean {
 		this.assertNotToBeRemoved('update')
 
-		const localDoc: ReadonlyDeep<Class> | undefined = this.doc
+		const localDoc: ReadonlyDeep<DBInterface> | undefined = this.doc
 		if (!localDoc) throw new Meteor.Error(404, `Error: The document does not yet exist`)
 
 		const newDoc: DBInterface = _.isFunction(modifier)
@@ -175,7 +152,7 @@ export class DbCacheWriteObject<
 		deleteAllUndefinedProperties(newDoc)
 
 		if (!_.isEqual(this.doc, newDoc)) {
-			this._document = this._transform(newDoc)
+			this._document = newDoc
 
 			this._updated = true
 			return true
@@ -212,7 +189,7 @@ export class DbCacheWriteObject<
 	discardChanges() {
 		if (this.isModified()) {
 			this._updated = false
-			this._document = this._rawDocument ? this._transform(clone(this._rawDocument)) : this._rawDocument
+			this._document = this._rawDocument ? clone(this._rawDocument) : this._rawDocument
 		}
 	}
 
@@ -225,39 +202,39 @@ export class DbCacheWriteObject<
  * Caches a single object, allowing reads and writes that will be later committed back to mongo. This variant allows the object to start off undefined
  * This should be used when the cache can only have one of something, and that must exist
  */
-export class DbCacheWriteOptionalObject<
-	Class extends DBInterface,
-	DBInterface extends { _id: ProtectedString<any> }
-> extends DbCacheWriteObject<Class, DBInterface, true> {
+export class DbCacheWriteOptionalObject<DBInterface extends { _id: ProtectedString<any> }> extends DbCacheWriteObject<
+	DBInterface,
+	true
+> {
 	private _inserted = false
 
-	constructor(collection: AsyncTransformedCollection<Class, DBInterface>, doc: ReadonlyDeep<Class> | undefined) {
+	constructor(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		doc: ReadonlyDeep<DBInterface> | undefined
+	) {
 		super(collection, true, doc)
 	}
 
-	public static createOptionalFromDoc<Class extends DBInterface, DBInterface extends { _id: ProtectedString<any> }>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
-		doc: ReadonlyDeep<Class> | undefined
-	): DbCacheWriteOptionalObject<Class, DBInterface> {
-		return new DbCacheWriteOptionalObject<Class, DBInterface>(collection, doc)
+	public static createOptionalFromDoc<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
+		doc: ReadonlyDeep<DBInterface> | undefined
+	): DbCacheWriteOptionalObject<DBInterface> {
+		return new DbCacheWriteOptionalObject<DBInterface>(collection, doc)
 	}
 
-	public static async createOptionalFromDatabase<
-		Class extends DBInterface,
-		DBInterface extends { _id: ProtectedString<any> }
-	>(
-		collection: AsyncTransformedCollection<Class, DBInterface>,
+	public static async createOptionalFromDatabase<DBInterface extends { _id: ProtectedString<any> }>(
+		collection: AsyncTransformedCollection<DBInterface, DBInterface>,
 		id: DBInterface['_id']
-	): Promise<DbCacheWriteOptionalObject<Class, DBInterface>> {
+	): Promise<DbCacheWriteOptionalObject<DBInterface>> {
 		const doc = await collection.findOneAsync(id)
 
-		return DbCacheWriteOptionalObject.createOptionalFromDoc<Class, DBInterface>(
+		return DbCacheWriteOptionalObject.createOptionalFromDoc<DBInterface>(
 			collection,
-			doc as ReadonlyDeep<Class> | undefined
+			doc as ReadonlyDeep<DBInterface> | undefined
 		)
 	}
 
-	replace(doc: DBInterface): ReadonlyDeep<Class> {
+	replace(doc: DBInterface): ReadonlyDeep<DBInterface> {
 		this.assertNotToBeRemoved('replace')
 
 		this._inserted = true
@@ -269,7 +246,7 @@ export class DbCacheWriteOptionalObject<
 		// ensure no properties are 'undefined'
 		deleteAllUndefinedProperties(newDoc)
 
-		this._document = this._transform(newDoc)
+		this._document = newDoc
 
 		return this._document as any
 	}

--- a/meteor/server/cache/lib.ts
+++ b/meteor/server/cache/lib.ts
@@ -18,7 +18,7 @@ export function saveIntoCache<DBInterface extends DBObj>(
 	collection: DbCacheWriteCollection<DBInterface>,
 	filter: MongoQuery<DBInterface>,
 	newData: Array<DBInterface>,
-	optionsOrg?: SaveIntoDbHooks<DBInterface, DBInterface>
+	optionsOrg?: SaveIntoDbHooks<DBInterface>
 ): ChangedIds<DBInterface['_id']> {
 	return saveIntoBase(collection.name ?? '', collection.findFetch(filter), newData, {
 		...optionsOrg,

--- a/meteor/server/cache/lib.ts
+++ b/meteor/server/cache/lib.ts
@@ -5,20 +5,20 @@ import { DbCacheWriteObject, DbCacheWriteOptionalObject } from './CacheObject'
 import { SaveIntoDbHooks, ChangedIds, saveIntoBase } from '../lib/database'
 import { logger } from '../logging'
 
-export function isDbCacheReadCollection(o: any): o is DbCacheReadCollection<any, any> {
+export function isDbCacheReadCollection(o: any): o is DbCacheReadCollection<any> {
 	return !!(o && typeof o === 'object' && o.fillWithDataFromDatabase)
 }
 export function isDbCacheWritable(
 	o: any
-): o is DbCacheWriteCollection<any, any> | DbCacheWriteObject<any, any> | DbCacheWriteOptionalObject<any, any> {
+): o is DbCacheWriteCollection<any> | DbCacheWriteObject<any> | DbCacheWriteOptionalObject<any> {
 	return !!(o && typeof o === 'object' && o.updateDatabaseWithData)
 }
 /** Caches data, allowing reads from cache, but not writes */
-export function saveIntoCache<DocClass extends DBInterface, DBInterface extends DBObj>(
-	collection: DbCacheWriteCollection<DocClass, DBInterface>,
+export function saveIntoCache<DBInterface extends DBObj>(
+	collection: DbCacheWriteCollection<DBInterface>,
 	filter: MongoQuery<DBInterface>,
 	newData: Array<DBInterface>,
-	optionsOrg?: SaveIntoDbHooks<DocClass, DBInterface>
+	optionsOrg?: SaveIntoDbHooks<DBInterface, DBInterface>
 ): ChangedIds<DBInterface['_id']> {
 	return saveIntoBase(collection.name ?? '', collection.findFetch(filter), newData, {
 		...optionsOrg,

--- a/meteor/server/lib/__tests__/lib.test.ts
+++ b/meteor/server/lib/__tests__/lib.test.ts
@@ -61,7 +61,7 @@ describe('server/lib', () => {
 			generationVersions: {} as any,
 		})
 
-		const options: SaveIntoDbHooks<any, any> = {
+		const options: SaveIntoDbHooks<any> = {
 			beforeInsert: jest.fn((o) => o),
 			beforeUpdate: jest.fn((o) => o),
 			beforeRemove: jest.fn((o) => o),

--- a/meteor/server/lib/database.ts
+++ b/meteor/server/lib/database.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import { BulkWriteOperation } from 'mongodb'
 import _ from 'underscore'
-import { AsyncTransformedCollection } from '../../lib/collections/lib'
+import { AsyncMongoCollection } from '../../lib/collections/lib'
 import { DBObj, normalizeArrayToMap, ProtectedString, deleteAllUndefinedProperties } from '../../lib/lib'
 import { MongoQuery } from '../../lib/typings/meteor'
 import { profiler } from '../api/profiler'
@@ -44,11 +44,11 @@ export function anythingChanged(changes: Changes): boolean {
  * @param filter The filter defining the data subset to be affected in db
  * @param newData The new data
  */
-export async function saveIntoDb<DocClass extends DBInterface, DBInterface extends DBObj>(
-	collection: AsyncTransformedCollection<DocClass, DBInterface>,
+export async function saveIntoDb<DBInterface extends DBObj>(
+	collection: AsyncMongoCollection<DBInterface>,
 	filter: MongoQuery<DBInterface>,
 	newData: Array<DBInterface>,
-	options?: SaveIntoDbHooks<DocClass, DBInterface>
+	options?: SaveIntoDbHooks<DBInterface>
 ): Promise<Changes> {
 	const preparedChanges = prepareSaveIntoDb(collection, filter, newData, options)
 
@@ -62,11 +62,11 @@ export interface PreparedChanges<T> {
 	unchanged: T[]
 }
 
-function prepareSaveIntoDb<DocClass extends DBInterface, DBInterface extends DBObj>(
-	collection: AsyncTransformedCollection<DocClass, DBInterface>,
+function prepareSaveIntoDb<DBInterface extends DBObj>(
+	collection: AsyncMongoCollection<DBInterface>,
 	filter: MongoQuery<DBInterface>,
 	newData: Array<DBInterface>,
-	optionsOrg?: SaveIntoDbHooks<DocClass, DBInterface>
+	optionsOrg?: SaveIntoDbHooks<DBInterface>
 ): PreparedChanges<DBInterface> {
 	const preparedChanges: PreparedChanges<DBInterface> = {
 		inserted: [],
@@ -90,10 +90,10 @@ function prepareSaveIntoDb<DocClass extends DBInterface, DBInterface extends DBO
 
 	return preparedChanges
 }
-async function savePreparedChanges<DocClass extends DBInterface, DBInterface extends DBObj>(
+async function savePreparedChanges<DBInterface extends DBObj>(
 	preparedChanges: PreparedChanges<DBInterface>,
-	collection: AsyncTransformedCollection<DocClass, DBInterface>,
-	options: SaveIntoDbHooks<DocClass, DBInterface>
+	collection: AsyncMongoCollection<DBInterface>,
+	options: SaveIntoDbHooks<DBInterface>
 ): Promise<Changes> {
 	const change: Changes = {
 		added: 0,
@@ -112,7 +112,7 @@ async function savePreparedChanges<DocClass extends DBInterface, DBInterface ext
 	}
 
 	const updates: BulkWriteOperation<DBInterface>[] = []
-	const removedDocs: DocClass['_id'][] = []
+	const removedDocs: DBInterface['_id'][] = []
 
 	_.each(preparedChanges.changed || [], (oUpdate) => {
 		checkInsertId(oUpdate._id)
@@ -172,11 +172,11 @@ async function savePreparedChanges<DocClass extends DBInterface, DBInterface ext
 	return change
 }
 
-export interface SaveIntoDbHooks<DocClass, DBInterface> {
+export interface SaveIntoDbHooks<DBInterface> {
 	beforeInsert?: (o: DBInterface) => DBInterface
-	beforeUpdate?: (o: DBInterface, pre?: DocClass) => DBInterface
-	beforeRemove?: (o: DocClass) => DBInterface
-	beforeDiff?: (o: DBInterface, oldObj: DocClass) => DBInterface
+	beforeUpdate?: (o: DBInterface, pre?: DBInterface) => DBInterface
+	beforeRemove?: (o: DBInterface) => DBInterface
+	beforeDiff?: (o: DBInterface, oldObj: DBInterface) => DBInterface
 	afterInsert?: (o: DBInterface) => void
 	afterUpdate?: (o: DBInterface) => void
 	afterRemove?: (o: DBInterface) => void
@@ -189,11 +189,11 @@ interface SaveIntoDbHandlers<DBInterface> {
 	remove: (o: DBInterface) => void
 	unchanged?: (o: DBInterface) => void
 }
-export function saveIntoBase<DocClass extends DBInterface, DBInterface extends DBObj>(
+export function saveIntoBase<DBInterface extends DBObj>(
 	collectionName: string,
-	oldDocs: DocClass[],
+	oldDocs: DBInterface[],
 	newData: Array<DBInterface>,
-	options: SaveIntoDbHooks<DocClass, DBInterface> & SaveIntoDbHandlers<DBInterface>
+	options: SaveIntoDbHooks<DBInterface> & SaveIntoDbHandlers<DBInterface>
 ): ChangedIds<DBInterface['_id']> {
 	const span = profiler.startSpan(`DBCache.saveIntoBase.${collectionName}`)
 

--- a/meteor/server/migration/deprecatedDataTypes/0_18_0.ts
+++ b/meteor/server/migration/deprecatedDataTypes/0_18_0.ts
@@ -20,4 +20,4 @@ export interface ShowStyle {
 	/** The name of the blueprint which is the post-process step to run on a segment after any part has changed */
 	postProcessBlueprint: string
 }
-export const ShowStyles = createMongoCollection<ShowStyle, ShowStyle>('showStyles')
+export const ShowStyles = createMongoCollection<ShowStyle>('showStyles')

--- a/meteor/server/publications/peripheralDevice.ts
+++ b/meteor/server/publications/peripheralDevice.ts
@@ -24,7 +24,11 @@ import {
 	PackageContainerOnPackage,
 	AccessorOnPackage,
 } from '@sofie-automation/blueprints-integration'
-import { DBRundownPlaylist, RundownPlaylists } from '../../lib/collections/RundownPlaylists'
+import {
+	DBRundownPlaylist,
+	RundownPlaylistCollectionUtil,
+	RundownPlaylists,
+} from '../../lib/collections/RundownPlaylists'
 import { DBRundown, Rundowns } from '../../lib/collections/Rundowns'
 import { clone, DBObj, literal, omit, protectString, unprotectObject, unprotectString } from '../../lib/lib'
 import deepExtend from 'deep-extend'
@@ -285,7 +289,8 @@ meteorCustomPublishArray(
 							  }).fetch()
 							: []
 
-						const selectPartInstances = activePlaylist?.getSelectedPartInstances()
+						const selectPartInstances =
+							activePlaylist && RundownPlaylistCollectionUtil.getSelectedPartInstances(activePlaylist)
 						context.nextPartInstance = selectPartInstances?.nextPartInstance
 						context.currentPartInstance = selectPartInstances?.currentPartInstance
 

--- a/meteor/server/security/lib/security.ts
+++ b/meteor/server/security/lib/security.ts
@@ -288,7 +288,7 @@ namespace AccessRules {
 		playlist: RundownPlaylist,
 		cred: ResolvedCredentials
 	): Access<RundownPlaylist> {
-		const studio = playlist.getStudioLight()
+		const studio = fetchStudioLight(playlist.studioId)
 		if (!studio) return noAccess(`Studio of playlist "${playlist._id}" not found`)
 		return { ...accessStudio(studio, cred), document: playlist }
 	}

--- a/meteor/server/security/lib/security.ts
+++ b/meteor/server/security/lib/security.ts
@@ -4,7 +4,7 @@ import { Settings } from '../../../lib/Settings'
 import { resolveCredentials, ResolvedCredentials, Credentials, isResolvedCredentials } from './credentials'
 import { allAccess, noAccess, combineAccess, Access } from './access'
 import { RundownPlaylist, RundownPlaylistId, RundownPlaylists } from '../../../lib/collections/RundownPlaylists'
-import { RundownId, Rundowns, Rundown } from '../../../lib/collections/Rundowns'
+import { RundownId, Rundowns, Rundown, RundownCollectionUtil } from '../../../lib/collections/Rundowns'
 import { StudioId } from '../../../lib/collections/Studios'
 import { isProtectedString } from '../../../lib/lib'
 import { OrganizationId, Organizations, Organization } from '../../../lib/collections/Organization'
@@ -293,7 +293,7 @@ namespace AccessRules {
 		return { ...accessStudio(studio, cred), document: playlist }
 	}
 	export function accessRundown(rundown: Rundown, cred: ResolvedCredentials): Access<Rundown> {
-		const playlist = rundown.getRundownPlaylist()
+		const playlist = RundownCollectionUtil.getRundownPlaylist(rundown)
 		if (!playlist) return noAccess(`Rundown playlist of rundown "${rundown._id}" not found`)
 		return { ...accessRundownPlaylist(playlist, cred), document: rundown }
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

performance/code quality

* **What is the current behavior?** (You can also link to an open issue here)

Some collection documents are transformed into classes instead of interfaces when being loaded from the db.
This results in an iteration over every propery on the documents, and some copying, and so will be a small performance penalty.

* **What is the new behavior (if this is a feature change)?**

Instead of this, we should move the methods off the classes and feed them the interface form as a parameter.
The classes can then be removed, as they serve no purpose. 

* **Other information**:

This has been split into many many commits, to aid in reviewing. It might be best to not squash when merging to keep this readability instead of a large touching everything commit

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
