### PR TITLE
docs: fix CasparCG Media Scanner links

### DIFF
--- a/packages/documentation/docs/getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md
+++ b/packages/documentation/docs/getting-started/installation/installing-connections-and-additional-hardware/casparcg-server-installation.md
@@ -4,13 +4,13 @@ description: Sofie specific fork of CasparCG Server 2.1
 
 # Installing CasparCG Server for Sofie
 
-Although CasparCG is an open source program that is free to use for both personal and cooperate applications, the hardware needed to create and execute high quality graphics is not. You can get a preview running without any additional hardware but, it is not recommended to use CasparCG for production in this manner. To begin, you will install the CasparCG Server on your machine then add the additional configuration needed for your setup of choice. 
+Although CasparCG is an open source program that is free to use for both personal and cooperate applications, the hardware needed to create and execute high quality graphics is not. You can get a preview running without any additional hardware but, it is not recommended to use CasparCG for production in this manner. To begin, you will install the CasparCG Server on your machine then add the additional configuration needed for your setup of choice.
 
 ## Installing the CasparCG Server
 
-To begin,  download the latest release of [CasparCG Server from GitHub](https://github.com/nrkno/tv-automation-casparcg-server/releases). There are multiple versions of CasparCG available to the public for download but, you specifically want the latest NRK version. 
+To begin, download the latest release of [CasparCG Server from GitHub](https://github.com/nrkno/tv-automation-casparcg-server/releases). There are multiple versions of CasparCG available to the public for download but, you specifically want the latest NRK version.
 
-Once downloaded, extract the files and navigate down the folders, _CasparCG Server_ then _Server_. This folder contains your CasparCG Configuration file, `casparcg.config`, and your CasparCG executable, `casparcg.exe`. 
+Once downloaded, extract the files and navigate down the folders, _CasparCG Server_ then _Server_. This folder contains your CasparCG Configuration file, `casparcg.config`, and your CasparCG executable, `casparcg.exe`.
 
 How you will configure the CasparCG server will depend on the number of Decklink cards your machine contains. The first subsection for each CasparCG setup, labeled _Channels_, will contain the unique portion of the configuration. The following is the majority of the configuration file that will be consistent between setups.
 
@@ -48,13 +48,13 @@ How you will configure the CasparCG server will depend on the number of Decklink
 </configuration>
 ```
 
- One additional note, the Server does require the configuration file be named `casparcg.config`. 
+One additional note, the Server does require the configuration file be named `casparcg.config`.
 
 ### Installing CasparCG Media Scanner
 
-You can use the CasparCG Media Scanner to locate and add all of your media to the _Core_. To install the Media Scanner, you will go to the [project's Release page](https://github.com/nrkno/tv-automation-casparcg-launcher/releases) and download the `.zip` file under the latest release. Similar to the CasparCG Server, you want to use the NRK version. 
+You can use the CasparCG Media Scanner to locate and add all of your media to the _Core_. To install the Media Scanner, you will go to the [project's Release page](https://github.com/nrkno/tv-automation-media-scanner/releases) and download the `.zip` file under the latest release. Similar to the CasparCG Server, you want to use the NRK version.
 
-Once downloaded and extracted, move the `scanner.exe` file to the same folder as your `casparcg.exe` file. 
+Once downloaded and extracted, move the `scanner.exe` file to the same folder as your `casparcg.exe` file.
 
 ### Installing the CasparCG Launcher
 
@@ -72,17 +72,17 @@ If you need to install redistributable then, navigate to [Microsoft's website](h
 
 Although CasparCG can be run on some lower end hardware, it is only recommended to do so for non-production uses. Below is a table of the minimum and preferred specs depending on what type of system you are using.
 
-| System Type | Min CPU | Pref CPU | Min GPU | Pref GPU | Min Storage | Pref Storage |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| Development | i5 Gen 6i7 Gen 6 | GTX 1050 | GTX 1060 | GTX 1060 | NVMe SSD 500gb |  |
-| Prod, 1 Card | i7 Gen 6 | i7 Gen 7 | GTX 1060 | GTX 1070 | NVMe SSD 500gb | NVMe SSD 500gb |
-| Prod, 2 Cards | i9 Gen 8 | i9 Gen 10 Extreme Edition | RTX 2070 | Quadro P4000 | Dual Drives | Dual Drives |
+| System Type   | Min CPU          | Pref CPU                  | Min GPU  | Pref GPU     | Min Storage    | Pref Storage   |
+| :------------ | :--------------- | :------------------------ | :------- | :----------- | :------------- | :------------- |
+| Development   | i5 Gen 6i7 Gen 6 | GTX 1050                  | GTX 1060 | GTX 1060     | NVMe SSD 500gb |                |
+| Prod, 1 Card  | i7 Gen 6         | i7 Gen 7                  | GTX 1060 | GTX 1070     | NVMe SSD 500gb | NVMe SSD 500gb |
+| Prod, 2 Cards | i9 Gen 8         | i9 Gen 10 Extreme Edition | RTX 2070 | Quadro P4000 | Dual Drives    | Dual Drives    |
 
 For _dual drives_, it is recommended to use a smaller 250gb NVMe SSD for the operating system. Then a faster 1tb NVMe SSD for the CasparCG Server and media. It is also recommended to buy a drive with about 40% storage overhead. This is for SSD p~~e~~rformance reasons and Sofie will warn you about this if your drive usage exceeds 60%.
 
 ### Decklink Cards
 
-There are a few SDI cards made by Blackmagic that are support by CasparCG. The base model, with four bi-directional input and outputs, is the [Duo 2](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-31). If you need additional channels, use the[ Quad 4](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-30) which supports eight bi-directional inputs and outputs. Be aware the BNC connections are not the standard BNC type. B&H offers [Mini BNC to BNC connecters](https://www.bhphotovideo.com/c/product/1462647-REG/canare_cal33mb018_mini_rg59_12g_sdi_4k.html). Finally, for 4k support, use the [8K Pro](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-34) which has four bi-directional BNC connections and one reference connection. 
+There are a few SDI cards made by Blackmagic that are support by CasparCG. The base model, with four bi-directional input and outputs, is the [Duo 2](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-31). If you need additional channels, use the[ Quad 4](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-30) which supports eight bi-directional inputs and outputs. Be aware the BNC connections are not the standard BNC type. B&H offers [Mini BNC to BNC connecters](https://www.bhphotovideo.com/c/product/1462647-REG/canare_cal33mb018_mini_rg59_12g_sdi_4k.html). Finally, for 4k support, use the [8K Pro](https://www.blackmagicdesign.com/products/decklink/techspecs/W-DLK-34) which has four bi-directional BNC connections and one reference connection.
 
 Here is the Blackmagic PDF for [installing your Decklink card \( Desktop Video Device \).](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf)
 
@@ -104,7 +104,7 @@ If you chose a Decklink Duo, then you will also need to set SDI connectors one a
 
 ### Preview Only \( Basic \)
 
-A preview only version of CasparCG does not lack any of the features of a production version. It is called a  _preview only_ version because the standard outputs on a computer, without a Decklink card, do not meet the requirements of a high quality broadcast graphics machine. It is perfectly suitable for development though.
+A preview only version of CasparCG does not lack any of the features of a production version. It is called a _preview only_ version because the standard outputs on a computer, without a Decklink card, do not meet the requirements of a high quality broadcast graphics machine. It is perfectly suitable for development though.
 
 #### Required Hardware
 
@@ -118,7 +118,7 @@ The default configuration will give you one preview window. No additional change
 
 #### Required Hardware
 
-To be production ready, you will need to output an SDI or HDMI signal from your production machine. CasparCG supports Blackmagic Decklink card because they provide a key generator which will aid in keeping the alpha and fill channels of your graphics in sync. Please review the [Decklink Cards](casparcg-server-installation.md#decklink-cards) section of this page to choose which card will best fit your production needs. 
+To be production ready, you will need to output an SDI or HDMI signal from your production machine. CasparCG supports Blackmagic Decklink card because they provide a key generator which will aid in keeping the alpha and fill channels of your graphics in sync. Please review the [Decklink Cards](casparcg-server-installation.md#decklink-cards) section of this page to choose which card will best fit your production needs.
 
 #### Configuration
 
@@ -152,7 +152,7 @@ You will need to add an additional consumer to your`caspar.config` file to outpu
 </channels>
 ```
 
-You may no longer need the screen consumer. If so, you can remove it and all of it's contents. This will dramatically improve overall performance. 
+You may no longer need the screen consumer. If so, you can remove it and all of it's contents. This will dramatically improve overall performance.
 
 ### Multiple Decklink Cards \( Recommended Production Setup \)
 
@@ -206,28 +206,27 @@ Once you have setup the configuration file, you can use an online validator to c
 
 ### Launching the Server
 
-Launching the Server is the same for each hardware setup. This means you can run`casparcg-launcher.exe` and the server and media scanner will start. There will be two additional warning from Windows. The first is about the EXE file and can be bypassed by selecting _Advanced_ and then _Run Anyways_. The second menu will be about CasparCG attempting to access your firewall. You will need to allow access. 
+Launching the Server is the same for each hardware setup. This means you can run`casparcg-launcher.exe` and the server and media scanner will start. There will be two additional warning from Windows. The first is about the EXE file and can be bypassed by selecting _Advanced_ and then _Run Anyways_. The second menu will be about CasparCG attempting to access your firewall. You will need to allow access.
 
 A window will open and display the status for the server and scanner. You can start, stop, and/or restart the server from here if needed. An additional window should have opened as well. This is the main output of your CasparCG Server and will contain nothing but a black background for now. If you have a Decklink card installed, its output will also be black.
 
 ## Connecting Sofie to the CasparCG Server
 
-Now that your CasparCG server is running, you can connect it to the _Sofie Core_. Navigate back to the _Settings page_ and in the menu, select the _Playout Gateway_. If the _Playout Gateway's_ status does not read _Good_, then please review the [Installing and Setting up the Playout Gateway](../installing-a-gateway/playout-gateway.md) section of this guide. 
+Now that your CasparCG server is running, you can connect it to the _Sofie Core_. Navigate back to the _Settings page_ and in the menu, select the _Playout Gateway_. If the _Playout Gateway's_ status does not read _Good_, then please review the [Installing and Setting up the Playout Gateway](../installing-a-gateway/playout-gateway.md) section of this guide.
 
 Under the Sub Devices section, you can add a new device with the _+_ button. Then select the pencil \( edit \) icon on the new device to open the sub device's settings. Select the _Device Type_ option and choose _CasparCG_ from the drop down menu. Some additional fields will be added to the form.
 
-The _Host_ and _Launcher Host_ fields will be _localhost_. The _Port_ will be CasparCG's TCP port responsible for handling the AMCP commands. It defaults to 5052 in the `casparcg.config` file. The _Launcher Port_ will be the CasparCG Launcher's port for handling HTTP requests. It will default to 8005 and can be changed in the _Launcher's settings page_. Once all four fields are filled out, you can click the check mark to save the device. 
+The _Host_ and _Launcher Host_ fields will be _localhost_. The _Port_ will be CasparCG's TCP port responsible for handling the AMCP commands. It defaults to 5052 in the `casparcg.config` file. The _Launcher Port_ will be the CasparCG Launcher's port for handling HTTP requests. It will default to 8005 and can be changed in the _Launcher's settings page_. Once all four fields are filled out, you can click the check mark to save the device.
 
 In the _Attached Sub Devices_ section, you should now see the status of the CasparCG Server. You may need to restart the Playout Gateway if the status is _Bad_.
 
 ## Further Reading
 
-* [CasparCG Server Releases](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
-* [Media Scanner Releases](https://github.com/nrkno/tv-automation-casparcg-launcher/releases) on GitHub.
-* [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
-* [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
-* [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](casparcg-server-installation.md#decklink-cards) section for compatibility.
-* [Installing a  Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
-* [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
-* [CasparCG Configuration Validator](https://casparcg.net/validator/)
-
+- [CasparCG Server Releases](https://github.com/nrkno/tv-automation-casparcg-server/releases) on GitHub.
+- [Media Scanner Releases](https://github.com/nrkno/tv-automation-media-scanner/releases) on GitHub.
+- [CasparCG Launcher](https://github.com/nrkno/tv-automation-casparcg-launcher) on GitHub.
+- [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) on Microsoft's website.
+- [Blackmagic Decklink Cards](https://www.blackmagicdesign.com/products/decklink/models) on Blackmagic's website. Check the [Decklink cards](casparcg-server-installation.md#decklink-cards) section for compatibility.
+- [Installing a Decklink Card](https://documents.blackmagicdesign.com/UserManuals/DesktopVideoManual.pdf) as a PDF.
+- [Desktop Video Download Page](https://www.blackmagicdesign.com/support/family/capture-and-playback) on Blackmagic's website.
+- [CasparCG Configuration Validator](https://casparcg.net/validator/)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update

* **What is the current behavior?** (You can also link to an open issue here)

The links to the CasparCG Media Scanner point to the CasparCG Launcher.

* **What is the new behavior (if this is a feature change)?**

The links now point to the correct place.

* **Other information**:

There are some unrelated changes caused by the auto formatter.