### PR TITLE
docs: rename spreadsheet-blueprints to demo-blueprints

### DIFF
--- a/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
+++ b/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
@@ -4,15 +4,15 @@ The Spreadsheet Gateway is an application for piping data between Sofie Core and
 
 ### Example Blueprints for Spreadsheet Gateway
 
-To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Core_. Download the ZIP file containing the three files you need from the [Spreadsheet Gateway's GitHub Repository](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases). It is recommended to choose the newest release but, an older _Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions. 
+To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Core_. Download the `bundle.json` file containing the blueprints you need from the [Demo Blueprints GitHub Repository](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases). It is recommended to choose the newest release but, an older _Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions.
 
-Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints.md) section from earlier. 
+Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints.md) section from earlier.
 
 ### Spreadsheet Gateway Configuration
 
-If you are using the Docker version of Sofie, then the Spreadsheet Gateway will come preinstalled. For those who are not, please follow the [instructions listed on the GitHub page](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet) labeled _Installation \(for developers\)._
+If you are using the Docker version of Sofie, then the Spreadsheet Gateway will come preinstalled. For those who are not, please follow the [instructions listed on the GitHub page](https://github.com/SuperFlyTV/spreadsheet-gateway) labeled _Installation \(for developers\)._
 
-Once the Gateway has been installed, you can navigate to the _Settings page_ and check the newly added Gateway is listed as _Spreadsheet Gateway_ under the _Devices section_. 
+Once the Gateway has been installed, you can navigate to the _Settings page_ and check the newly added Gateway is listed as _Spreadsheet Gateway_ under the _Devices section_.
 
 Before you select the Device, you want to add it to the current _Studio_ you are using. Select your current Studio from the menu and navigate to the _Attached Devices_ option. Click the _+_ icon and select the Spreadsheet Gateway.
 
@@ -28,7 +28,7 @@ Now follow the steps in **Create credentials** and make sure to create an **OAut
 
 ![](/gitbook/assets/screenshot-2021-05-07-155351.png)
 
-Use the button to download the configuration to a file and navigate back to _Sofie Core's Settings page_. Select the Spreadsheet Gateway, then click the _Browse_ button and upload the configuration file you just downloaded. A new link will appear to confirm access to your google drive account. Select the link and in the new window, select the Google account you would like to use. Currently, the Sofie Core Application is not verified with Google so you will need to acknowledge this and proceed passed the unverified page. Click the _Advanced_ button and then click _Go to QuickStart \( Unsafe \)_. 
+Use the button to download the configuration to a file and navigate back to _Sofie Core's Settings page_. Select the Spreadsheet Gateway, then click the _Browse_ button and upload the configuration file you just downloaded. A new link will appear to confirm access to your google drive account. Select the link and in the new window, select the Google account you would like to use. Currently, the Sofie Core Application is not verified with Google so you will need to acknowledge this and proceed passed the unverified page. Click the _Advanced_ button and then click _Go to QuickStart \( Unsafe \)_.
 
 After navigating through the prompts you are presented with your verification code. Copy this code into the input field on the _Settings page_ and the field should be removed. A message confirming the access token was saved will appear.
 
@@ -36,12 +36,11 @@ You can now navigate to your Google Drive account and create a new folder for yo
 
 The indicator should now read _Good, Watching folder 'Folder Name Here'_. Now you just need an example rundown.[ Navigate to this Google Sheets file](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) and select the _File_ menu and then select _Make a copy_. In the popup window, select _My Drive_ and then navigate to and select the rundowns folder you created earlier.
 
-At this point, one of two things will happen. If you have the Google Sheets API enabled, this is different from the Google Drive API you enabled earlier, then the Rundown you just copied will appear in the Rundown page and is accessible. The other outcome is the Spreadsheet Gateway status reads _Unknown, Initializing..._ which most likely means you need to enable the Google Sheets API. Navigate to the[ Google Sheets API Dashboard with this link](https://console.developers.google.com/apis/library/sheets.googleapis.com?) and click the _Enable_ button. Navigate back to _Sofie's Settings page_ and restart the Spreadsheet Gateway. The status should now read, _Good, Watching folder 'Folder Name Here'_ and the rundown will appear in the _Rundown page_. 
+At this point, one of two things will happen. If you have the Google Sheets API enabled, this is different from the Google Drive API you enabled earlier, then the Rundown you just copied will appear in the Rundown page and is accessible. The other outcome is the Spreadsheet Gateway status reads _Unknown, Initializing..._ which most likely means you need to enable the Google Sheets API. Navigate to the[ Google Sheets API Dashboard with this link](https://console.developers.google.com/apis/library/sheets.googleapis.com?) and click the _Enable_ button. Navigate back to _Sofie's Settings page_ and restart the Spreadsheet Gateway. The status should now read, _Good, Watching folder 'Folder Name Here'_ and the rundown will appear in the _Rundown page_.
 
 ### Further Reading
 
-* [Spreadsheet Gateway's ](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases)[Repository](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases)[ ](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases)on GitHub's website.
-* [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
-* [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
-* [Spreadsheet Gateway](https://github.com/SuperFlyTV/spreadsheet-gateway) GitHub Page for Developers
-
+- [Demo Blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints/) GitHub Page for Developers
+- [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
+- [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
+- [Spreadsheet Gateway](https://github.com/SuperFlyTV/spreadsheet-gateway) GitHub Page for Developers

--- a/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
+++ b/packages/documentation/docs/getting-started/installation/installing-a-gateway/rundown-or-newsroom-system-connection/installing-sofie-with-google-spreadsheet-support.md
@@ -4,7 +4,7 @@ The Spreadsheet Gateway is an application for piping data between Sofie Core and
 
 ### Example Blueprints for Spreadsheet Gateway
 
-To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Core_. Download the `bundle.json` file containing the blueprints you need from the [Demo Blueprints GitHub Repository](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases). It is recommended to choose the newest release but, an older _Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions.
+To begin with, you will need to install a set of Blueprints that can handle the data being sent from the _Gateway_ to _Core_. Download the `demo-blueprints-r*.zip` file containing the blueprints you need from the [Demo Blueprints GitHub Repository](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases). It is recommended to choose the newest release but, an older _Core_ version may require a different Blueprint version. The _Rundown page_ will warn you about any issue and display the desired versions.
 
 Instructions on how to install any Blueprint can be found in the [Installing Blueprints](../../installing-blueprints.md) section from earlier.
 

--- a/packages/documentation/docs/getting-started/installation/installing-blueprints.md
+++ b/packages/documentation/docs/getting-started/installation/installing-blueprints.md
@@ -2,12 +2,12 @@
 
 #### Prerequisites
 
-* [Installed and running Sofie Core](installing-sofie-server-core.md)
-* [Initial Sofie Core Setup](initial-sofie-core-setup.md)
+- [Installed and running Sofie Core](installing-sofie-server-core.md)
+- [Initial Sofie Core Setup](initial-sofie-core-setup.md)
 
 Blueprints are little plug-in programs that runs inside _Sofie_. They are the logic that determines how _Sofie_ interacts with rundowns, hardware, and media.
 
-Blueprints are custom scripts that you create yourself \(or download an existing one\). There are a set of example Blueprints for the Spreadsheet Gateway available for use here: [https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet).
+Blueprints are custom scripts that you create yourself \(or download an existing one\). There are a set of example Blueprints for the Spreadsheet Gateway available for use here: [https://github.com/SuperFlyTV/sofie-demo-blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints).
 
 To begin installing any Blueprint, navigate to the _Settings page_. Getting there is covered in the [Sofie Access Levels](../../features-and-configuration/sofie-navigation.md) page.
 
@@ -39,5 +39,4 @@ After you've uploaded the your show-style-blueprint js-file, navigate to a Show 
 
 ### Further Reading
 
-* [Blueprints Supporting the Spreadsheet Gateway](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet)
-
+- [Blueprints Supporting the Spreadsheet Gateway](https://github.com/SuperFlyTV/sofie-demo-blueprints)

--- a/packages/documentation/docs/main/features-and-configuration/concepts-and-architecture.md
+++ b/packages/documentation/docs/main/features-and-configuration/concepts-and-architecture.md
@@ -15,17 +15,16 @@ Read more: [_System architecture_](concepts-and-architecture.md#system-architect
 Gateways are applications that connect to Sofie Core and and exchanges data; such as rundown-data from an NRCS or the [Timeline ](../dictionary.md#timeline)for play-out.
 
 Examples of Gateways are the [MOS Gateway](https://github.com/nrkno/tv-automation-mos-gateway), the [Spreadsheet Gateway](https://github.com/SuperFlyTV/spreadsheet-gateway) and the [Playout Gateway](https://github.com/nrkno/tv-automation-playout-gateway).  
-All gateways use the [Core-integration library](https://github.com/nrkno/tv-automation-server-core-integration) to communicate with Core.  
-
+All gateways use the [Core-integration library](https://github.com/nrkno/tv-automation-server-core-integration) to communicate with Core.
 
 ## System, \(Organization\), Studio & Show Style
 
 To be able to facilitate various work-flows and to Here's a short explanation about the differences between the "System", "Organization", "Studio" and "Show Style".
 
-* The **System** defines the whole of the Sofie Core
-* The **Organization** \(only available if user accounts are enabled\) defines things that are common for an organization. An organization consists of: **Users, Studios** and **ShowStyles**.
-* The **Studio** contains things that are related to the "hardware" or "rig". Technically, a Studio is defined as an entity that can have one \(or none\) rundown active at any given time. In most cases, this will be a representation of your gallery, with cameras, video playback and graphics systems, external inputs, sound mixers, lighting controls and so on. A single System can easily control multiple Studios.
-* The **Show Style** contains settings for the "show", for example if there's a "Morning Show" and an "Afternoon Show" - produced in the same gallery - they might be two different Show Styles \(played in the same Studio\).
+- The **System** defines the whole of the Sofie Core
+- The **Organization** \(only available if user accounts are enabled\) defines things that are common for an organization. An organization consists of: **Users, Studios** and **ShowStyles**.
+- The **Studio** contains things that are related to the "hardware" or "rig". Technically, a Studio is defined as an entity that can have one \(or none\) rundown active at any given time. In most cases, this will be a representation of your gallery, with cameras, video playback and graphics systems, external inputs, sound mixers, lighting controls and so on. A single System can easily control multiple Studios.
+- The **Show Style** contains settings for the "show", for example if there's a "Morning Show" and an "Afternoon Show" - produced in the same gallery - they might be two different Show Styles \(played in the same Studio\).
 
 ![](/gitbook/assets/frame-9-2-.png)
 
@@ -85,7 +84,7 @@ An AdLib isn't added to the Part in the GUI until it starts playing, instead you
 
 Blueprints are plug-ins that run in Sofie Core. They interpret the data coming in from the rundowns and transform them into a rich set of playable elements \(Segments, Parts, AdLibs etc\).
 
-The blueprints are webpacked javascript bundles which are uploaded into Sofie via the GUI. They are custom-made and changes depending on the show style, type of input data \(NRCS\) and the types of controlled devices. A generic [blueprint based on spreadsheets is available here](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet).
+The blueprints are webpacked javascript bundles which are uploaded into Sofie via the GUI. They are custom-made and changes depending on the show style, type of input data \(NRCS\) and the types of controlled devices. A generic [blueprint that works with spreadsheets is available here](https://github.com/SuperFlyTV/sofie-demo-blueprints).
 
 When [Sofie Core](../dictionary.md#sofie-core) calls upon a Blueprint, it returns a JavaScript object containing methods callable by Sofie Core. These methods will be called by Sofie Core in different situations, depending on the method.  
 Documentation on these interfaces are available in the [Blueprints integration](https://www.npmjs.com/package/tv-automation-sofie-blueprints-integration) library.
@@ -116,11 +115,11 @@ Documentation on the interface to be exposed by the Blueprint:
 
 The Timeline is a collection of timeline-objects, that together form a "target state", i.e. an intent on what is to be played and at what times.
 
-The timeline-objects can be programmed to contain relative references to each other, so programming things like _"play this thing right after this other thing"_  is as easy as `{start: { #otherThing.end }}` 
+The timeline-objects can be programmed to contain relative references to each other, so programming things like _"play this thing right after this other thing"_ is as easy as `{start: { #otherThing.end }}`
 
 The [Playout Gateway](../for-developers/libraries.md#gateways) picks up the timeline from Sofie Core and \(using the [timeline-state-resolver](https://github.com/nrkno/tv-automation-state-timeline-resolver)\) controls the play-out devices to make sure that they actually play what is intended.
 
-![Example of 2 objects in a timeline: The \#video object, destined to play at a certain time, and \#gfx0, destined to start 15 seconds into the video.](/gitbook/assets/timeline.png)
+![Example of 2 objects in a timeline: The #video object, destined to play at a certain time, and #gfx0, destined to start 15 seconds into the video.](/gitbook/assets/timeline.png)
 
 ### Why a timeline?
 
@@ -145,22 +144,22 @@ The Timeline is stored by Sofie Core in a MongoDB collection. It is generated wh
 
 [Sofie Core](../dictionary.md#sofie-core) generates the timeline using:
 
-* The [Studio Baseline](../dictionary.md#baseline) \(only if no rundown is currently active\)
-* The [Showstyle Baseline](../dictionary.md#baseline), of the currently active rundown.
-* The [currently playing Part](../dictionary.md#take-point)
-* The [Next:ed Part](../dictionary.md#next-point-and-lookahead) and Parts that come after it \(the [Lookahead](../dictionary.md#lookahead)\)
-* Any [AdLibs ](../dictionary.md#adlib-pieces)the user has manually selected to play
+- The [Studio Baseline](../dictionary.md#baseline) \(only if no rundown is currently active\)
+- The [Showstyle Baseline](../dictionary.md#baseline), of the currently active rundown.
+- The [currently playing Part](../dictionary.md#take-point)
+- The [Next:ed Part](../dictionary.md#next-point-and-lookahead) and Parts that come after it \(the [Lookahead](../dictionary.md#lookahead)\)
+- Any [AdLibs ](../dictionary.md#adlib-pieces)the user has manually selected to play
 
 The [**Playout Gateway**](../for-developers/libraries.md#gateways) then picks up the new timeline, and pipes it into the [timeline-state-resolver](https://github.com/nrkno/tv-automation-state-timeline-resolver)-library \(TSR\).
 
 The TSR then...
 
-* Resolves the timeline, using the [timeline-library](https://github.com/SuperFlyTV/supertimeline)
-* Calculates new target-states for each relevant point in time
-* Maps the target-state to each play-out device.
-* Compares the target-states for each device with the currently-tracked-state and..
-* ..generates commands to send to each device to account for the change.
-* The commands are then put on queue and sent to the devices at the correct time.
+- Resolves the timeline, using the [timeline-library](https://github.com/SuperFlyTV/supertimeline)
+- Calculates new target-states for each relevant point in time
+- Maps the target-state to each play-out device.
+- Compares the target-states for each device with the currently-tracked-state and..
+- ..generates commands to send to each device to account for the change.
+- The commands are then put on queue and sent to the devices at the correct time.
 
 {% hint style="info" %}
 For more information about what play-out devices the TSR supports, and examples of the timeline-objects, see the [README of TSR](https://github.com/nrkno/tv-automation-state-timeline-resolver#timeline-state-resolver)
@@ -169,4 +168,3 @@ For more information about what play-out devices the TSR supports, and examples 
 {% hint style="info" %}
 For more information about how to program timeline-objects, see the [README of the timeline-library](https://github.com/SuperFlyTV/supertimeline#superfly-timeline)
 {% endhint %}
-

--- a/packages/documentation/docs/main/resources.md
+++ b/packages/documentation/docs/main/resources.md
@@ -6,59 +6,56 @@ description: This guide has a lot of links. Here they are all listed by section.
 
 ## Getting Started
 
-* [Sofie Core Layout](getting-started/#sofie-core-layout)
-* [Sofie Core Overview](getting-started/#sofie-core-overview)
+- [Sofie Core Layout](getting-started/#sofie-core-layout)
+- [Sofie Core Overview](getting-started/#sofie-core-overview)
 
-  * [Gateways](getting-started/#gateways)
-  * [Blueprints](getting-started/#blueprints)
+  - [Gateways](getting-started/#gateways)
+  - [Blueprints](getting-started/#blueprints)
 
-* Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI) 
+- Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI)
 
 ## Installation & Setup
 
 ### Installing Sofie Core
 
-* [Windows install for Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
-* [Linux install instructions for Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-* [Linux install instructions for Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-18-04)
-* [Sofie Core Docker File Download](https://firebasestorage.googleapis.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LWRCgfY_-kYo9iX6UNy%2F-Lo5eWjgoVlRRDeFzLuO%2F-Lo5fLSSyM1eO6OXScew%2Fdocker-compose.yaml?alt=media&token=fc2fbe79-365c-4817-b270-e507c6a6e3c6)
+- [Windows install for Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
+- [Linux install instructions for Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+- [Linux install instructions for Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-18-04)
+- [Sofie Core Docker File Download](https://firebasestorage.googleapis.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LWRCgfY_-kYo9iX6UNy%2F-Lo5eWjgoVlRRDeFzLuO%2F-Lo5fLSSyM1eO6OXScew%2Fdocker-compose.yaml?alt=media&token=fc2fbe79-365c-4817-b270-e507c6a6e3c6)
 
 ### Installing a Gateway
 
 #### Ingest gateways and NRCS
 
-* [MOS Protocol Overview & Documentation](http://mosprotocol.com/)
-* Information about ENPS on [The Associated Press' Website](https://www.ap.org/enps/support)
-* Information about iNews: [Avid's Website](https://www.avid.com/products/inews/how-to-buy)
+- [MOS Protocol Overview & Documentation](http://mosprotocol.com/)
+- Information about ENPS on [The Associated Press' Website](https://www.ap.org/enps/support)
+- Information about iNews: [Avid's Website](https://www.avid.com/products/inews/how-to-buy)
 
 **Google Spreadsheet Gateway**
 
-* [Demo Spreadsheet Blueprints](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases) on GitHub's website.
-* [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
-* [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
+- [Demo Blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases) on GitHub's website.
+- [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
+- [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
 
 ### Additional Software & Hardware
 
 #### Installing CasparCG Server for Sofie
 
-* NRK's version of [CasparCG Server](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
-* [Media Scanner ](https://github.com/nrkno/tv-automation-casparcg-launcher/releases)on GitHub.
-* [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
-* [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
-* [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md#decklink-cards) section for compatibility.
-* [Installing a  Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
-* [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
-* [CasparCG Configuration Validator](https://casparcg.net/validator/)
+- NRK's version of [CasparCG Server](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
+- [Media Scanner ](https://github.com/nrkno/tv-automation-casparcg-launcher/releases)on GitHub.
+- [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
+- [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
+- [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md#decklink-cards) section for compatibility.
+- [Installing a Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
+- [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
+- [CasparCG Configuration Validator](https://casparcg.net/validator/)
 
 **Additional resources**
 
-* Viz graphics through MSE, info on [Vizrt's](https://www.vizrt.com/) website.
-* Information about [Blackmagic's Hyperdeck](https://www.blackmagicdesign.com/products/hyperdeckstudio)
+- Viz graphics through MSE, info on [Vizrt's](https://www.vizrt.com/) website.
+- Information about [Blackmagic's Hyperdeck](https://www.blackmagicdesign.com/products/hyperdeckstudio)
 
 ## FAQ, Progress, and Issues
 
-* [MIT Licence](https://opensource.org/licenses/MIT)
-* [Road map and Issues page on GitHub](https://github.com/nrkno/Sofie-TV-automation/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3ARelease)
-
-
-
+- [MIT Licence](https://opensource.org/licenses/MIT)
+- [Road map and Issues page on GitHub](https://github.com/nrkno/Sofie-TV-automation/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3ARelease)

--- a/packages/documentation/versioned_docs/version-1.32.0/getting-started/installation/installing-blueprints.md
+++ b/packages/documentation/versioned_docs/version-1.32.0/getting-started/installation/installing-blueprints.md
@@ -2,12 +2,12 @@
 
 #### Prerequisites
 
-* [Installed and running Sofie Core](installing-sofie-server-core.md)
-* [Initial Sofie Core Setup](initial-sofie-core-setup.md)
+- [Installed and running Sofie Core](installing-sofie-server-core.md)
+- [Initial Sofie Core Setup](initial-sofie-core-setup.md)
 
 Blueprints are little plug-in programs that runs inside _Sofie_. They are the logic that determines how _Sofie_ interacts with rundowns, hardware, and media.
 
-Blueprints are custom scripts that you create yourself \(or download an existing one\). There are a set of example Blueprints for the Spreadsheet Gateway available for use here: [https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet).
+Blueprints are custom scripts that you create yourself \(or download an existing one\). There are a set of example Blueprints for the [Spreadsheet Gateway](https://github.com/SuperFlyTV/spreadsheet-gateway) or [Rundown Editor](https://github.com/SuperFlyTV/sofie-automation-rundown-editor) available for use here: [https://github.com/SuperFlyTV/sofie-demo-blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints).
 
 To begin installing any Blueprint, navigate to the _Settings page_. Getting there is covered in the [Sofie Access Levels](../../features-and-configuration/sofie-navigation.md) page.
 
@@ -39,5 +39,4 @@ After you've uploaded the your show-style-blueprint js-file, navigate to a Show 
 
 ### Further Reading
 
-* [Blueprints Supporting the Spreadsheet Gateway](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet)
-
+- [Blueprints Supporting the Spreadsheet Gateway and Rundown Editor](https://github.com/SuperFlyTV/sofie-demo-blueprints)

--- a/packages/documentation/versioned_docs/version-1.32.0/main/features-and-configuration/concepts-and-architecture.md
+++ b/packages/documentation/versioned_docs/version-1.32.0/main/features-and-configuration/concepts-and-architecture.md
@@ -15,17 +15,16 @@ Read more: [_System architecture_](concepts-and-architecture.md#system-architect
 Gateways are applications that connect to Sofie Core and and exchanges data; such as rundown-data from an NRCS or the [Timeline ](../dictionary.md#timeline)for play-out.
 
 Examples of Gateways are the [MOS Gateway](https://github.com/nrkno/tv-automation-mos-gateway), the [Spreadsheet Gateway](https://github.com/SuperFlyTV/spreadsheet-gateway) and the [Playout Gateway](https://github.com/nrkno/tv-automation-playout-gateway).  
-All gateways use the [Core-integration library](https://github.com/nrkno/tv-automation-server-core-integration) to communicate with Core.  
-
+All gateways use the [Core-integration library](https://github.com/nrkno/tv-automation-server-core-integration) to communicate with Core.
 
 ## System, \(Organization\), Studio & Show Style
 
 To be able to facilitate various work-flows and to Here's a short explanation about the differences between the "System", "Organization", "Studio" and "Show Style".
 
-* The **System** defines the whole of the Sofie Core
-* The **Organization** \(only available if user accounts are enabled\) defines things that are common for an organization. An organization consists of: **Users, Studios** and **ShowStyles**.
-* The **Studio** contains things that are related to the "hardware" or "rig". Technically, a Studio is defined as an entity that can have one \(or none\) rundown active at any given time. In most cases, this will be a representation of your gallery, with cameras, video playback and graphics systems, external inputs, sound mixers, lighting controls and so on. A single System can easily control multiple Studios.
-* The **Show Style** contains settings for the "show", for example if there's a "Morning Show" and an "Afternoon Show" - produced in the same gallery - they might be two different Show Styles \(played in the same Studio\).
+- The **System** defines the whole of the Sofie Core
+- The **Organization** \(only available if user accounts are enabled\) defines things that are common for an organization. An organization consists of: **Users, Studios** and **ShowStyles**.
+- The **Studio** contains things that are related to the "hardware" or "rig". Technically, a Studio is defined as an entity that can have one \(or none\) rundown active at any given time. In most cases, this will be a representation of your gallery, with cameras, video playback and graphics systems, external inputs, sound mixers, lighting controls and so on. A single System can easily control multiple Studios.
+- The **Show Style** contains settings for the "show", for example if there's a "Morning Show" and an "Afternoon Show" - produced in the same gallery - they might be two different Show Styles \(played in the same Studio\).
 
 ![](/gitbook/assets/frame-9-2-.png)
 
@@ -85,7 +84,7 @@ An AdLib isn't added to the Part in the GUI until it starts playing, instead you
 
 Blueprints are plug-ins that run in Sofie Core. They interpret the data coming in from the rundowns and transform them into a rich set of playable elements \(Segments, Parts, AdLibs etc\).
 
-The blueprints are webpacked javascript bundles which are uploaded into Sofie via the GUI. They are custom-made and changes depending on the show style, type of input data \(NRCS\) and the types of controlled devices. A generic [blueprint based on spreadsheets is available here](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet).
+The blueprints are webpacked javascript bundles which are uploaded into Sofie via the GUI. They are custom-made and changes depending on the show style, type of input data \(NRCS\) and the types of controlled devices. A generic [blueprint that works with spreadsheets is available here](https://github.com/SuperFlyTV/sofie-demo-blueprints).
 
 When [Sofie Core](../dictionary.md#sofie-core) calls upon a Blueprint, it returns a JavaScript object containing methods callable by Sofie Core. These methods will be called by Sofie Core in different situations, depending on the method.  
 Documentation on these interfaces are available in the [Blueprints integration](https://www.npmjs.com/package/tv-automation-sofie-blueprints-integration) library.
@@ -116,11 +115,11 @@ Documentation on the interface to be exposed by the Blueprint:
 
 The Timeline is a collection of timeline-objects, that together form a "target state", i.e. an intent on what is to be played and at what times.
 
-The timeline-objects can be programmed to contain relative references to each other, so programming things like _"play this thing right after this other thing"_  is as easy as `{start: { #otherThing.end }}` 
+The timeline-objects can be programmed to contain relative references to each other, so programming things like _"play this thing right after this other thing"_ is as easy as `{start: { #otherThing.end }}`
 
 The [Playout Gateway](../for-developers/libraries.md#gateways) picks up the timeline from Sofie Core and \(using the [timeline-state-resolver](https://github.com/nrkno/tv-automation-state-timeline-resolver)\) controls the play-out devices to make sure that they actually play what is intended.
 
-![Example of 2 objects in a timeline: The \#video object, destined to play at a certain time, and \#gfx0, destined to start 15 seconds into the video.](/gitbook/assets/timeline.png)
+![Example of 2 objects in a timeline: The #video object, destined to play at a certain time, and #gfx0, destined to start 15 seconds into the video.](/gitbook/assets/timeline.png)
 
 ### Why a timeline?
 
@@ -145,22 +144,22 @@ The Timeline is stored by Sofie Core in a MongoDB collection. It is generated wh
 
 [Sofie Core](../dictionary.md#sofie-core) generates the timeline using:
 
-* The [Studio Baseline](../dictionary.md#baseline) \(only if no rundown is currently active\)
-* The [Showstyle Baseline](../dictionary.md#baseline), of the currently active rundown.
-* The [currently playing Part](../dictionary.md#take-point)
-* The [Next:ed Part](../dictionary.md#next-point-and-lookahead) and Parts that come after it \(the [Lookahead](../dictionary.md#lookahead)\)
-* Any [AdLibs ](../dictionary.md#adlib-pieces)the user has manually selected to play
+- The [Studio Baseline](../dictionary.md#baseline) \(only if no rundown is currently active\)
+- The [Showstyle Baseline](../dictionary.md#baseline), of the currently active rundown.
+- The [currently playing Part](../dictionary.md#take-point)
+- The [Next:ed Part](../dictionary.md#next-point-and-lookahead) and Parts that come after it \(the [Lookahead](../dictionary.md#lookahead)\)
+- Any [AdLibs ](../dictionary.md#adlib-pieces)the user has manually selected to play
 
 The [**Playout Gateway**](../for-developers/libraries.md#gateways) then picks up the new timeline, and pipes it into the [timeline-state-resolver](https://github.com/nrkno/tv-automation-state-timeline-resolver)-library \(TSR\).
 
 The TSR then...
 
-* Resolves the timeline, using the [timeline-library](https://github.com/SuperFlyTV/supertimeline)
-* Calculates new target-states for each relevant point in time
-* Maps the target-state to each play-out device.
-* Compares the target-states for each device with the currently-tracked-state and..
-* ..generates commands to send to each device to account for the change.
-* The commands are then put on queue and sent to the devices at the correct time.
+- Resolves the timeline, using the [timeline-library](https://github.com/SuperFlyTV/supertimeline)
+- Calculates new target-states for each relevant point in time
+- Maps the target-state to each play-out device.
+- Compares the target-states for each device with the currently-tracked-state and..
+- ..generates commands to send to each device to account for the change.
+- The commands are then put on queue and sent to the devices at the correct time.
 
 {% hint style="info" %}
 For more information about what play-out devices the TSR supports, and examples of the timeline-objects, see the [README of TSR](https://github.com/nrkno/tv-automation-state-timeline-resolver#timeline-state-resolver)
@@ -169,4 +168,3 @@ For more information about what play-out devices the TSR supports, and examples 
 {% hint style="info" %}
 For more information about how to program timeline-objects, see the [README of the timeline-library](https://github.com/SuperFlyTV/supertimeline#superfly-timeline)
 {% endhint %}
-

--- a/packages/documentation/versioned_docs/version-1.32.0/main/resources.md
+++ b/packages/documentation/versioned_docs/version-1.32.0/main/resources.md
@@ -6,59 +6,56 @@ description: This guide has a lot of links. Here they are all listed by section.
 
 ## Getting Started
 
-* [Sofie Core Layout](getting-started/#sofie-core-layout)
-* [Sofie Core Overview](getting-started/#sofie-core-overview)
+- [Sofie Core Layout](getting-started/#sofie-core-layout)
+- [Sofie Core Overview](getting-started/#sofie-core-overview)
 
-  * [Gateways](getting-started/#gateways)
-  * [Blueprints](getting-started/#blueprints)
+  - [Gateways](getting-started/#gateways)
+  - [Blueprints](getting-started/#blueprints)
 
-* Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI) 
+- Ask questions in the [Sofie Slack Channel](https://join.slack.com/t/sofietv/shared_invite/enQtNTk2Mzc3MTQ1NzAzLTJkZjMyMDg3OGM0YWU3MmU4YzBhZDAyZWI1YmJmNmRiYWQ1OTZjYTkzOTkzMTA2YTE1YjgxMmVkM2U1OGZlNWI)
 
 ## Installation & Setup
 
 ### Installing Sofie Core
 
-* [Windows install for Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
-* [Linux install instructions for Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-* [Linux install instructions for Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-18-04)
-* [Sofie Core Docker File Download](https://firebasestorage.googleapis.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LWRCgfY_-kYo9iX6UNy%2F-Lo5eWjgoVlRRDeFzLuO%2F-Lo5fLSSyM1eO6OXScew%2Fdocker-compose.yaml?alt=media&token=fc2fbe79-365c-4817-b270-e507c6a6e3c6)
+- [Windows install for Docker](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
+- [Linux install instructions for Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+- [Linux install instructions for Docker Compose](https://www.digitalocean.com/community/tutorials/how-to-install-docker-compose-on-ubuntu-18-04)
+- [Sofie Core Docker File Download](https://firebasestorage.googleapis.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LWRCgfY_-kYo9iX6UNy%2F-Lo5eWjgoVlRRDeFzLuO%2F-Lo5fLSSyM1eO6OXScew%2Fdocker-compose.yaml?alt=media&token=fc2fbe79-365c-4817-b270-e507c6a6e3c6)
 
 ### Installing a Gateway
 
 #### Ingest gateways and NRCS
 
-* [MOS Protocol Overview & Documentation](http://mosprotocol.com/)
-* Information about ENPS on [The Associated Press' Website](https://www.ap.org/enps/support)
-* Information about iNews: [Avid's Website](https://www.avid.com/products/inews/how-to-buy)
+- [MOS Protocol Overview & Documentation](http://mosprotocol.com/)
+- Information about ENPS on [The Associated Press' Website](https://www.ap.org/enps/support)
+- Information about iNews: [Avid's Website](https://www.avid.com/products/inews/how-to-buy)
 
 **Google Spreadsheet Gateway**
 
-* [Demo Spreadsheet Blueprints](https://github.com/SuperFlyTV/sofie-blueprints-spreadsheet/releases) on GitHub's website.
-* [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
-* [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
+- [Demo Blueprints](https://github.com/SuperFlyTV/sofie-demo-blueprints/releases) on GitHub's website.
+- [Example Rundown](https://docs.google.com/spreadsheets/d/1iyegRv5MxYYtlVu8uEEMkBYXsLL-71PAMrNW0ZfWRUw/edit?usp=sharing) provided by Sofie.
+- [Google Sheets API](https://console.developers.google.com/apis/library/sheets.googleapis.com?) on the Google Developer website.
 
 ### Additional Software & Hardware
 
 #### Installing CasparCG Server for Sofie
 
-* NRK's version of [CasparCG Server](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
-* [Media Scanner ](https://github.com/nrkno/tv-automation-casparcg-launcher/releases)on GitHub.
-* [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
-* [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
-* [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md#decklink-cards) section for compatibility.
-* [Installing a  Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
-* [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
-* [CasparCG Configuration Validator](https://casparcg.net/validator/)
+- NRK's version of [CasparCG Server](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
+- [Media Scanner ](https://github.com/nrkno/tv-automation-casparcg-launcher/releases)on GitHub.
+- [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
+- [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
+- [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md#decklink-cards) section for compatibility.
+- [Installing a Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
+- [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
+- [CasparCG Configuration Validator](https://casparcg.net/validator/)
 
 **Additional resources**
 
-* Viz graphics through MSE, info on [Vizrt's](https://www.vizrt.com/) website.
-* Information about [Blackmagic's Hyperdeck](https://www.blackmagicdesign.com/products/hyperdeckstudio)
+- Viz graphics through MSE, info on [Vizrt's](https://www.vizrt.com/) website.
+- Information about [Blackmagic's Hyperdeck](https://www.blackmagicdesign.com/products/hyperdeckstudio)
 
 ## FAQ, Progress, and Issues
 
-* [MIT Licence](https://opensource.org/licenses/MIT)
-* [Road map and Issues page on GitHub](https://github.com/nrkno/Sofie-TV-automation/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3ARelease)
-
-
-
+- [MIT Licence](https://opensource.org/licenses/MIT)
+- [Road map and Issues page on GitHub](https://github.com/nrkno/Sofie-TV-automation/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3ARelease)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update

* **What is the current behavior?** (You can also link to an open issue here)

The demo blueprints are mentioned as spreadsheet blueprints.

* **What is the new behavior (if this is a feature change)?**

The blueprints are now explicitly called demo blueprints instead of spreadsheet blueprints.

* **Other information**:

I also added a few more links to the [Rundown Editor](https://github.com/SuperFlyTV/sofie-automation-rundown-editor). There's also some unrelated style and formatting changes caused by the auto formatter.