### PR TITLE
fix: PGW: old device names in log

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -686,6 +686,11 @@ export class TSRHandler {
 					deviceStatus = connectedOrStatus
 				}
 				coreTsrHandler.statusChanged(deviceStatus)
+
+				// When the status has changed, the deviceName might have changed:
+				device.reloadProps().catch((err) => {
+					this.logger.error(`Error in reloadProps: ${err}`)
+				})
 				// hack to make sure atem has media after restart
 				if (
 					(deviceStatus.statusCode === P.StatusCode.GOOD ||
@@ -779,10 +784,8 @@ export class TSRHandler {
 			const onClearMediaObjectCollection = (collectionId: string) => {
 				coreTsrHandler.onClearMediaObjectCollection(collectionId)
 			}
-			let deviceName = device.deviceName
-			const deviceInstanceId = device.instanceId
 			const fixError = (e: any): string => {
-				const name = `Device "${deviceName || deviceId}" (${deviceInstanceId})`
+				const name = `Device "${device.deviceName || deviceId}" (${device.instanceId})`
 				if (e.reason) e.reason = name + ': ' + e.reason
 				if (e.message) e.message = name + ': ' + e.message
 				if (e.stack) {
@@ -793,8 +796,6 @@ export class TSRHandler {
 				return e
 			}
 			await coreTsrHandler.init()
-
-			deviceName = device.deviceName
 
 			device.onChildClose = () => {
 				// Called if a child is closed / crashed


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When errors from PGW are logged, the device names are old ("VizMSE Uninitialized", "Quantel device (uninitialized)"), ie not the ones up to date.


* **What is the new behavior (if this is a feature change)?**
The up to date device names are logged ("VizMSE xxx.xxx.xxx.xxx", "Quantel xxx.xxx.xxx.xxx,xxx.xxx.xxx.xxx/default/xxxxxx")

