### PR TITLE
fix: win32 meteor yarn (Release 40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"postinstall": "yarn install:packages && yarn install:meteor",
-		"install:meteor": "cd meteor && meteor --version && meteor npm install -g yarn && meteor yarn install",
+		"install:meteor": "cd meteor && meteor --version && meteor npm install -g yarn && node ../scripts/fix-windows-yarn.js && meteor yarn install",
 		"install:packages": "cd packages && yarn install",
 		"start": "yarn install && yarn dev",
 		"dev": "node ./scripts/run.js",

--- a/scripts/fix-windows-yarn.js
+++ b/scripts/fix-windows-yarn.js
@@ -1,0 +1,63 @@
+// this is expected to run from within `meteor`
+const process = require('process')
+const fs = require('fs')
+var path = require('path')
+
+function mkdirSyncIfNotExists(path) {
+	if (fs.existsSync(path)) return
+	fs.mkdirSync(path)
+}
+
+function copyFileSyncIfNotExists(source, target) {
+	if (fs.existsSync(target)) return
+	fs.copyFileSync(source, target)
+}
+
+function copyFileSync(source, target) {
+
+	var targetFile = target
+
+	// If target is a directory, a new file with the same name will be created
+	if (fs.existsSync(target)) {
+		if (fs.lstatSync(target).isDirectory()) {
+			targetFile = path.join(target, path.basename(source))
+		}
+	}
+
+	fs.copyFileSync(source, targetFile)
+}
+
+function copyFolderRecursiveSync(source, target) {
+	var files = [];
+
+	// Check if folder needs to be created or integrated
+	var targetFolder = path.join(target, path.basename(source));
+	if (!fs.existsSync(targetFolder)) {
+		fs.mkdirSync(targetFolder)
+	}
+
+	// Copy
+	if (fs.lstatSync(source).isDirectory()) {
+		files = fs.readdirSync(source);
+		files.forEach(function (file) {
+			var curSource = path.join(source, file);
+			if (fs.lstatSync(curSource).isDirectory()) {
+				copyFolderRecursiveSync(curSource, targetFolder)
+			} else {
+				copyFileSync(curSource, targetFolder)
+			}
+		});
+	}
+}
+
+// only run on Windows
+if (process.platform !== 'win32') return
+
+const files = ['yarn', 'yarn.cmd', 'yarnpkg', 'yarnpkg.cmd', 'yarn.js']
+
+files.forEach((file) => {
+	copyFileSyncIfNotExists(`.meteor/local/dev_bundle/node_modules/yarn/bin/${file}`, `.meteor/local/dev_bundle/bin/${file}`)
+})
+
+mkdirSyncIfNotExists('.meteor/local/dev_bundle/lib')
+copyFolderRecursiveSync('.meteor/local/dev_bundle/node_modules/yarn/lib', '.meteor/local/dev_bundle')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Repo package install scripts don't work correctly on Windows.

* **What is the new behavior (if this is a feature change)?**

Patches the yarn installation so that it works with `meteor yarn`

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
