### PR TITLE
fix: strict select of pieceinstances in timelineTriggerTime

### DIFF
--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1085,23 +1085,18 @@ export namespace ServerPlayoutAPI {
 						activePlaylist,
 						PlayoutLockFunctionPriority.CALLBACK_PLAYOUT,
 						async () => {
-							const rundownIDs = Rundowns.find({ playlistId }, { fields: { _id: 1 } }).map(
-								(r) => r._id
-							)
+							const rundownIDs = Rundowns.find({ playlistId }, { fields: { _id: 1 } }).map((r) => r._id)
 							const partInstanceIDs = [activePlaylist.currentPartInstanceId].filter(
 								(id): id is PartInstanceId => id !== null
 							)
 
 							// We only need the PieceInstances, so load just them
-							const pieceInstanceCache = await DbCacheWriteCollection.createFromDatabase(
-								PieceInstances,
-								{
-									rundownId: { $in: rundownIDs },
-									partInstanceId: {
-										$in: partInstanceIDs,
-									},
-								}
-							)
+							const pieceInstanceCache = await DbCacheWriteCollection.createFromDatabase(PieceInstances, {
+								rundownId: { $in: rundownIDs },
+								partInstanceId: {
+									$in: partInstanceIDs,
+								},
+							})
 
 							// Take ownership of the playlist in the db, so that we can mutate the timeline and piece instances
 							timelineTriggerTimeInner(studioCache, results, pieceInstanceCache, activePlaylist)

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1085,12 +1085,23 @@ export namespace ServerPlayoutAPI {
 						activePlaylist,
 						PlayoutLockFunctionPriority.CALLBACK_PLAYOUT,
 						async () => {
-							const rundownIDs = Rundowns.find({ playlistId }).map((r) => r._id)
+							const rundownIDs = Rundowns.find({ playlistId }, { fields: { _id: 1 } }).map(
+								(r) => r._id
+							)
+							const partInstanceIDs = [activePlaylist.currentPartInstanceId].filter(
+								(id): id is PartInstanceId => id !== null
+							)
 
 							// We only need the PieceInstances, so load just them
-							const pieceInstanceCache = await DbCacheWriteCollection.createFromDatabase(PieceInstances, {
-								rundownId: { $in: rundownIDs },
-							})
+							const pieceInstanceCache = await DbCacheWriteCollection.createFromDatabase(
+								PieceInstances,
+								{
+									rundownId: { $in: rundownIDs },
+									partInstanceId: {
+										$in: partInstanceIDs,
+									},
+								}
+							)
 
 							// Take ownership of the playlist in the db, so that we can mutate the timeline and piece instances
 							timelineTriggerTimeInner(studioCache, results, pieceInstanceCache, activePlaylist)


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Only load pieceInstances that we know we the timings may need to be updated for, ie ones that come from the current or next part. This reduces data transferred from the database and reduces the search space for when we use the cache.


* **What is the current behavior?** (You can also link to an open issue here)
All piece instances in the currently active playlist are loaded.



* **Other information**:
I think the current and next part covers all piece instances that could possibly have a 'now' time that will be updated but do please correct me if I'm wrong here.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
