### PR TITLE
feat: REST method for disabling subdevice

### DIFF
--- a/meteor/lib/api/deviceConfig.ts
+++ b/meteor/lib/api/deviceConfig.ts
@@ -11,7 +11,7 @@
  * describe some properties to be rendered inside this table
  *
  * IMPORTANT - any updates done to this file should also be changed in
- * @tv-automation/server-core-integration, such that the gateways can actually
+ * @sofie-automation/server-core-integration, such that the gateways can actually
  * implement it in the manifests.
  */
 
@@ -72,7 +72,10 @@ export interface ConfigManifestEnumEntry extends ConfigManifestEntryBase {
 export interface ConfigManifestEntryDefault extends ConfigManifestEntryBase {
 	type: Exclude<
 		ConfigManifestEntryType,
-		ConfigManifestEntryType.ENUM | ConfigManifestEntryType.INT | ConfigManifestEntryType.FLOAT
+		| ConfigManifestEntryType.ENUM
+		| ConfigManifestEntryType.INT
+		| ConfigManifestEntryType.FLOAT
+		| ConfigManifestEntryType.TABLE
 	>
 }
 export interface ConfigManifestIntEntry extends ConfigManifestEntryBase {
@@ -108,7 +111,9 @@ export interface TableConfigManifestEntry extends ConfigManifestEntryBase {
 	deviceTypesMapping?: any
 	/** The name of the the property used to decide the type of the entry */
 	typeField?: string
-	/** Only one type means that the type option will not be present */
+	/** Only one type means that the type option will not be present. When using this as a subDevice configuration object,
+	 * a property of type BOOLEAN and id `disable` has special meaning and can be operated on outside of the GUI
+	 */
 	config: { [type: string]: TableEntryConfigManifestEntry[] }
 }
 

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -219,6 +219,7 @@ export interface NewUserActionAPI extends MethodContext {
 	): Promise<ClientAPI.ClientResponse<void>>
 	restoreRundownOrder(userEvent: string, playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
 	disablePeripheralSubDevice(
+		userEvent: string,
 		peripheralDeviceId: PeripheralDeviceId,
 		subDeviceId: string,
 		disable: boolean

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -218,6 +218,11 @@ export interface NewUserActionAPI extends MethodContext {
 		rundownsIdsInPlaylistInOrder: RundownId[]
 	): Promise<ClientAPI.ClientResponse<void>>
 	restoreRundownOrder(userEvent: string, playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
+	disablePeripheralSubDevice(
+		peripheralDeviceId: PeripheralDeviceId,
+		subDeviceId: string,
+		disable: boolean
+	): Promise<ClientAPI.ClientResponse<void>>
 }
 
 export enum UserActionAPIMethods {
@@ -270,6 +275,9 @@ export enum UserActionAPIMethods {
 	'removeRundown' = 'userAction.removeRundown',
 	'resyncRundown' = 'userAction.resyncRundown',
 
+	'moveRundown' = 'userAction.moveRundown',
+	'restoreRundownOrder' = 'userAction.restoreRundownOrder',
+
 	'mediaRestartWorkflow' = 'userAction.mediamanager.restartWorkflow',
 	'mediaAbortWorkflow' = 'userAction.mediamanager.abortWorkflow',
 	'mediaRestartAllWorkflows' = 'userAction.mediamanager.restartAllWorkflows',
@@ -289,11 +297,9 @@ export enum UserActionAPIMethods {
 	'guiFocused' = 'userAction.focused',
 	'guiBlurred' = 'userAction.blurred',
 
-	'getTranslationBundle' = 'userAction.getTranslationBundle',
-
 	'switchRouteSet' = 'userAction.switchRouteSet',
-	'moveRundown' = 'userAction.moveRundown',
-	'restoreRundownOrder' = 'userAction.restoreRundownOrder',
+
+	'disablePeripheralSubDevice' = 'userAction.system.disablePeripheralSubDevice',
 }
 
 export interface ReloadRundownPlaylistResponse {

--- a/meteor/server/api/__tests__/userActions/system.test.ts
+++ b/meteor/server/api/__tests__/userActions/system.test.ts
@@ -1,0 +1,190 @@
+import { Meteor } from 'meteor/meteor'
+import { ConfigManifestEntryType } from '../../../../lib/api/deviceConfig'
+import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
+import { PeripheralDevice, PeripheralDevices } from '../../../../lib/collections/PeripheralDevices'
+import {
+	DefaultEnvironment,
+	setupDefaultStudioEnvironment,
+	setupMockPeripheralDevice,
+} from '../../../../__mocks__/helpers/database'
+import { testInFiber } from '../../../../__mocks__/helpers/jest'
+
+require('../../userActions') // include in order to create the Meteor methods needed
+
+namespace UserActionAPI {
+	// Using our own method definition, to catch external API changes
+	export enum methods {
+		'disablePeripheralSubDevice' = 'userAction.system.disablePeripheralSubDevice',
+	}
+}
+
+describe('User Actions - Disable Peripheral SubDevice', () => {
+	let env: DefaultEnvironment
+	let pDevice: PeripheralDevice
+	const mockSubDeviceId = 'mockSubDevice0'
+
+	beforeEach(async () => {
+		const organizationId = null
+		env = await setupDefaultStudioEnvironment(organizationId)
+		pDevice = setupMockPeripheralDevice(
+			PeripheralDeviceAPI.DeviceCategory.PLAYOUT,
+			PeripheralDeviceAPI.DeviceType.PLAYOUT,
+			PeripheralDeviceAPI.SUBTYPE_PROCESS,
+			env.studio,
+			{
+				organizationId,
+				settings: {
+					devices: {
+						[mockSubDeviceId]: {
+							type: 'dummy',
+							disable: false,
+						},
+					},
+				},
+				configManifest: {
+					deviceConfig: [
+						{
+							id: 'devices',
+							type: ConfigManifestEntryType.TABLE,
+							isSubDevices: true,
+							defaultType: 'dummy',
+							typeField: 'type',
+							name: 'Devices',
+							config: {
+								dummy: [
+									{
+										id: 'disable',
+										type: ConfigManifestEntryType.BOOLEAN,
+										name: 'Disable',
+									},
+								],
+							},
+						},
+					],
+				},
+			}
+		)
+		jest.resetAllMocks()
+	})
+	testInFiber('disable existing subDevice', () => {
+		expect(
+			Meteor.call(UserActionAPI.methods.disablePeripheralSubDevice, 'e', pDevice._id, mockSubDeviceId, true)
+		).toMatchObject({
+			success: 200,
+		})
+
+		const peripheralDevice = PeripheralDevices.findOne(pDevice._id)
+		expect(peripheralDevice).toBeDefined()
+		expect(peripheralDevice?.settings).toBeDefined()
+		expect(peripheralDevice?.settings && peripheralDevice?.settings['devices'][mockSubDeviceId].disable).toBe(true)
+	})
+	testInFiber('enable existing subDevice', () => {
+		{
+			expect(
+				Meteor.call(UserActionAPI.methods.disablePeripheralSubDevice, 'e', pDevice._id, mockSubDeviceId, true)
+			).toMatchObject({
+				success: 200,
+			})
+
+			const peripheralDevice = PeripheralDevices.findOne(pDevice._id)
+			expect(peripheralDevice).toBeDefined()
+			expect(peripheralDevice?.settings).toBeDefined()
+			expect(peripheralDevice?.settings && peripheralDevice?.settings['devices'][mockSubDeviceId].disable).toBe(
+				true
+			)
+		}
+
+		{
+			expect(
+				Meteor.call(UserActionAPI.methods.disablePeripheralSubDevice, 'e', pDevice._id, mockSubDeviceId, false)
+			).toMatchObject({
+				success: 200,
+			})
+
+			const peripheralDevice = PeripheralDevices.findOne(pDevice._id)
+			expect(peripheralDevice).toBeDefined()
+			expect(peripheralDevice?.settings).toBeDefined()
+			expect(peripheralDevice?.settings && peripheralDevice?.settings['devices'][mockSubDeviceId].disable).toBe(
+				false
+			)
+		}
+	})
+	testInFiber('edit missing subDevice throws an error', () => {
+		{
+			expect(() =>
+				Meteor.call(
+					UserActionAPI.methods.disablePeripheralSubDevice,
+					'e',
+					pDevice._id,
+					'nonExistentSubDevice',
+					true
+				)
+			).toThrowError(/is not configured/)
+		}
+	})
+	testInFiber('edit missing device throws an error', () => {
+		{
+			expect(() =>
+				Meteor.call(
+					UserActionAPI.methods.disablePeripheralSubDevice,
+					'e',
+					'nonExistentDevice',
+					'nonExistentSubDevice',
+					true
+				)
+			).toThrowError(/not found/)
+		}
+	})
+	testInFiber("edit device that doesn't support the disable property throws an error", () => {
+		const pDeviceUnsupported = setupMockPeripheralDevice(
+			PeripheralDeviceAPI.DeviceCategory.PLAYOUT,
+			PeripheralDeviceAPI.DeviceType.PLAYOUT,
+			PeripheralDeviceAPI.SUBTYPE_PROCESS,
+			env.studio,
+			{
+				organizationId: null,
+				settings: {
+					devices: {
+						[mockSubDeviceId]: {
+							type: 'dummy',
+							disable: false,
+						},
+					},
+				},
+				configManifest: {
+					deviceConfig: [
+						{
+							id: 'devices',
+							type: ConfigManifestEntryType.TABLE,
+							isSubDevices: true,
+							defaultType: 'dummy',
+							typeField: 'type',
+							name: 'Devices',
+							config: {
+								dummy: [
+									{
+										id: 'disable',
+										type: ConfigManifestEntryType.STRING,
+										name: 'A property mislabeled as Disable',
+									},
+								],
+							},
+						},
+					],
+				},
+			}
+		)
+
+		{
+			expect(() =>
+				Meteor.call(
+					UserActionAPI.methods.disablePeripheralSubDevice,
+					'e',
+					pDeviceUnsupported._id,
+					mockSubDeviceId,
+					true
+				)
+			).toThrowError(/does not support the disable property/)
+		}
+	})
+})

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -380,6 +380,7 @@ export namespace ServerPeripheralDeviceAPI {
 	) {
 		const peripheralDevice = checkAccessAndGetPeripheralDevice(deviceId, token, context)
 
+		// check that the peripheralDevice has subDevices
 		if (!peripheralDevice.settings)
 			throw new Meteor.Error(500, `PeripheralDevice "${deviceId}" does not provide a settings object`)
 		if (!peripheralDevice.configManifest)
@@ -400,6 +401,7 @@ export namespace ServerPeripheralDeviceAPI {
 		const subDevices = peripheralDevice.settings[subDevicesPropId]
 		if (!subDevices) throw new Meteor.Error(500, `PeripheralDevice "${deviceId}" has a malformed settings object`)
 
+		// check if the subDevice supports disabling using the magical 'disable' BOOLEAN property.
 		const subDeviceSettings = subDevices[subDeviceId] as Record<string, any> | undefined
 		if (!subDeviceSettings)
 			throw new Meteor.Error(500, `PeripheralDevice "${deviceId}", subDevice "${subDeviceId}" is not configured`)

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -382,9 +382,9 @@ export namespace ServerPeripheralDeviceAPI {
 
 		// check that the peripheralDevice has subDevices
 		if (!peripheralDevice.settings)
-			throw new Meteor.Error(500, `PeripheralDevice "${deviceId}" does not provide a settings object`)
+			throw new Meteor.Error(405, `PeripheralDevice "${deviceId}" does not provide a settings object`)
 		if (!peripheralDevice.configManifest)
-			throw new Meteor.Error(500, `PeripheralDevice "${deviceId}" does not provide a configuration manifest`)
+			throw new Meteor.Error(405, `PeripheralDevice "${deviceId}" does not provide a configuration manifest`)
 
 		const subDevicesProp = peripheralDevice.configManifest.deviceConfig.find(
 			(prop) => prop.type === ConfigManifestEntryType.TABLE && prop.isSubDevices === true
@@ -392,7 +392,7 @@ export namespace ServerPeripheralDeviceAPI {
 
 		if (!subDevicesProp)
 			throw new Meteor.Error(
-				500,
+				405,
 				`PeripheralDevice "${deviceId}" does not provide a subDevices configuration property`
 			)
 
@@ -404,7 +404,7 @@ export namespace ServerPeripheralDeviceAPI {
 		// check if the subDevice supports disabling using the magical 'disable' BOOLEAN property.
 		const subDeviceSettings = subDevices[subDeviceId] as Record<string, any> | undefined
 		if (!subDeviceSettings)
-			throw new Meteor.Error(500, `PeripheralDevice "${deviceId}", subDevice "${subDeviceId}" is not configured`)
+			throw new Meteor.Error(404, `PeripheralDevice "${deviceId}", subDevice "${subDeviceId}" is not configured`)
 
 		const subDeviceType = subDeviceSettings[subDevicesProp.typeField || 'type']
 		const subDeviceSettingTopology = subDevicesProp.config[subDeviceType]
@@ -414,7 +414,7 @@ export namespace ServerPeripheralDeviceAPI {
 		)
 		if (!hasDisableProperty)
 			throw new Meteor.Error(
-				500,
+				405,
 				`PeripheralDevice "${deviceId}, subDevice "${subDeviceId}" of type "${subDeviceType}" does not support the disable property`
 			)
 

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -1515,6 +1515,7 @@ export namespace ServerPlayoutAPI {
 		check(studioId, String)
 		check(routeSetId, String)
 		check(state, Boolean)
+		logger.debug(`switchRouteSet "${studioId}" "${routeSetId}"=${state}`)
 
 		const allowed = StudioContentWriteAccess.routeSet(context, studioId)
 		if (!allowed) throw new Meteor.Error(403, `Not allowed to edit RouteSet on studio ${studioId}`)
@@ -1543,8 +1544,6 @@ export namespace ServerPlayoutAPI {
 		Studios.update(studioId, {
 			$set: modification,
 		})
-
-		// TODO: Run update timeline here
 
 		return ClientAPI.responseSuccess(undefined)
 	}

--- a/meteor/server/api/rest/__tests__/rest.test.ts
+++ b/meteor/server/api/rest/__tests__/rest.test.ts
@@ -1,0 +1,174 @@
+import * as _ from 'underscore'
+import { testInFiber } from '../../../../__mocks__/helpers/jest'
+import { MeteorMock } from '../../../../__mocks__/meteor'
+import { Meteor } from 'meteor/meteor'
+import { PickerMock, parseResponseBuffer, MockResponseDataString } from '../../../../__mocks__/meteorhacks-picker'
+import { Response as MockResponse, Request as MockRequest } from 'mock-http'
+
+import { UserActionAPIMethods } from '../../../../lib/api/userActions'
+import { MeteorMethodSignatures } from '../../../methods'
+import { ClientAPI } from '../../../../lib/api/client'
+import '../../userActions.ts' // required to get the UserActionsAPI methods populated
+
+import '../rest.ts'
+
+describe('REST API', () => {
+	describe('UNSTABLE v0', () => {
+		function callRoute(routeName: string, url: string, params: Record<string, any>): MockResponseDataString {
+			const route = PickerMock.mockRoutes[routeName]
+			expect(route).toBeTruthy()
+			const res = new MockResponse()
+			const req = new MockRequest({
+				method: 'POST',
+				url,
+			})
+
+			route.handler(params, req, res, jest.fn())
+
+			const resStr = parseResponseBuffer(res)
+			return resStr
+		}
+
+		testInFiber('registers endpoints for all UserActionAPI methods', () => {
+			MeteorMock.mockRunMeteorStartup()
+
+			Object.keys(UserActionAPIMethods).forEach((methodName) => {
+				const methodValue = UserActionAPIMethods[methodName]
+				const signature = MeteorMethodSignatures[methodValue]
+
+				let resource = `/api/0/action/${methodName}`
+				const params: Record<string, any> = {}
+				_.each(signature || [], (paramName, i) => {
+					resource += `/:param${i}`
+					params[paramName] = ''
+				})
+
+				const route = PickerMock.mockRoutes[resource]
+				expect(route).toBeTruthy()
+			})
+		})
+
+		testInFiber('calls the UserActionAPI methods, when doing a POST to the endpoint', () => {
+			MeteorMock.mockRunMeteorStartup()
+
+			Object.keys(UserActionAPIMethods).forEach((methodName) => {
+				const methodValue = UserActionAPIMethods[methodName]
+				const signature = MeteorMethodSignatures[methodValue]
+
+				let resource = `/api/0/action/${methodName}`
+				let docString = resource
+				const params: Record<string, any> = {}
+				_.each(signature || [], (paramName, i) => {
+					resource += `/:param${i}`
+					docString += `/${paramName}`
+					params[paramName] = ''
+				})
+
+				jest.spyOn(MeteorMock.mockMethods as any, methodValue).mockReturnValue(
+					ClientAPI.responseSuccess(undefined)
+				)
+
+				const result = callRoute(resource, docString, params)
+				expect(result.statusCode).toBe(200)
+				expect(result.headers).toMatchObject({
+					'content-type': 'application/json',
+				})
+				expect(JSON.parse(result.bufferStr)).toMatchObject({
+					success: 200,
+				})
+			})
+		})
+
+		testInFiber('returns a matching HTTP error code when method throws a Meteor.Error', () => {
+			MeteorMock.mockRunMeteorStartup()
+
+			const methodName = Object.keys(UserActionAPIMethods)[0]
+
+			const methodValue = UserActionAPIMethods[methodName]
+			const signature = MeteorMethodSignatures[methodValue]
+
+			let resource = `/api/0/action/${methodName}`
+			let docString = resource
+			const params: Record<string, any> = {}
+			_.each(signature || [], (paramName, i) => {
+				resource += `/:param${i}`
+				docString += `/${paramName}`
+				params[paramName] = ''
+			})
+
+			jest.spyOn(MeteorMock.mockMethods as any, methodValue).mockImplementation(() => {
+				throw new Meteor.Error(401, 'Mock error')
+			})
+
+			const result = callRoute(resource, docString, params)
+			expect(result.statusCode).toBe(401)
+			expect(result.headers).toMatchObject({
+				'content-type': 'text/plain',
+			})
+			expect(result.bufferStr).toMatch('Mock error')
+		})
+
+		testInFiber('returns a 500 HTTP error code when method throws a Node Exception', () => {
+			MeteorMock.mockRunMeteorStartup()
+
+			const methodName = Object.keys(UserActionAPIMethods)[0]
+
+			const methodValue = UserActionAPIMethods[methodName]
+			const signature = MeteorMethodSignatures[methodValue]
+
+			let resource = `/api/0/action/${methodName}`
+			let docString = resource
+			const params: Record<string, any> = {}
+			_.each(signature || [], (paramName, i) => {
+				resource += `/:param${i}`
+				docString += `/${paramName}`
+				params[paramName] = ''
+			})
+
+			jest.spyOn(MeteorMock.mockMethods as any, methodValue).mockImplementation(() => {
+				throw new Error('Mock error')
+			})
+
+			const result = callRoute(resource, docString, params)
+			expect(result.statusCode).toBe(500)
+			expect(result.headers).toMatchObject({
+				'content-type': 'text/plain',
+			})
+			expect(result.bufferStr).toMatch('Mock error')
+		})
+
+		testInFiber('lists available endpoints on /api/0', () => {
+			MeteorMock.mockRunMeteorStartup()
+
+			const resource = `/api/0`
+			const docString = resource
+
+			const result = callRoute(resource, docString, {})
+			expect(result.statusCode).toBe(200)
+			expect(result.headers).toMatchObject({
+				'content-type': 'application/json',
+			})
+
+			const index = JSON.parse(result.bufferStr)
+			Object.keys(UserActionAPIMethods).forEach((methodName) => {
+				const methodValue = UserActionAPIMethods[methodName]
+				const signature = MeteorMethodSignatures[methodValue]
+
+				let resource = `/api/0/action/${methodName}`
+				let docString = resource
+				const params: Record<string, any> = {}
+				_.each(signature || [], (paramName, i) => {
+					resource += `/:param${i}`
+					docString += `/:${paramName}`
+					params[paramName] = ''
+				})
+
+				const found = index.POST.indexOf(docString)
+				if (found < 0) {
+					console.error(docString, 'not found in REST index')
+				}
+				expect(found).toBeGreaterThanOrEqual(0)
+			})
+		})
+	})
+})

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -138,7 +138,7 @@ function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource:
 	const route: Router = routeType === 'POST' ? PickerPOST : PickerGET
 
 	index[routeType].push(indexResource)
-	route.route(resource, (params: Params, req: IncomingMessage, res: ServerResponse) => {
+	route.route(resource, async (params: Params, req: IncomingMessage, res: ServerResponse) => {
 		logger.info(`REST APIv0: ${req.connection.remoteAddress} ${routeType} "${req.url}"`, {
 			url: req.url,
 			method: routeType,
@@ -163,28 +163,14 @@ function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource:
 					break
 				}
 			}
-			const result = fcn(p)
 
-			if (result && typeof result.then === 'function') {
-				result.then(
-					(resolvedResult) => {
-						let code = 200
-						if (ClientAPI.isClientResponseError(resolvedResult)) {
-							code = 500
-						}
-						sendResult(res, code, resolvedResult)
-					},
-					(e) => {
-						sendError(res, e)
-					}
-				)
-			} else {
-				let code = 200
-				if (ClientAPI.isClientResponseError(result)) {
-					code = 500
-				}
-				sendResult(res, code, result)
+			const result = await fcn(p)
+
+			let code = 200
+			if (ClientAPI.isClientResponseError(result)) {
+				code = 500
 			}
+			sendResult(res, code, result)
 		} catch (e) {
 			sendError(res, e)
 		}

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -10,7 +10,40 @@ import { PickerPOST, PickerGET } from '../http'
 
 const apiVersion = 0
 
-const index: any = []
+const index = {
+	version: apiVersion,
+	GET: [] as string[],
+	POST: [] as string[],
+}
+
+function typeConvertUrlParameters(args: any[]) {
+	const convertedArgs: any[] = []
+
+	for (const i in args) {
+		let val = args[i]
+		if (val === 'null') val = null
+		else if (val === 'undefined') val = undefined
+		else if (val === 'true') val = true
+		else if (val === 'false') val = false
+		else val = unescape(val)
+
+		if (!_.isNaN(Number(val))) {
+			val = Number(val)
+		} else {
+			let json: any = null
+			try {
+				json = JSON.parse(val)
+			} catch (e) {
+				// ignore
+			}
+			if (json) val = json
+		}
+
+		convertedArgs[i] = val
+	}
+
+	return convertedArgs
+}
 
 Meteor.startup(() => {
 	// Expose all user actions:
@@ -26,8 +59,9 @@ Meteor.startup(() => {
 			docString += `/:${paramName}`
 		})
 
-		assignRoute('POST', resource, docString, (p) => {
-			return Meteor.call(methodValue, ...p)
+		assignRoute('POST', resource, docString, (args) => {
+			const convArgs = typeConvertUrlParameters(args)
+			return Meteor.call(methodValue, ...convArgs)
 		})
 	})
 
@@ -47,31 +81,12 @@ Meteor.startup(() => {
 			})
 
 			assignRoute('GET', resource, docString, (args) => {
-				for (const i in args) {
-					let val = args[i]
-					if (val === 'null') val = null
-					else if (val === 'undefined') val = undefined
-					else val = unescape(val)
-
-					if (!_.isNaN(Number(val))) {
-						val = Number(val)
-					} else {
-						let json: any = null
-						try {
-							json = JSON.parse(val)
-						} catch (e) {
-							// ignore
-						}
-						if (json) val = json
-					}
-
-					args[i] = val
-				}
+				const convArgs = typeConvertUrlParameters(args)
 				const cursor = f.apply(
 					{
 						ready: () => null,
 					},
-					args
+					convArgs
 				)
 				if (cursor) return cursor.fetch()
 				return []
@@ -80,10 +95,25 @@ Meteor.startup(() => {
 	})
 })
 
+function sendResult(res: ServerResponse, statusCode: number, payload: any) {
+	res.statusCode = statusCode
+	res.setHeader('Content-Type', typeof payload === 'object' ? 'application/json' : 'text/plain')
+	res.end(typeof payload === 'object' ? JSON.stringify(payload) : String(payload))
+}
+
+function sendError(res: ServerResponse, e: any) {
+	if (e.error && e.reason) {
+		// is Meteor.Error
+		sendResult(res, e.error, String(e.reason))
+	} else {
+		sendResult(res, 500, String(e))
+	}
+}
+
 function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource: string, fcn: (p: any[]) => any) {
 	const route: Router = routeType === 'POST' ? PickerPOST : PickerGET
 
-	index.push(routeType + ' ' + indexResource)
+	index[routeType].push(indexResource)
 	route.route(resource, (params: Params, req: IncomingMessage, res: ServerResponse) => {
 		const p: any[] = []
 		for (let i = 0; i < 20; i++) {
@@ -104,25 +134,20 @@ function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource:
 			}
 			const result = fcn(p)
 
-			res.statusCode = 200
-			if (typeof result === 'object') {
-				res.setHeader('Content-Type', 'application/json')
-				res.end(JSON.stringify(result))
+			if (result && typeof result.then === 'function') {
+				result.then(
+					(resolvedResult) => {
+						sendResult(res, 200, resolvedResult)
+					},
+					(e) => {
+						sendError(res, e)
+					}
+				)
 			} else {
-				res.setHeader('Content-Type', 'text/plain')
-				res.end(result)
+				sendResult(res, 200, result)
 			}
 		} catch (e) {
-			if (e.error && e.reason) {
-				// is Meteor.Error
-				res.statusCode = e.error
-				res.setHeader('Content-Type', 'text/plain')
-				res.end(e.reason)
-			} else {
-				res.statusCode = e.error
-				res.setHeader('Content-Type', 'text/plain')
-				res.end(e && e.toString())
-			}
+			sendError(res, e)
 		}
 	})
 }

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -7,6 +7,7 @@ import { PubSub } from '../../../lib/api/pubsub'
 import { MeteorPublications, MeteorPublicationSignatures } from '../../publications/lib'
 import { UserActionAPIMethods } from '../../../lib/api/userActions'
 import { PickerPOST, PickerGET } from '../http'
+import { logger } from '../../../lib/logging'
 
 const apiVersion = 0
 
@@ -116,6 +117,13 @@ function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource:
 
 	index[routeType].push(indexResource)
 	route.route(resource, (params: Params, req: IncomingMessage, res: ServerResponse) => {
+		logger.info(`REST APIv0: ${req.connection.remoteAddress} ${routeType} "${req.url}"`, {
+			url: req.url,
+			method: routeType,
+			remoteAddress: req.connection.remoteAddress,
+			remotePort: req.connection.remotePort,
+			headers: req.headers,
+		})
 		const p: any[] = []
 		for (let i = 0; i < 20; i++) {
 			if (_.has(params, 'param' + i)) {

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -22,21 +22,22 @@ function typeConvertUrlParameters(args: any[]) {
 	for (const i in args) {
 		let val = args[i]
 		if (val === 'null') val = null
-		else if (val === 'undefined') val = undefined
 		else if (val === 'true') val = true
 		else if (val === 'false') val = false
-		else val = unescape(val)
+		else {
+			val = unescape(val)
 
-		if (!_.isNaN(Number(val))) {
-			val = Number(val)
-		} else {
-			let json: any = null
-			try {
-				json = JSON.parse(val)
-			} catch (e) {
-				// ignore
+			if (!_.isNaN(Number(val))) {
+				val = Number(val)
+			} else {
+				let json: any = null
+				try {
+					json = JSON.parse(val)
+				} catch (e) {
+					// ignore
+				}
+				if (json) val = json
 			}
-			if (json) val = json
 		}
 
 		convertedArgs[i] = val

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -8,6 +8,7 @@ import { MeteorPublications, MeteorPublicationSignatures } from '../../publicati
 import { UserActionAPIMethods } from '../../../lib/api/userActions'
 import { PickerPOST, PickerGET } from '../http'
 import { logger } from '../../../lib/logging'
+import { ClientAPI } from '../../../lib/api/client'
 
 const apiVersion = 0
 
@@ -146,14 +147,22 @@ function assignRoute(routeType: 'POST' | 'GET', resource: string, indexResource:
 			if (result && typeof result.then === 'function') {
 				result.then(
 					(resolvedResult) => {
-						sendResult(res, 200, resolvedResult)
+						let code = 200
+						if (ClientAPI.isClientResponseError(resolvedResult)) {
+							code = 500
+						}
+						sendResult(res, code, resolvedResult)
 					},
 					(e) => {
 						sendError(res, e)
 					}
 				)
 			} else {
-				sendResult(res, 200, result)
+				let code = 200
+				if (ClientAPI.isClientResponseError(result)) {
+					code = 500
+				}
+				sendResult(res, code, result)
 			}
 		} catch (e) {
 			sendError(res, e)

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -18,6 +18,12 @@ const index = {
 	POST: [] as string[],
 }
 
+/**
+ * Takes an array of strings and converts them to Null, Boolean, Number, String primitives or Objects, if the string
+ * seems like a valid JSON.
+ *
+ * @param args Array of URL-encoded strings
+ */
 function typeConvertUrlParameters(args: any[]) {
 	const convertedArgs: any[] = []
 
@@ -98,12 +104,27 @@ Meteor.startup(() => {
 	})
 })
 
+/**
+ * Send a resulting payload back to the HTTP client. If the payload is an Object, it will be sent as JSON, otherwise
+ * will be sent as Plain Text.
+ *
+ * @param {ServerResponse} res
+ * @param {number} statusCode
+ * @param {*} payload
+ */
 function sendResult(res: ServerResponse, statusCode: number, payload: any) {
 	res.statusCode = statusCode
 	res.setHeader('Content-Type', typeof payload === 'object' ? 'application/json' : 'text/plain')
 	res.end(typeof payload === 'object' ? JSON.stringify(payload) : String(payload))
 }
 
+/**
+ * Send an error back to the HTTP client. If the error object is a Meteor.Error, use the Error.error value as
+ * HTTP error code. Otherwise, send generic 500 error.
+ *
+ * @param {ServerResponse} res
+ * @param {*} e
+ */
 function sendError(res: ServerResponse, e: any) {
 	if (e.error && e.reason) {
 		// is Meteor.Error

--- a/meteor/server/api/rest/rest.ts
+++ b/meteor/server/api/rest/rest.ts
@@ -11,7 +11,7 @@ import { PickerPOST, PickerGET } from '../http'
 const apiVersion = 0
 
 const index = {
-	version: apiVersion,
+	version: `${apiVersion}`,
 	GET: [] as string[],
 	POST: [] as string[],
 }

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -1163,6 +1163,7 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		return restoreRundownOrder(this, playlistId)
 	}
 	async disablePeripheralSubDevice(
+		_userEvent: string,
 		peripheralDeviceId: PeripheralDeviceId,
 		subDeviceId: string,
 		disable: boolean

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -49,6 +49,7 @@ import { AdLibActionId, AdLibActionCommon } from '../../lib/collections/AdLibAct
 import { BucketAdLibAction } from '../../lib/collections/BucketAdlibActions'
 import { checkAccessAndGetPlaylist, checkAccessAndGetRundown, checkAccessToPlaylist } from './lib'
 import { PackageManagerAPI } from './packageManager'
+import { ServerPeripheralDeviceAPI } from './peripheralDevice'
 import { PeripheralDeviceId } from '../../lib/collections/PeripheralDevices'
 import { moveRundownIntoPlaylist, restoreRundownsInPlaylistToDefaultOrder } from './rundownPlaylist'
 import { getShowStyleCompound } from './showStyles'
@@ -908,6 +909,21 @@ export async function restoreRundownOrder(
 	return ClientAPI.responseSuccess(await restoreRundownsInPlaylistToDefaultOrder(context, playlistId))
 }
 
+export async function disablePeripheralSubDevice(
+	context: MethodContext,
+	peripheralDeviceId: PeripheralDeviceId,
+	subDeviceId: string,
+	disable: boolean
+): Promise<ClientAPI.ClientResponse<void>> {
+	check(peripheralDeviceId, String)
+	check(subDeviceId, String)
+	check(disable, Boolean)
+
+	return ClientAPI.responseSuccess(
+		ServerPeripheralDeviceAPI.disableSubDevice(context, peripheralDeviceId, undefined, subDeviceId, disable)
+	)
+}
+
 class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 	async take(_userEvent: string, rundownPlaylistId: RundownPlaylistId) {
 		return take(this, rundownPlaylistId)
@@ -1145,6 +1161,13 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 		playlistId: RundownPlaylistId
 	): Promise<ClientAPI.ClientResponse<void>> {
 		return restoreRundownOrder(this, playlistId)
+	}
+	async disablePeripheralSubDevice(
+		peripheralDeviceId: PeripheralDeviceId,
+		subDeviceId: string,
+		disable: boolean
+	): Promise<ClientAPI.ClientResponse<void>> {
+		return disablePeripheralSubDevice(this, peripheralDeviceId, subDeviceId, disable)
 	}
 }
 registerClassToMeteorMethods(

--- a/packages/server-core-integration/src/lib/configManifest.ts
+++ b/packages/server-core-integration/src/lib/configManifest.ts
@@ -111,7 +111,9 @@ export interface TableConfigManifestEntry extends ConfigManifestEntryBase {
 	deviceTypesMapping?: any
 	/** The name of the the property used to decide the type of the entry */
 	typeField?: string
-	/** Only one type means that the type option will not be present */
+	/** Only one type means that the type option will not be present. When using this as a subDevice configuration object,
+	 * a property of type BOOLEAN and id `disable` has special meaning and can be operated on outside of the GUI
+	 */
 	config: { [type: string]: ConfigManifestEntry[] }
 }
 

--- a/packages/server-core-integration/src/lib/configManifest.ts
+++ b/packages/server-core-integration/src/lib/configManifest.ts
@@ -1,6 +1,29 @@
+/**
+ * A device has configuration options. This file describes a format using
+ * typescript in which these options can be described.
+ *
+ * In general a device can have an array of configuration fields like strings,
+ * booleans, numbers etc.
+ *
+ * A special type is the TABLE. This type describes another array of config
+ * options. A table type is rendered as an actual table in core, where the rows
+ * are instances of a certain type or are all the same. Manifests entries can
+ * describe some properties to be rendered inside this table
+ */
+
 export interface DeviceConfigManifest {
+	/**
+	 * A description of the config fields
+	 */
 	deviceConfig: ConfigManifestEntry[]
+	/**
+	 * If the device has an OAuthFlow (like spreadsheet gw) the instructions for
+	 * getting an authentication token go in here
+	 */
 	deviceOAuthFlow?: DeviceOAuthFlow
+	/**
+	 * A description of the layer mapping config fields
+	 */
 	layerMappings?: MappingsManifest
 }
 
@@ -28,7 +51,7 @@ export enum ConfigManifestEntryType {
 	INT = 'int',
 	TABLE = 'table',
 	OBJECT = 'object',
-	ENUM = 'enum', // @todo: implement
+	ENUM = 'enum',
 }
 
 export type ConfigManifestEntry =
@@ -50,7 +73,10 @@ export interface ConfigManifestEntryBase {
 export interface ConfigManifestEntryDefault extends ConfigManifestEntryBase {
 	type: Exclude<
 		ConfigManifestEntryType,
-		ConfigManifestEntryType.ENUM | ConfigManifestEntryType.INT | ConfigManifestEntryType.FLOAT
+		| ConfigManifestEntryType.ENUM
+		| ConfigManifestEntryType.INT
+		| ConfigManifestEntryType.FLOAT
+		| ConfigManifestEntryType.TABLE
 	>
 }
 export interface ConfigManifestIntEntry extends ConfigManifestEntryBase {
@@ -76,12 +102,16 @@ export interface SubDeviceConfigManifestEntry extends ConfigManifestEntryBase {
 export interface TableConfigManifestEntry extends ConfigManifestEntryBase {
 	/** Whether this follows the deviceId logic for updating */
 	isSubDevices?: boolean
+	/** The default name/id for any new devices */
 	subDeviceDefaultName?: string
+	/** The type any new entry gets by default */
 	defaultType?: string
 	type: ConfigManifestEntryType.TABLE
+	/** Used when the .config indexes are different from the type enum */
 	deviceTypesMapping?: any
+	/** The name of the the property used to decide the type of the entry */
 	typeField?: string
-	/** Only one type means that the option will not be present */
+	/** Only one type means that the type option will not be present */
 	config: { [type: string]: ConfigManifestEntry[] }
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The only way to disable a subDevice in a Peripheral Device is through the GUI

* **What is the new behavior (if this is a feature change)?**

The unstable (v0) REST API now exposes a method to disable a SubDevice in a given PeripheralDevice. The PeripheralDevice's configuration manifest is inspected to make sure this is allowed.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
