### PR TITLE
docs: add links for the Sofie Rundown Editor

### DIFF
--- a/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/rundown-editor.md
+++ b/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/rundown-editor.md
@@ -1,0 +1,7 @@
+# Sofie Rundown Editor
+
+Sofie Rundown Editor is a tool for creating and editing rundowns in a _demo_ environment of Sofie.
+
+### Installing Sofie Rundown Editor
+
+Check the installation instructions on the [project repository](https://github.com/SuperFlyTV/sofie-automation-rundown-editor).

--- a/packages/documentation/docs/getting-started/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/getting-started/installation/installing-sofie-server-core.md
@@ -21,22 +21,23 @@ Then open a terminal, `cd your-sofie-folder` and `sudo docker-compose up` \(just
 
 Once the installation is done, Sofie should be running on [http://localhost:3000](http://localhost:3000)
 
-Next, you will need to install a Rundown Gateway. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/) to see which _Rundown Gateway_ is best suited for ~~_your_~~ production environment. 
+Next, you will need to install a Rundown Gateway. Visit [Rundowns & Newsroom Systems](installing-a-gateway/rundown-or-newsroom-system-connection/) to see which _Rundown Gateway_ is best suited for ~~_your_~~ production environment.
+
+To get a demo rundown up and running quickly, check out the [Sofie Rundown Editor](installing-a-gateway/rundown-or-newsroom-system-connection/rundown-editor.md).
 
 ### Tips for running in production
 
 There are some things not covered in this guide needed to run Sofie in a production environment:
 
-* Logging: Collect, store and track error messages. [Kibana ](https://www.elastic.co/kibana)and [logstash](https://www.elastic.co/logstash) is one way to do it.
-* NGINX: It is customary to put a load-balancer in front of Sofie-Core.
-* Memory and CPU usage monitoring.
+- Logging: Collect, store and track error messages. [Kibana ](https://www.elastic.co/kibana)and [logstash](https://www.elastic.co/logstash) is one way to do it.
+- NGINX: It is customary to put a load-balancer in front of Sofie-Core.
+- Memory and CPU usage monitoring.
 
 ## Installing for Development
 
-Installation instructions for installing Sofie-Core or the various gateways are available in the README-file in their respective github-repos. 
+Installation instructions for installing Sofie-Core or the various gateways are available in the README-file in their respective github-repos.
 
 Common prerequisites are [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/).  
 Links to the repos are listed at [Applications & Libraries](../../for-developers/libraries.md).
 
 [Sofie Core GitHub Page for Developers](https://github.com/nrkno/tv-automation-server-core)
-


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update

* **What is the current behavior?** (You can also link to an open issue here)

Sofie Rundown Editor is not mentioned in the docs.

* **What is the new behavior (if this is a feature change)?**

This PR adds basic links to the Rundown Editor repo and suggests using the Rundown Editor for demo deployments of Sofie.

* **Other information**:

There's some unrelated changes in `installing-sofie-server-core.md` which were caused by the auto formatter.