### PR TITLE
feat: pass currentPartInstanceId into UserActions.take call

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -477,7 +477,9 @@ const RundownHeader = withTranslation()(
 						},
 					})
 				} else {
-					doUserAction(t, e, UserAction.TAKE, (e) => MeteorCall.userAction.take(e, this.props.playlist._id))
+					doUserAction(t, e, UserAction.TAKE, (e) =>
+						MeteorCall.userAction.take(e, this.props.playlist._id, this.props.playlist.currentPartInstanceId)
+					)
 				}
 			}
 		}
@@ -1891,7 +1893,10 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 						})
 						if (!err && take && this.props.playlist) {
 							const playlistId = this.props.playlist._id
-							doUserAction(t, e, UserAction.TAKE, (e) => MeteorCall.userAction.take(e, playlistId))
+							const currentPartInstanceId = this.props.playlist.currentPartInstanceId
+							doUserAction(t, e, UserAction.TAKE, (e) =>
+								MeteorCall.userAction.take(e, playlistId, currentPartInstanceId)
+							)
 						}
 					}
 				)

--- a/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
+++ b/meteor/client/ui/Shelf/AdLibRegionPanel.tsx
@@ -114,7 +114,9 @@ class AdLibRegionPanelInner extends MeteorReactComponent<
 	take = (e: any) => {
 		const { t } = this.props
 		if (this.props.studioMode) {
-			doUserAction(t, e, UserAction.TAKE, (e) => MeteorCall.userAction.take(e, this.props.playlist._id))
+			doUserAction(t, e, UserAction.TAKE, (e) =>
+				MeteorCall.userAction.take(e, this.props.playlist._id, this.props.playlist.currentPartInstanceId)
+			)
 		}
 	}
 

--- a/meteor/client/ui/Shelf/DashboardActionButtonGroup.tsx
+++ b/meteor/client/ui/Shelf/DashboardActionButtonGroup.tsx
@@ -22,7 +22,9 @@ export const DashboardActionButtonGroup = withTranslation()(
 		take = (e: any) => {
 			const { t } = this.props
 			if (this.props.studioMode) {
-				doUserAction(t, e, UserAction.TAKE, (e) => MeteorCall.userAction.take(e, this.props.playlist._id))
+				doUserAction(t, e, UserAction.TAKE, (e) =>
+					MeteorCall.userAction.take(e, this.props.playlist._id, this.props.playlist.currentPartInstanceId)
+				)
 			}
 		}
 

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -21,7 +21,11 @@ import { PeripheralDeviceId } from '../collections/PeripheralDevices'
 import { RundownBaselineAdLibActionId } from '../collections/RundownBaselineAdLibActions'
 
 export interface NewUserActionAPI extends MethodContext {
-	take(userEvent: string, rundownPlaylistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
+	take(
+		userEvent: string,
+		rundownPlaylistId: RundownPlaylistId,
+		fromPartInstanceId: PartInstanceId | null
+	): Promise<ClientAPI.ClientResponse<void>>
 	setNext(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,
@@ -96,20 +100,20 @@ export interface NewUserActionAPI extends MethodContext {
 		partInstanceId: PartInstanceId,
 		adLibPieceId: PieceId,
 		queue: boolean
-	)
+	): Promise<ClientAPI.ClientResponse<void>>
 	sourceLayerOnPartStop(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		sourceLayerIds: string[]
-	)
+	): Promise<ClientAPI.ClientResponse<void>>
 	baselineAdLibPieceStart(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		adlibPieceId: PieceId,
 		queue: boolean
-	)
+	): Promise<ClientAPI.ClientResponse<void>>
 	sourceLayerStickyPieceStart(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,
@@ -121,14 +125,14 @@ export interface NewUserActionAPI extends MethodContext {
 		showStyleVariantId: ShowStyleVariantId,
 		bucketId: BucketId,
 		ingestItem: IngestAdlib
-	)
+	): Promise<ClientAPI.ClientResponse<void>>
 	bucketAdlibStart(
 		_userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		bucketAdlibId: PieceId,
 		queue?: boolean
-	)
+	): Promise<ClientAPI.ClientResponse<void>>
 	activateHold(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -302,7 +302,7 @@ describe('test peripheralDevice general API methods', () => {
 			rundownPlaylistID,
 			false
 		)
-		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
+		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, null)
 
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -327,7 +327,7 @@ describe('test peripheralDevice general API methods', () => {
 			rundownPlaylistID,
 			false
 		)
-		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
+		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, null)
 
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -353,7 +353,7 @@ describe('test peripheralDevice general API methods', () => {
 			rundownPlaylistID,
 			false
 		)
-		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
+		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, null)
 
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -387,7 +387,7 @@ describe('test peripheralDevice general API methods', () => {
 			rundownPlaylistID,
 			false
 		)
-		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
+		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, null)
 
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)
@@ -421,7 +421,7 @@ describe('test peripheralDevice general API methods', () => {
 			rundownPlaylistID,
 			false
 		)
-		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID)
+		await ActualServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(rundownPlaylistID), rundownPlaylistID, null)
 
 		if (DEBUG) setLogLevel(LogLevel.DEBUG)
 		const playlist = RundownPlaylists.findOne(rundownPlaylistID)

--- a/meteor/server/api/__tests__/userActions/general.test.ts
+++ b/meteor/server/api/__tests__/userActions/general.test.ts
@@ -146,7 +146,9 @@ describe('User Actions - General', () => {
 
 		{
 			// Take the first Part:
-			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
+			expect(
+				Meteor.call(UserActionAPI.methods.take, 'e', playlistId0, getPlaylist0().currentPartInstanceId)
+			).toMatchObject({ success: 200 })
 
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
@@ -157,7 +159,9 @@ describe('User Actions - General', () => {
 
 		{
 			// Take the second Part:
-			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
+			expect(
+				Meteor.call(UserActionAPI.methods.take, 'e', playlistId0, getPlaylist0().currentPartInstanceId)
+			).toMatchObject({ success: 200 })
 
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
@@ -202,7 +206,9 @@ describe('User Actions - General', () => {
 
 		{
 			// Take the Nexted Part:
-			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
+			expect(
+				Meteor.call(UserActionAPI.methods.take, 'e', playlistId0, getPlaylist0().currentPartInstanceId)
+			).toMatchObject({ success: 200 })
 
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
@@ -213,7 +219,9 @@ describe('User Actions - General', () => {
 
 		{
 			// Take the last Part:
-			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
+			expect(
+				Meteor.call(UserActionAPI.methods.take, 'e', playlistId0, getPlaylist0().currentPartInstanceId)
+			).toMatchObject({ success: 200 })
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeFalsy()
@@ -249,7 +257,9 @@ describe('User Actions - General', () => {
 
 		{
 			// Take the nexted Part:
-			expect(Meteor.call(UserActionAPI.methods.take, 'e', playlistId0)).toMatchObject({ success: 200 })
+			expect(
+				Meteor.call(UserActionAPI.methods.take, 'e', playlistId0, getPlaylist0().currentPartInstanceId)
+			).toMatchObject({ success: 200 })
 
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()

--- a/meteor/server/api/ingest/__tests__/ingest.test.ts
+++ b/meteor/server/api/ingest/__tests__/ingest.test.ts
@@ -1406,7 +1406,11 @@ describe('Test ingest actions for rundowns and segments', () => {
 			resyncRundown()
 			expect(getRundown().orphaned).toBeUndefined()
 
-			await ServerPlayoutAPI.takeNextPart(PLAYLIST_ACCESS(playlist._id), playlist._id)
+			await ServerPlayoutAPI.takeNextPart(
+				PLAYLIST_ACCESS(playlist._id),
+				playlist._id,
+				playlist.currentPartInstanceId
+			)
 			const partInstance = PartInstances.find({ 'part._id': parts[0]._id }).fetch()
 			expect(partInstance).toHaveLength(1)
 			expect(getPlaylist().currentPartInstanceId).toEqual(partInstance[0]._id)
@@ -1543,7 +1547,11 @@ describe('Test ingest actions for rundowns and segments', () => {
 			expect(getPlaylist().currentPartInstanceId).toBeNull()
 
 			// Take the first part
-			await ServerPlayoutAPI.takeNextPart(PLAYLIST_ACCESS(playlist._id), playlist._id)
+			await ServerPlayoutAPI.takeNextPart(
+				PLAYLIST_ACCESS(playlist._id),
+				playlist._id,
+				playlist.currentPartInstanceId
+			)
 			expect(getPlaylist().currentPartInstanceId).not.toBeNull()
 
 			{

--- a/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
+++ b/meteor/server/api/ingest/mosDevice/__tests__/mosIngest.test.ts
@@ -1178,7 +1178,7 @@ describe('Test recieved mos ingest payloads', () => {
 		// activate and set on air
 		await MeteorCall.userAction.activate('', rundown.playlistId, true)
 		await MeteorCall.userAction.setNext('', rundown.playlistId, getPartId(rundown._id, 'ro1;s2;p1'))
-		await MeteorCall.userAction.take('', rundown.playlistId)
+		await MeteorCall.userAction.take('', rundown.playlistId, null)
 
 		const partInstances0 = rundown.getAllPartInstances()
 		const { segments: segments0, parts: parts0 } = rundown.getSegmentsAndPartsSync()
@@ -1209,7 +1209,7 @@ describe('Test recieved mos ingest payloads', () => {
 		// activate and set on air
 		await MeteorCall.userAction.activate('', rundown.playlistId, true)
 		await MeteorCall.userAction.setNext('', rundown.playlistId, getPartId(rundown._id, 'ro1;s2;p1'))
-		await MeteorCall.userAction.take('', rundown.playlistId)
+		await MeteorCall.userAction.take('', rundown.playlistId, null)
 
 		const partInstances0 = rundown.getAllPartInstances()
 		const { segments: segments0, parts: parts0 } = rundown.getSegmentsAndPartsSync()

--- a/meteor/server/api/playout/__tests__/playout-executeAction.test.ts
+++ b/meteor/server/api/playout/__tests__/playout-executeAction.test.ts
@@ -67,7 +67,7 @@ describe('Playout API', () => {
 			rundownId = rundownId0
 
 			await ServerPlayoutAPI.activateRundownPlaylist(DEFAULT_ACCESS(playlistId), playlistId, true)
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId), playlistId)
+			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId), playlistId, null)
 
 			const rundown = Rundowns.findOne(rundownId) as Rundown
 			expect(rundown).toBeTruthy()

--- a/meteor/server/api/playout/__tests__/playout.test.ts
+++ b/meteor/server/api/playout/__tests__/playout.test.ts
@@ -157,7 +157,11 @@ describe('Playout API', () => {
 
 		{
 			// Take the first Part:
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist0()), playlistId0)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist0()),
+				playlistId0,
+				getPlaylist0().currentPartInstanceId
+			)
 
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
@@ -303,7 +307,11 @@ describe('Playout API', () => {
 
 			{
 				// Take the first Part:
-				await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist0()), playlistId0)
+				await ServerPlayoutAPI.takeNextPart(
+					DEFAULT_ACCESS(getPlaylist0()),
+					playlistId0,
+					getPlaylist0().currentPartInstanceId
+				)
 
 				const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 				expect(currentPartInstance).toBeTruthy()
@@ -330,11 +338,19 @@ describe('Playout API', () => {
 
 			// Attempt to take the first Part of inactive playlist0, should throw
 			await expect(
-				ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist0()), playlistId0)
+				ServerPlayoutAPI.takeNextPart(
+					DEFAULT_ACCESS(getPlaylist0()),
+					playlistId0,
+					getPlaylist0().currentPartInstanceId
+				)
 			).rejects.toMatchToString(/is not active/gi)
 
 			// Take the first Part of active playlist1:
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			expect(
 				getAllPartInstances().filter(
@@ -352,7 +368,11 @@ describe('Playout API', () => {
 			await ServerPlayoutAPI.resetAndActivateRundownPlaylist(DEFAULT_ACCESS(getPlaylist1()), playlistId1, true)
 
 			// Take the first Part of active playlist1 again:
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// still should only contain a single taken instance, as rehearsal partInstances should be removed
 			expect(
@@ -371,10 +391,18 @@ describe('Playout API', () => {
 			await ServerPlayoutAPI.resetAndActivateRundownPlaylist(DEFAULT_ACCESS(getPlaylist1()), playlistId1, false)
 
 			// Take the first Part of active playlist1 once more:
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// Take the second Part of active playlist1 so that we have more pieceInstances to reset
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// should throw with 402 code, as resetting the rundown when active is forbidden, with default configuration
 			await expect(
@@ -392,7 +420,11 @@ describe('Playout API', () => {
 				)
 			).toHaveLength(2)
 
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// should contain one nonreset taken partInstance
 			expect(
@@ -410,7 +442,11 @@ describe('Playout API', () => {
 			).toHaveLength(3)
 
 			// take the second part
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// Setting as next a part that is previous
 
@@ -420,10 +456,18 @@ describe('Playout API', () => {
 				playlistId1,
 				getRundown1().getParts()[0]._id
 			)
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// take the second part to check if we reset all previous partInstances correctly
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// should contain two nonreset taken partInstances
 			expect(
@@ -448,7 +492,11 @@ describe('Playout API', () => {
 				)
 			).toHaveLength(3)
 
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// Setting as next a non-previous and non-current part:
 
@@ -458,7 +506,11 @@ describe('Playout API', () => {
 				playlistId1,
 				getRundown1().getParts()[0]._id
 			)
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist1()), playlistId1)
+			await ServerPlayoutAPI.takeNextPart(
+				DEFAULT_ACCESS(getPlaylist1()),
+				playlistId1,
+				getPlaylist1().currentPartInstanceId
+			)
 
 			// should contain two nonreset taken instance
 			expect(
@@ -542,7 +594,11 @@ describe('Playout API', () => {
 
 			{
 				// Take the first Part:
-				await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist0()), playlistId0)
+				await ServerPlayoutAPI.takeNextPart(
+					DEFAULT_ACCESS(getPlaylist0()),
+					playlistId0,
+					getPlaylist0().currentPartInstanceId
+				)
 
 				const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 				expect(currentPartInstance).toBeTruthy()
@@ -606,7 +662,11 @@ describe('Playout API', () => {
 				expect(currentPartInstance?.part.expectedDuration).toBeTruthy()
 				now += (currentPartInstance?.part.expectedDuration ?? 0) - 500
 				// try to take just before an autonext
-				const response = await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(getPlaylist0()), playlistId0)
+				const response = await ServerPlayoutAPI.takeNextPart(
+					DEFAULT_ACCESS(getPlaylist0()),
+					playlistId0,
+					getPlaylist0().currentPartInstanceId
+				)
 				expect(response).toBeTruthy()
 				expect((response as ClientAPI.ClientResponseError).message).toMatch(/cannot take shortly before/gi)
 				now = nowBuf

--- a/meteor/server/api/playout/__tests__/timeline.test.ts
+++ b/meteor/server/api/playout/__tests__/timeline.test.ts
@@ -74,7 +74,7 @@ describe('Timeline', () => {
 
 		{
 			// Take the first Part:
-			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId0), playlistId0)
+			await ServerPlayoutAPI.takeNextPart(DEFAULT_ACCESS(playlistId0), playlistId0, null)
 			const { currentPartInstance, nextPartInstance } = getPlaylist0().getSelectedPartInstances()
 			expect(currentPartInstance).toBeTruthy()
 			expect(nextPartInstance).toBeTruthy()

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -89,6 +89,11 @@ export async function take(
 		if (!playlist.nextPartInstanceId) {
 			return ClientAPI.responseError('No Next point found, please set a part as Next before doing a TAKE.')
 		}
+
+		if (playlist.currentPartInstanceId !== fromPartInstanceId) {
+			return ClientAPI.responseError('Ignoring take as playing part has changed since TAKE was requested.')
+		}
+
 		if (playlist.currentPartInstanceId) {
 			const currentPartInstance = await PartInstances.findOneAsync(playlist.currentPartInstanceId)
 			if (currentPartInstance && currentPartInstance.timings) {
@@ -113,7 +118,7 @@ export async function take(
 				)
 			}
 		}
-		return ServerPlayoutAPI.takeNextPart(access, playlist._id)
+		return ServerPlayoutAPI.takeNextPart(access, playlist._id, playlist.currentPartInstanceId)
 	})
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Users will sometimes press take multiple times close to each other when it looks like the first press did nothing.
If the second press is within 1s of the first it will be rejected.
If it is longer, then both takes will be performed

* **What is the new behavior (if this is a feature change)?**

When the user does a take, the currentPartInstanceId is passed to the backend. This avoids the double-take problem as the currentPartInstance will have changed when the second one attempts to be executed and so will fail

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
